### PR TITLE
Mzcld 449 create mozcloud preview chart

### DIFF
--- a/mozcloud-preview/library/.helmignore
+++ b/mozcloud-preview/library/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/mozcloud-preview/library/Chart.yaml
+++ b/mozcloud-preview/library/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: mozcloud-preview-lib
+description: A library chart that creates preview http routes and supporting resources
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: library
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+dependencies:
+  - name: mozcloud-service-lib
+    version: 0.1.0
+    repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-preview/library/templates/_endpointcheck.yaml
+++ b/mozcloud-preview/library/templates/_endpointcheck.yaml
@@ -1,0 +1,36 @@
+{{- define "mozcloud-preview-lib.endpointcheck" -}}
+{{- $config := include "mozcloud-preview-lib.defaults.endpointcheck" . | fromYaml }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: endpoint-check-{{ randAlphaNum 7 | lower }}
+  labels:
+    {{- $config.labels | toYaml | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  backoffLimit: {{ $config.backoffLimit }}
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: wait-for-endpoint
+          image: {{ $config.image }}
+          args:
+            - /bin/sh
+            - -c
+            - |
+              echo "Checking endpoint availability: {{ $config.url }}/{{ $config.checkPath }}"
+              for i in $(seq 1 {{ $config.maxAttempts }}); do
+                if curl -sSf --max-time {{ $config.maxTimePerAttempt }} {{ $config.url }}/{{ $config.checkPath }}; then
+                  echo "Endpoint check succeeded."
+                  exit 0
+                fi
+                echo "Not ready yet (attempt $i), sleeping {{ $config.sleepSeconds }}s..."
+                sleep {{ $config.sleepSeconds }}
+              done
+              echo "Timed out waiting for endpoint."
+              exit 1
+{{- end }}

--- a/mozcloud-preview/library/templates/_endpointcheck.yaml
+++ b/mozcloud-preview/library/templates/_endpointcheck.yaml
@@ -22,9 +22,9 @@ spec:
             - /bin/sh
             - -c
             - |
-              echo "Checking endpoint availability: {{ $config.url }}/{{ $config.checkPath }}"
+              echo "Checking endpoint availability: https://{{ $config.url }}/{{ $config.checkPath }}"
               for i in $(seq 1 {{ $config.maxAttempts }}); do
-                if curl -sSf --max-time {{ $config.maxTimePerAttempt }} {{ $config.url }}/{{ $config.checkPath }}; then
+                if curl -sSf --max-time {{ $config.maxTimePerAttempt }} https://{{ $config.url }}/{{ $config.checkPath }}; then
                   echo "Endpoint check succeeded."
                   exit 0
                 fi

--- a/mozcloud-preview/library/templates/_helpers.tpl
+++ b/mozcloud-preview/library/templates/_helpers.tpl
@@ -244,6 +244,7 @@ HTTPRoute Render
       {{- $_ := set $route "fullnameOverride" $route_name }}
       {{- $_ := set $route "labels" (include "mozcloud-preview-lib.labels" . | fromYaml) }}
       {{- $_ := set $route "hostnames" $host.domains }}
+      {{- $_ := set $route "previewHost" $.previewHost -}}
       {{- $_ := set $route "gateway" (default dict $.gateway) }}
       {{- $_ := set $route "backend" (dict "name" $svc.name "port" $svc.port) }}
 
@@ -253,6 +254,22 @@ HTTPRoute Render
 {{- end }}
 
 {{ $routes | toYaml }}
+{{- end }}
+
+{{/*
+EndpointCheck Render
+*/}}
+{{- define "mozcloud-preview-lib.defaults.endpointcheck" -}}
+url: {{ $.previewHost | quote }}
+checkPath: {{ .checkPath | default "__heartbeat__" }}
+image: {{ .image | default "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/curlimages/curl:8.14.1" | quote }}
+maxAttempts: {{ .maxAttempts | default 15 }}
+maxTimePerAttempt: {{ .maxTimePerAttempt | default 2 }}
+sleepSeconds: {{ .sleepSeconds | default 5 }}
+backoffLimit: {{ .backoffLimit | default 1 }}
+labels:
+  app.kubernetes.io/component: endpoint-check
+  {{- .labels | toYaml | nindent 4 }}
 {{- end }}
 
 {{/*

--- a/mozcloud-preview/library/templates/_helpers.tpl
+++ b/mozcloud-preview/library/templates/_helpers.tpl
@@ -219,7 +219,6 @@ type: {{ $defaults.type }}
 {{/*
 HTTPRoute Render
 */}}
-
 {{- define "mozcloud-preview-lib.config.httproutes" -}}
 {{- $name_override := default "" .nameOverride -}}
 {{- $ingresses := include "mozcloud-preview-lib.config.ingresses" . | fromYaml -}}
@@ -244,7 +243,7 @@ HTTPRoute Render
       {{- /* Assign fields */ -}}
       {{- $_ := set $route "fullnameOverride" $route_name }}
       {{- $_ := set $route "labels" (include "mozcloud-preview-lib.labels" . | fromYaml) }}
-      {{- $_ := set $route "hostname" (first $host.domains) }}
+      {{- $_ := set $route "hostnames" $host.domains }}
       {{- $_ := set $route "gateway" (default dict $.gateway) }}
       {{- $_ := set $route "backend" (dict "name" $svc.name "port" $svc.port) }}
 

--- a/mozcloud-preview/library/templates/_helpers.tpl
+++ b/mozcloud-preview/library/templates/_helpers.tpl
@@ -1,0 +1,306 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mozcloud-preview-lib.name" -}}
+{{- if .nameOverride -}}
+{{- .nameOverride }}
+{{- else -}}
+mozcloud-preview
+{{- end -}}
+{{- end -}}
+{{- /*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mozcloud-preview-lib.fullname" -}}
+{{- if .fullnameOverride -}}
+{{- .fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+{{- include "mozcloud-preview-lib.name" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mozcloud-preview-lib.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mozcloud-preview-lib.labels" -}}
+{{- if .labels -}}
+{{- .labels | toYaml }}
+{{- else -}}
+helm.sh/chart: {{ default "mozcloud-preview" (.Chart).Name }}
+{{- if (.Chart).AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end }}
+app.kubernetes.io/component: {{ default "preview" .component }}
+{{ include "mozcloud-preview-lib.selectorLabels" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mozcloud-preview-lib.selectorLabels" -}}
+{{- if .selectorLabels -}}
+{{- .selectorLabels | toYaml }}
+{{- else -}}
+app.kubernetes.io/name: {{ default "mozcloud-webservice" .nameOverride }}
+app.kubernetes.io/instance: {{ default "mozcloud-deployment" (.Release).Name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Template helpers
+*/}}
+{{- define "mozcloud-preview-lib.config.name" -}}
+{{- $name := "" -}}
+{{- if .name -}}
+  {{- $name = .name -}}
+{{- end -}}
+{{- if and (.backendConfig).name (not $name) -}}
+  {{- $name = .backendConfig.name -}}
+{{- end -}}
+{{- if and (.frontendConfig).name (not $name) -}}
+  {{- $name = .frontendConfig.name -}}
+{{- end -}}
+{{- if and (.ingressConfig).name (not $name) -}}
+  {{- $name = .ingressConfig.name -}}
+{{- end -}}
+{{- if and (.nameOverride) (not $name) -}}
+  {{- $name = .nameOverride -}}
+{{- end -}}
+{{- if not $name -}}
+  {{- $name = include "mozcloud-preview-lib.fullname" $ -}}
+{{- end -}}
+{{- if .prefix -}}
+  {{- $name = printf "%s-%s" .prefix $name -}}
+{{- end -}}
+{{- if .suffixes -}}
+  {{- $suffix := join "-" .suffixes -}}
+  {{- $length := $suffix | len | add1 -}}
+  {{- $name = printf "%s-%s" ($name | trunc (sub 63 $length | int)) $suffix -}}
+{{- end -}}
+{{ $name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "mozcloud-preview-lib.config.backend.name" -}}
+{{- if (.backendService).name -}}
+{{- include "mozcloud-preview-lib.config.name" (dict "name" .backendService.name "prefix" "preview") }}
+{{- else -}}
+{{- include "mozcloud-preview-lib.config.name" (merge (dict "prefix" "preview") .) }}{{- end -}}
+{{- end -}}
+
+{{/*
+Ingress template helpers
+*/}}
+{{- define "mozcloud-preview-lib.config.ingress.preSharedCerts" -}}
+{{- $name_override := default "" .nameOverride -}}
+{{- $pre_shared_certs := dict "preSharedCerts" (dict) -}}
+{{- $tls_defaults := (index (include "mozcloud-preview-lib.defaults.ingresses" . | fromYaml) "ingresses" 0).tls -}}
+{{- range $ingress := .ingresses -}}
+  {{- range $host := $ingress.hosts -}}
+    {{- $tls := mergeOverwrite (mergeOverwrite $tls_defaults (default (dict) $ingress.tls)) (default (dict) ($host.tls)) -}}
+    {{- if and (eq $tls.type "pre-shared") (gt (len (default "" $tls.preSharedCerts)) 0) -}}
+      {{- $params := (dict "ingressConfig" $ingress) -}}
+      {{- if $name_override -}}
+        {{- $_ := set $params "nameOverride" $name_override -}}
+      {{- end -}}
+      {{- $ingress_name := include "mozcloud-preview-lib.config.name" $params -}}
+      {{- if and (not (index $pre_shared_certs "preSharedCerts" $ingress_name)) $tls.createCertificates -}}
+        {{- $cert_list := $tls.preSharedCerts | toString -}}
+        {{- $_ := set $pre_shared_certs.preSharedCerts $ingress_name $cert_list -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{ $pre_shared_certs | toYaml }}
+{{- end -}}
+
+
+{{- define "mozcloud-preview-lib.config.ingresses" -}}
+{{- $defaults := include "mozcloud-preview-lib.defaults.ingresses" . | fromYaml -}}
+{{- $ingresses := $defaults -}}
+{{- if .ingressConfig -}}
+  {{- $ingresses = mergeOverwrite $defaults (dict "ingresses" .ingressConfig) -}}
+{{- end -}}
+{{- $params := (dict "ingresses" $ingresses.ingresses) }}
+{{- $name_override := default "" .nameOverride }}
+{{- if $name_override }}
+  {{- $_ := set $params "nameOverride" $name_override }}
+{{- end -}}
+{{- $pre_shared_certs := include "mozcloud-preview-lib.config.ingress.preSharedCerts" $params | fromYaml -}}
+{{- $_ := set $ingresses "preSharedCerts" $pre_shared_certs.preSharedCerts -}}
+{{ $ingresses | toYaml }}
+{{- end -}}
+
+{{/*
+Service template helpers
+*/}}
+{{- define "mozcloud-preview-lib.config.services" -}}
+{{- $name_override := default "" .nameOverride -}}
+{{- $backend_defaults := include "mozcloud-preview-lib.defaults.backendConfig" . | fromYaml -}}
+{{- $ingresses := include "mozcloud-preview-lib.config.ingresses" . | fromYaml -}}
+{{- $services := list -}}
+{{- range $ingress := $ingresses.ingresses -}}
+  {{- range $host := $ingress.hosts -}}
+    {{- range $path := $host.paths -}}
+      {{- $service := dict -}}
+      {{- $backend := mergeOverwrite $backend_defaults (default (dict) $path.backend.config) -}}
+      {{- $backend_service := $path.backend.service -}}
+      {{- $params := dict "backendConfig" $backend "backendService" $backend_service "ingressConfig" $ingress -}}
+      {{- if $name_override -}}
+        {{- $_ := set $params "nameOverride" $name_override -}}
+      {{- end -}}
+      {{- $service_name := include "mozcloud-preview-lib.config.backend.name" $params -}}
+      {{- /* Check if service was already included. If so, skip to avoid duplicates. */}}
+      {{- /* Configure args for library chart */}}
+      {{- /* Service annotations */}}
+      {{- /* This allows users to explicitly specify "false" without overriding with "true" from defaults */}}
+      {{- $create_neg := false -}}
+      {{- $annotation_params := dict "backendName" $service_name "createNeg" $create_neg -}}
+      {{- if $ingress.annotations -}}
+        {{- $_ := set $annotation_params "annotations" $ingress.annotations -}}
+      {{- end -}}
+      {{- $annotations := include "mozcloud-preview-lib.config.service.annotations" $annotation_params | fromYaml -}}
+      {{- $_ := set $service "annotations" $annotations -}}
+      {{- /* Service config */}}
+      {{- $port_config := dict -}}
+      {{- if $backend_service.port -}}
+        {{- $_ = set $port_config "port" $backend_service.port -}}
+      {{- end -}}
+      {{- if $backend_service.protocol -}}
+        {{- $_ = set $port_config "protocol" $backend_service.protocol -}}
+      {{- end -}}
+      {{- if $backend_service.targetPort -}}
+        {{- $_ = set $port_config "target_port" $backend_service.targetPort -}}
+      {{- end -}}
+      {{- $config := include "mozcloud-preview-lib.config.service.config" $port_config | fromYaml -}}
+      {{- $_ = set $service "config" $config -}}
+      {{- /* Service fullnameOverride */}}
+      {{- $_ = set $service "fullnameOverride" $service_name -}}
+      {{- /* Service labels */}}
+      {{- $labels := default (include "mozcloud-preview-lib.labels" $ | fromYaml) $backend_service.labels -}}
+      {{- $_ = set $service "labels" $labels -}}
+      {{- /* Service selectorLabels */}}
+      {{- $selector_labels := default (include "mozcloud-preview-lib.selectorLabels" $ | fromYaml) $backend_service.selectorLabels -}}
+      {{- $_ = set $service "selectorLabels" $selector_labels -}}
+      {{- /* Append to services list */}}
+      {{- $services = append $services $service -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{ $services | toYaml }}
+{{- end -}}
+
+{{- define "mozcloud-preview-lib.config.service.annotations" -}}
+{{- if .annotations -}}
+{{ .annotations | toYaml }}
+{{- end }}
+{{- end -}}
+
+{{- define "mozcloud-preview-lib.config.service.config" -}}
+{{- $defaults := (include "mozcloud-preview-lib.defaults.service.config" . | fromYaml) -}}
+ports:
+  - port: {{ default $defaults.port .port }}
+    targetPort: {{ default $defaults.targetPort .targetPort }}
+    protocol: {{ default $defaults.protocol .protocol }}
+    name: {{ $defaults.name }}
+type: {{ $defaults.type }}
+{{- end -}}
+
+
+{{/*
+HTTPRoute Render
+*/}}
+
+{{- define "mozcloud-preview-lib.config.httproutes" -}}
+{{- $name_override := default "" .nameOverride -}}
+{{- $ingresses := include "mozcloud-preview-lib.config.ingresses" . | fromYaml -}}
+{{- $routes := list -}}
+
+{{- range $ingress := $ingresses.ingresses -}}
+  {{- range $host := $ingress.hosts -}}
+    {{- range $path := $host.paths -}}
+      {{- $svc := $path.backend.service -}}
+      {{- $route := dict -}}
+
+      {{- /* Name construction */ -}}
+      {{- $name_params := dict "ingressConfig" $ingress "nameOverride" $name_override "prefix" $.previewPr "suffixes" (list "httproute") }}
+      {{- $route_name := include "mozcloud-preview-lib.config.name" $name_params }}
+
+      {{- /* Assign fields */ -}}
+      {{- $_ := set $route "fullnameOverride" $route_name }}
+      {{- $_ := set $route "labels" (include "mozcloud-preview-lib.labels" . | fromYaml) }}
+      {{- $_ := set $route "hostname" (first $host.domains) }}
+      {{- $_ := set $route "gateway" (default dict $.gateway) }}
+      {{- $_ := set $route "backend" (dict "name" $svc.name "port" $svc.port) }}
+
+      {{- $routes = append $routes $route }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{ $routes | toYaml }}
+{{- end }}
+
+{{/*
+Defaults
+*/}}
+{{- define "mozcloud-preview-lib.defaults.backendConfig" -}}
+{{- if .defaults -}}
+{{ .defaults | toYaml }}
+{{- else -}}
+logging:
+  enable: true
+  sampleRate: 1.0
+{{- end -}}
+{{- end -}}
+
+{{- define "mozcloud-preview-lib.defaults.frontendConfig" -}}
+redirectToHttps:
+  enabled: true
+  responseCodeName: MOVED_PERMANENTLY_DEFAULT
+sslPolicy: mozilla-intermediate
+{{- end -}}
+
+{{- define "mozcloud-preview-lib.defaults.ingresses" -}}
+ingresses:
+  - hosts:
+      - domains: ["chart.example.local"]
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                port: 8080
+    tls:
+      createCertificates: true
+      type: ManagedCertificate
+      multipleHosts: true
+{{- end -}}
+
+{{- define "mozcloud-preview-lib.defaults.service.config" -}}
+# Default configurables for service
+# See https://kubernetes.io/docs/concepts/services-networking/service/ for
+# information on how to configure a service
+createNeg: false
+port: 8080
+targetPort: http
+protocol: TCP
+name: http
+type: ClusterIP
+{{- end }}
+
+{{/*
+Debug helper
+*/}}
+{{- define "mozcloud-preview-lib.debug" -}}
+{{- . | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
+{{- end -}}

--- a/mozcloud-preview/library/templates/_helpers.tpl
+++ b/mozcloud-preview/library/templates/_helpers.tpl
@@ -232,7 +232,13 @@ HTTPRoute Render
       {{- $route := dict -}}
 
       {{- /* Name construction */ -}}
-      {{- $name_params := dict "ingressConfig" $ingress "nameOverride" $name_override "prefix" $.previewPr "suffixes" (list "httproute") }}
+      {{- $service_suffix := $svc.name | replace "." "-" | replace "_" "-" }}
+      {{- $name_params := dict
+          "ingressConfig" $ingress
+          "nameOverride" $name_override
+          "prefix" $.previewPr
+          "suffixes" (list "httproute" $service_suffix)
+      }}
       {{- $route_name := include "mozcloud-preview-lib.config.name" $name_params }}
 
       {{- /* Assign fields */ -}}

--- a/mozcloud-preview/library/templates/_httproute.yaml
+++ b/mozcloud-preview/library/templates/_httproute.yaml
@@ -1,0 +1,40 @@
+{{- define "mozcloud-preview-lib.httproute" -}}
+{{- $routes := (include "mozcloud-preview-lib.config.httproutes" . | fromYamlArray) }}
+{{- $rendered := list }}
+{{- range $route := $routes }}
+  {{- if not (has $route.fullnameOverride $rendered) }}
+    {{- include "mozcloud-preview-lib.httproute.render" $route }}
+    {{- $rendered = append $rendered $route.fullnameOverride }}
+  {{- end }}
+{{- end }}
+{{- end }}
+---
+{{- define "mozcloud-preview-lib.httproute.render" -}}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: {{ .fullnameOverride }}
+  labels:
+    {{- .labels | toYaml | nindent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .gateway.name | default "sandbox-high-preview-gateway" }}
+      namespace: {{ .gateway.namespace | default "preview-shared-infrastructure" }}
+      sectionName: {{ .gateway.sectionName | default "https" }}
+  hostnames:
+    - {{ .hostname }}
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .backend.name }}
+          port: {{ .backend.port }}
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+{{- end }}

--- a/mozcloud-preview/library/templates/_httproute.yaml
+++ b/mozcloud-preview/library/templates/_httproute.yaml
@@ -25,7 +25,9 @@ spec:
       namespace: {{ .gateway.namespace | default "preview-shared-infrastructure" }}
       sectionName: {{ .gateway.sectionName | default "https" }}
   hostnames:
-    - {{ .hostname }}
+    {{- range .hostnames }}
+    - {{ . }}
+    {{- end }}
   rules:
     - backendRefs:
         - group: ""

--- a/mozcloud-preview/library/templates/_httproute.yaml
+++ b/mozcloud-preview/library/templates/_httproute.yaml
@@ -37,4 +37,4 @@ spec:
         - path:
             type: PathPrefix
             value: /
-{{- end }}
+{{ end }}

--- a/mozcloud-preview/library/templates/_httproute.yaml
+++ b/mozcloud-preview/library/templates/_httproute.yaml
@@ -25,9 +25,15 @@ spec:
       namespace: {{ .gateway.namespace | default "preview-shared-infrastructure" }}
       sectionName: {{ .gateway.sectionName | default "https" }}
   hostnames:
-    {{- range .hostnames }}
-    - {{ . }}
+  {{- if eq (len .hostnames) 1 }}
+    - {{ .previewHost }}
+  {{- else }}
+    {{- range $hostname := .hostnames }}
+      {{- $hostStr := print $hostname }}
+      {{- $prefix := first (splitList "." $hostStr) }}
+    - {{ printf "%s-%s" $prefix $.previewHost }}
     {{- end }}
+  {{- end }}
   rules:
     - backendRefs:
         - group: ""

--- a/mozcloud-preview/library/templates/_service.yaml
+++ b/mozcloud-preview/library/templates/_service.yaml
@@ -1,0 +1,10 @@
+{{- define "mozcloud-preview-lib.service" -}}
+{{- $service_config := (include "mozcloud-preview-lib.config.services" . | fromYamlArray) }}
+{{- $services := list }}
+{{- range $service := $service_config }}
+  {{- if not (has $service.fullnameOverride $services) }}
+    {{- include "mozcloud-service-lib.service" $service }}
+    {{- $services = append $services $service.fullnameOverride }}
+  {{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Use these values to test: 

```
preview:
  pr: 17
  host: pr16-cicd-demos.preview.mozilla.cloud

ingresses:
  - hosts:
      # The host will be used to match incoming traffic and generate TLS
      # certs.
      - domains:
          - dev.cicd-demos.nonprod.sandbox.mozgcp.net
        paths:
          - backend:
              service:
                # The name of your service. By default, the service name will
                # match the ingress name.
                name: cicd-demos-2
                port: 8080
  - hosts:
      - domains:
        - dev2.cicd-demos.nonprod.sandbox.mozgcp.net
        - dev3.cicd-demos.nonprod.sandbox.mozgcp.net
        paths:
        - backend:
            service:
              name: test
              port: 8088
```