### PR TITLE
feat(mozcloud-labels): create resuable labels chart, implement it in other charts

### DIFF
--- a/mozcloud-ingress/application/Chart.yaml
+++ b/mozcloud-ingress/application/Chart.yaml
@@ -15,18 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.0
+appVersion: 0.2.0
 
 dependencies:
-  - name: mozcloud-service-lib
-    version: 0.1.0
-    repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts
   - name: mozcloud-ingress-lib
-    version: 0.1.0
+    version: 0.2.0
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-ingress/application/templates/_helpers.tpl
+++ b/mozcloud-ingress/application/templates/_helpers.tpl
@@ -31,32 +31,15 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Common labels
+Create label parameters to be used in library chart if defined as values.
 */}}
-{{- define "mozcloud-ingress.labels" -}}
-helm.sh/chart: {{ include "mozcloud-ingress.chart" . }}
-{{ include "mozcloud-ingress.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- define "mozcloud-ingress.labelParams" -}}
+{{- $params := dict "chartName" (include "mozcloud-ingress.name" .) -}}
+{{- $label_params := list "appCode" "component" "environment" -}}
+{{- range $label_param := $label_params -}}
+  {{- if index $.Values $label_param -}}
+    {{- $_ := set $params $label_param (index $.Values $label_param) -}}
+  {{- end }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "mozcloud-ingress.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "mozcloud-ingress.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "mozcloud-ingress.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "mozcloud-ingress.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{- $params | toYaml }}
 {{- end }}

--- a/mozcloud-ingress/application/templates/backendconfig.yaml
+++ b/mozcloud-ingress/application/templates/backendconfig.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enabled }}
 {{- $params := dict "ingressConfig" .Values.ingresses "defaults" .Values.backendConfig "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
-{{- include "mozcloud-ingress-lib.backendConfig" $params }}
+{{- $label_params := include "mozcloud-ingress.labelParams" .  | fromYaml }}
+{{- include "mozcloud-ingress-lib.backendConfig" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/templates/frontendconfig.yaml
+++ b/mozcloud-ingress/application/templates/frontendconfig.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enabled }}
 {{- $params := dict "frontendConfig" .Values.frontendConfig "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
-{{- include "mozcloud-ingress-lib.frontendConfig" $params }}
+{{- $label_params := include "mozcloud-ingress.labelParams" .  | fromYaml }}
+{{- include "mozcloud-ingress-lib.frontendConfig" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/templates/ingress.yaml
+++ b/mozcloud-ingress/application/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enabled }}
 {{- $params := dict "defaults" .Values.backendConfig "ingressConfig" .Values.ingresses "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
-{{- include "mozcloud-ingress-lib.ingress" $params }}
+{{- $label_params := include "mozcloud-ingress.labelParams" .  | fromYaml }}
+{{- include "mozcloud-ingress-lib.ingress" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/templates/managedcertificate.yaml
+++ b/mozcloud-ingress/application/templates/managedcertificate.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enabled }}
 {{- $params := dict "ingressConfig" .Values.ingresses "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
-{{- include "mozcloud-ingress-lib.managedCertificate" $params }}
+{{- $label_params := include "mozcloud-ingress.labelParams" .  | fromYaml }}
+{{- include "mozcloud-ingress-lib.managedCertificate" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/templates/service.yaml
+++ b/mozcloud-ingress/application/templates/service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enabled }}
 {{- $params := dict "ingressConfig" .Values.ingresses "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
-{{- include "mozcloud-ingress-lib.service" $params }}
+{{- $label_params := include "mozcloud-ingress.labelParams" . | fromYaml }}
+{{- include "mozcloud-ingress-lib.service" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/values.yaml
+++ b/mozcloud-ingress/application/values.yaml
@@ -4,6 +4,18 @@ enabled: true
 # Name to be used for all resources if not specified at the resource level.
 #nameOverride:
 
+# Application code. This should match the `app_code` value in your tenant's
+# values.yaml file.
+#appCode:
+
+# Component. This should match the `component` value in your tenant's
+# values.yaml file.
+#component:
+
+# Environment. This should match the `environment` value in your tenant's
+# values.yaml file.
+#environment:
+
 # Global backend configuration. These values can be overridden at the host
 # level in the ingress definitions: .Values.ingresses[].hosts[].backend
 backendConfig:

--- a/mozcloud-ingress/library/Chart.yaml
+++ b/mozcloud-ingress/library/Chart.yaml
@@ -15,9 +15,12 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 dependencies:
-  - name: mozcloud-service-lib
+  - name: mozcloud-labels-lib
     version: 0.1.0
+    repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts
+  - name: mozcloud-service-lib
+    version: 0.2.0
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-ingress/library/templates/_backendconfig.yaml
+++ b/mozcloud-ingress/library/templates/_backendconfig.yaml
@@ -9,7 +9,9 @@ kind: BackendConfig
 metadata:
   name: {{ $backend.name }}
   labels:
-    {{- default (include "mozcloud-ingress-lib.labels" $) (default $backend.ingressConfig.labels $backend.labels) | nindent 4 }}
+    {{- $label_params := dict "labels" (default (default (dict) $backend.ingressConfig.labels) $backend.labels) }}
+    {{- $labels := include "mozcloud-ingress-lib.labels" (mergeOverwrite $ $label_params) | fromYaml }}
+    {{- $labels | toYaml | nindent 4 }}
 spec:
   {{- omit $backend "name" "ingressConfig" | toYaml | nindent 2 }}
 {{- $backends = append $backends $backend.name }}

--- a/mozcloud-ingress/library/templates/_frontendconfig.yaml
+++ b/mozcloud-ingress/library/templates/_frontendconfig.yaml
@@ -6,7 +6,9 @@ kind: FrontendConfig
 metadata:
   name: {{ $frontend_config.name }}
   labels:
-    {{- default (include "mozcloud-ingress-lib.labels" .) ($frontend_config.labels) | nindent 4 }}
+    {{- $label_params := dict "labels" (default (dict) $frontend_config.labels) }}
+    {{- $labels := include "mozcloud-ingress-lib.labels" (mergeOverwrite . $label_params) | fromYaml }}
+    {{- $labels | toYaml | nindent 4 }}
 spec:
   redirectToHttps:
     {{- $frontend_config.redirectToHttps | toYaml | nindent 4 }}

--- a/mozcloud-ingress/library/templates/_helpers.tpl
+++ b/mozcloud-ingress/library/templates/_helpers.tpl
@@ -32,28 +32,22 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "mozcloud-ingress-lib.labels" -}}
+{{- $labels := include "mozcloud-labels-lib.labels" . | fromYaml -}}
 {{- if .labels -}}
-{{- .labels | toYaml }}
-{{- else -}}
-helm.sh/chart: {{ default "mozcloud-ingress" (.Chart).Name }}
-{{- if (.Chart).AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- $labels = mergeOverwrite $labels .labels -}}
 {{- end }}
-app.kubernetes.io/component: {{ default "ingress" .component }}
-{{ include "mozcloud-ingress-lib.selectorLabels" . }}
-{{- end }}
+{{- $labels | toYaml }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "mozcloud-ingress-lib.selectorLabels" -}}
+{{- $selector_labels := include "mozcloud-labels-lib.selectorLabels" . | fromYaml -}}
 {{- if .selectorLabels -}}
-{{- .selectorLabels | toYaml }}
-{{- else -}}
-app.kubernetes.io/name: {{ default "mozcloud-webservice" .nameOverride }}
-app.kubernetes.io/instance: {{ default "mozcloud-deployment" (.Release).Name }}
+  {{- $selector_labels = mergeOverwrite $selector_labels .selector_labels -}}
 {{- end }}
+{{- $selector_labels | toYaml }}
 {{- end }}
 
 {{/*
@@ -286,7 +280,8 @@ Service template helpers
       {{- /* Service fullnameOverride */}}
       {{- $_ = set $service "fullnameOverride" $service_name -}}
       {{- /* Service labels */}}
-      {{- $labels := default (include "mozcloud-ingress-lib.labels" $ | fromYaml) $backend_service.labels -}}
+      {{- $label_params := dict "labels" (default (dict) $backend_service.labels) -}}
+      {{- $labels := include "mozcloud-ingress-lib.labels" (mergeOverwrite $ $label_params) | fromYaml -}}
       {{- $_ = set $service "labels" $labels -}}
       {{- /* Service selectorLabels */}}
       {{- $selector_labels := default (include "mozcloud-ingress-lib.selectorLabels" $ | fromYaml) $backend_service.selectorLabels -}}

--- a/mozcloud-ingress/library/templates/_ingress.yaml
+++ b/mozcloud-ingress/library/templates/_ingress.yaml
@@ -16,7 +16,9 @@ kind: Ingress
 metadata:
   name: {{ $ingress_name }}
   labels:
-    {{- default (include "mozcloud-ingress-lib.labels" $) $ingress.labels | nindent 4 }}
+    {{- $label_params := dict "labels" (default (dict) $ingress.labels) }}
+    {{- $labels := include "mozcloud-ingress-lib.labels" (mergeOverwrite $ $label_params) | fromYaml }}
+    {{- $labels | toYaml | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: "gce"
     kubernetes.io/ingress.global-static-ip-name: {{ default "mozcloud-ingress-dev-ip-v4" $ingress.staticIpName }}

--- a/mozcloud-labels/.helmignore
+++ b/mozcloud-labels/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/mozcloud-labels/library/Chart.yaml
+++ b/mozcloud-labels/library/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: mozcloud-labels
+description: Standardized labels for MozCloud Helm charts
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: library
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0

--- a/mozcloud-labels/library/Chart.yaml
+++ b/mozcloud-labels/library/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: mozcloud-labels
+name: mozcloud-labels-lib
 description: Standardized labels for MozCloud Helm charts
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/mozcloud-labels/library/templates/_helpers.tpl
+++ b/mozcloud-labels/library/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mozcloud-labels.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mozcloud-labels.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mozcloud-labels.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/mozcloud-labels/library/templates/_helpers.tpl
+++ b/mozcloud-labels/library/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "mozcloud-labels.name" -}}
+{{- define "mozcloud-labels-lib.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "mozcloud-labels.fullname" -}}
+{{- define "mozcloud-labels-lib.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,6 +26,6 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "mozcloud-labels.chart" -}}
+{{- define "mozcloud-labels-lib.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/mozcloud-labels/library/templates/_labels.yaml
+++ b/mozcloud-labels/library/templates/_labels.yaml
@@ -1,0 +1,8 @@
+{{- define "mozcloud-labels.labels" -}}
+helm.sh/chart: {{ .chartName }}
+{{ include "mozcloud-labels.selectorLabels" . }}
+{{- if .appVersion }}
+app.kubernetes.io/version: {{ .appVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: Helm
+{{- end -}}

--- a/mozcloud-labels/library/templates/_labels.yaml
+++ b/mozcloud-labels/library/templates/_labels.yaml
@@ -1,6 +1,6 @@
-{{- define "mozcloud-labels.labels" -}}
+{{- define "mozcloud-labels-lib.labels" -}}
 helm.sh/chart: {{ .chartName }}
-{{ include "mozcloud-labels.selectorLabels" . }}
+{{ include "mozcloud-labels-lib.selectorLabels" . }}
 {{- if .appVersion }}
 app.kubernetes.io/version: {{ .appVersion | quote }}
 {{- end }}

--- a/mozcloud-labels/library/templates/_labels.yaml
+++ b/mozcloud-labels/library/templates/_labels.yaml
@@ -1,5 +1,15 @@
 {{- define "mozcloud-labels-lib.labels" -}}
-helm.sh/chart: {{ .chartName }}
+{{- $chart_name := "" }}
+{{- if .chartName }}
+  {{- $chart_name = .chartName }}
+{{- else if (.Chart).Name }}
+  {{- $chart_name = .Chart.Name }}
+{{- else if (.Chart).name }}
+  {{- $chart_name = .Chart.name }}
+{{- end }}
+{{- if $chart_name }}
+helm.sh/chart: {{ $chart_name }}
+{{- end }}
 {{ include "mozcloud-labels-lib.selectorLabels" . }}
 {{- if .appVersion }}
 app.kubernetes.io/version: {{ .appVersion | quote }}

--- a/mozcloud-labels/library/templates/_selectorlabels.yaml
+++ b/mozcloud-labels/library/templates/_selectorlabels.yaml
@@ -1,5 +1,11 @@
 {{- define "mozcloud-labels-lib.selectorLabels" -}}
+{{- if .appCode }}
 app.kubernetes.io/name: {{ .appCode }}
-app.kubernetes.io/component: {{ .componentCode }}
+{{- end -}}
+{{- if .component }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+{{- if .environment }}
 env_code: {{ .environment }}
+{{- end -}}
 {{- end -}}

--- a/mozcloud-labels/library/templates/_selectorlabels.yaml
+++ b/mozcloud-labels/library/templates/_selectorlabels.yaml
@@ -1,0 +1,5 @@
+{{- define "mozcloud-labels.selectorLabels" -}}
+app.kubernetes.io/name: {{ .appCode }}
+app.kubernetes.io/component: {{ .componentCode }}
+env_code: {{ .environment }}
+{{- end -}}

--- a/mozcloud-labels/library/templates/_selectorlabels.yaml
+++ b/mozcloud-labels/library/templates/_selectorlabels.yaml
@@ -1,4 +1,4 @@
-{{- define "mozcloud-labels.selectorLabels" -}}
+{{- define "mozcloud-labels-lib.selectorLabels" -}}
 app.kubernetes.io/name: {{ .appCode }}
 app.kubernetes.io/component: {{ .componentCode }}
 env_code: {{ .environment }}

--- a/mozcloud-service/library/Chart.yaml
+++ b/mozcloud-service/library/Chart.yaml
@@ -15,4 +15,9 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
+
+dependencies:
+  - name: mozcloud-labels-lib
+    version: 0.1.0
+    repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-service/library/templates/_helpers.tpl
+++ b/mozcloud-service/library/templates/_helpers.tpl
@@ -31,28 +31,22 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "mozcloud-service-lib.labels" -}}
-{{- if (index . "labels") -}}
-{{- index . "labels" | toYaml }}
-{{- else -}}
-helm.sh/chart: {{ include "mozcloud-service-lib.chart" . }}
-{{ include "mozcloud-service-lib.selectorLabels" . }}
-{{- if (.Chart).AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
-{{- end }}
-app.kubernetes.io/component: service
-{{- end }}
+{{- $labels := include "mozcloud-labels-lib.labels" . | fromYaml -}}
+{{- if .labels -}}
+  {{- $labels = mergeOverwrite $labels .labels -}}
+{{- end -}}
+{{- $labels | toYaml }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "mozcloud-service-lib.selectorLabels" -}}
-{{- if (index . "selectorLabels") -}}
-{{- index . "selectorLabels" | toYaml }}
-{{- else -}}
-app.kubernetes.io/name: {{ include "mozcloud-service-lib.name" . }}
-app.kubernetes.io/instance: {{ default (include "mozcloud-service-lib.name" .) (.Release).Name }}
+{{- $selector_labels := include "mozcloud-labels-lib.selectorLabels" . | fromYaml -}}
+{{- if .selectorLabels -}}
+  {{- $selector_labels = mergeOverwrite $selector_labels .selectorLabels -}}
 {{- end }}
+{{- $selector_labels | toYaml }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
This creates the mozcloud-labels-lib library chart which allows us to centrally define and version K8s labels to use on resources managed by MozCloud charts. Additionally, this chart allows us to create labels we always want assigned to resources, allowing parent charts to override them if necessary.

As part of this change, I also tweaked the mozcloud-ingress and mozcloud-service application and library charts:

- These are now using the mozcloud-labels-lib chart for labels.
- Minor versions for these charts were bumped.
- New values were added to the mozcloud-ingress application chart (`appCode`, `component`, `environment`) which are necessary to generate tenant and environment-specific labels.
  - The long term goal is to abstract everything into either `mozcloud-<service_type>` (eg. `mozcloud-webservice`) or even just `mozcloud`.
  - As part of this, global `.Values.{app_code,component_code,environment` configurations would be moved into a `mozcloud-<service_type>` or `mozcloud` key.