### PR TITLE
feat(mozcloud-gateway): create initial mozcloud-gateway library and application charts

### DIFF
--- a/mozcloud-gateway/application/.helmignore
+++ b/mozcloud-gateway/application/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.3
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.0
+appVersion: 0.1.3
 
 dependencies:
   - name: mozcloud-gateway-lib

--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: 0.1.0
 
 dependencies:
   - name: mozcloud-gateway-lib
-    version: 0.1.0
+    version: 0.1.3
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: mozcloud-gateway
+description: A Helm chart that creates gateways and supporting Gateway API resources
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: 0.1.0
+
+dependencies:
+  - name: mozcloud-gateway-lib
+    version: 0.1.0
+    repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-gateway/application/templates/_helpers.tpl
+++ b/mozcloud-gateway/application/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "application.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "application.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "application.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "application.labels" -}}
+helm.sh/chart: {{ include "application.chart" . }}
+{{ include "application.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "application.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "application.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "application.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "application.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/mozcloud-gateway/application/templates/_helpers.tpl
+++ b/mozcloud-gateway/application/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create label parameters to be used in library chart if defined as values.
+*/}}
+{{- define "mozcloud-gateway.labelParams" -}}
+{{- $params := dict "chartName" (include "mozcloud-gateway.name" .) -}}
+{{- $label_params := list "appCode" "component" "environment" -}}
+{{- range $label_param := $label_params -}}
+  {{- if index $.Values $label_param -}}
+    {{- $_ := set $params $label_param (index $.Values $label_param) -}}
+  {{- end }}
+{{- end }}
+{{- $params | toYaml }}
+{{- end }}

--- a/mozcloud-gateway/application/templates/_helpers.tpl
+++ b/mozcloud-gateway/application/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "application.name" -}}
+{{- define "mozcloud-gateway.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "application.fullname" -}}
+{{- define "mozcloud-gateway.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "application.chart" -}}
+{{- define "mozcloud-gateway.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "application.labels" -}}
-helm.sh/chart: {{ include "application.chart" . }}
-{{ include "application.selectorLabels" . }}
+{{- define "mozcloud-gateway.labels" -}}
+helm.sh/chart: {{ include "mozcloud-gateway.chart" . }}
+{{ include "mozcloud-gateway.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,17 +45,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "application.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "application.name" . }}
+{{- define "mozcloud-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mozcloud-gateway.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "application.serviceAccountName" -}}
+{{- define "mozcloud-gateway.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "application.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "mozcloud-gateway.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/backendpolicy.yaml
+++ b/mozcloud-gateway/application/templates/backendpolicy.yaml
@@ -1,0 +1,2 @@
+{{- if and .Values.enabled (.Values.httpRoute).enabled }}
+{{- end }}

--- a/mozcloud-gateway/application/templates/gateway.yaml
+++ b/mozcloud-gateway/application/templates/gateway.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.enabled (.Values.gateway).enabled }}
-{{- $params := dict "gatewayConfig" .Values.gateways "Chart" .Chart "Release" .Release }}
+{{- $params := dict "gatewayConfig" .Values.gateway "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
 {{- $label_params := include "mozcloud-gateway.labelParams" .  | fromYaml }}
 {{ include "mozcloud-gateway-lib.gateway" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/gateway.yaml
+++ b/mozcloud-gateway/application/templates/gateway.yaml
@@ -1,0 +1,5 @@
+{{- if and .Values.enabled (.Values.gateway).enabled }}
+{{- $params := dict "gatewayConfig" .Values.gateways "Chart" .Chart "Release" .Release }}
+{{- $label_params := include "mozcloud-gateway.labelParams" .  | fromYaml }}
+{{ include "mozcloud-gateway-lib.gateway" (mergeOverwrite $params $label_params) }}
+{{- end }}

--- a/mozcloud-gateway/application/templates/gatewaypolicy.yaml
+++ b/mozcloud-gateway/application/templates/gatewaypolicy.yaml
@@ -1,0 +1,2 @@
+{{- if and .Values.enabled (.Values.gateway).enabled }}
+{{- end }}

--- a/mozcloud-gateway/application/templates/httpcheckpolicy.yaml
+++ b/mozcloud-gateway/application/templates/httpcheckpolicy.yaml
@@ -1,0 +1,2 @@
+{{- if and .Values.enabled (.Values.httpRoute).enabled }}
+{{- end }}

--- a/mozcloud-gateway/application/templates/httproute.yaml
+++ b/mozcloud-gateway/application/templates/httproute.yaml
@@ -1,0 +1,2 @@
+{{- if and .Values.enabled (.Values.httpRoute).enabled }}
+{{- end }}

--- a/mozcloud-gateway/application/templates/service.yaml
+++ b/mozcloud-gateway/application/templates/service.yaml
@@ -1,0 +1,2 @@
+{{- if and .Values.enabled (.Values.httpRoute).enabled }}
+{{- end }}

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -56,7 +56,6 @@ backendPolicy:
   # Backend service timeout period in seconds.
   #timeoutSec: 30
 
-# TODO: Create backend services
 # Defines the backend services to create and their configurations.
 backendServices:
   - name: mozcloud-gateway
@@ -156,23 +155,6 @@ gateway:
       addresses:
         - mozcloud-gateway-dev-ip-v4
 
-      certificates:
-        # A list of the certmap, pre-shared cert, or secret names to use on the
-        # gateway.
-        #
-        # Certificate maps and pre-shared certificates are created
-        # outside of Kubernetes either by tenant Terraform modules (certmaps)
-        # or manually (pre-shared).
-        #
-        # Secrets can be created via Certificate resources provisioned by
-        # cert-manager.
-        names:
-          - my-certmap
-
-        # Can be "certmap", "pre-shared", or "secret". Default (and preferred)
-        # is "certmap".
-        type: certmap
-
       listeners:
         # The http listener will be created by default to handle HTTP to HTTPS
         # redirects.
@@ -186,6 +168,32 @@ gateway:
           protocol: HTTPS
           port: 443
 
+          # Certificate details for external gateways. This section is only
+          # necessary for listeners using the HTTPS protocol.
+          certificates:
+            # A list of the certmap, pre-shared cert, or secret names to use on the
+            # gateway. Only the first entry is used if "type" is "certmap".
+            #
+            # Certificate maps and pre-shared certificates are created
+            # outside of Kubernetes either by tenant Terraform modules (certmaps)
+            # or manually (pre-shared).
+            #
+            # Secrets can be created via Certificate resources provisioned by
+            # cert-manager.
+            names:
+              - my-certmap
+
+            # Can be "certmap", "pre-shared", or "secret". Default (and preferred)
+            # is "certmap".
+            type: certmap
+
+
+      # Additional annotations
+      #annotations: {}
+
+      # Custom labels. Additional labels are generated in templates/_helpers.tpl.
+      #labels: {}
+
 # Defines specific parameters of the frontend of the Google Cloud load
 # balancer. This policy is similar to a FrontendConfig for an Ingress resource.
 gatewayPolicy:
@@ -193,7 +201,6 @@ gatewayPolicy:
   # the load balancer uses to terminate HTTPS traffic from clients.
   sslPolicy: mozilla-intermediate
 
-# TODO: Create HTTP Routes
 # Defines how HTTP and HTTPS requests received by a Gateway are directed to
 # Services.
 httpRoute:

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -155,6 +155,27 @@ gateway:
       addresses:
         - mozcloud-gateway-dev-ip-v4
 
+      # Global certificate details for external gateways. Certificates are only
+      # necessary if one or more listeners use the HTTP procotol.
+      #
+      # This section is overridden by certificates defined at the listener level.
+      certificates:
+        # A list of the certmap, pre-shared cert, or secret names to use on the
+        # gateway. Only the first entry is used if "type" is "certmap".
+        #
+        # Certificate maps and pre-shared certificates are created
+        # outside of Kubernetes either by tenant Terraform modules (certmaps)
+        # or manually (pre-shared).
+        #
+        # Secrets can be created via Certificate resources provisioned by
+        # cert-manager.
+        names:
+          - my-certmap
+
+        # Can be "certmap", "pre-shared", or "secret". Default (and preferred)
+        # is "certmap".
+        type: certmap
+
       listeners:
         # The http listener will be created by default to handle HTTP to HTTPS
         # redirects.
@@ -168,24 +189,12 @@ gateway:
           protocol: HTTPS
           port: 443
 
-          # Certificate details for external gateways. This section is only
-          # necessary for listeners using the HTTPS protocol.
-          certificates:
-            # A list of the certmap, pre-shared cert, or secret names to use on the
-            # gateway. Only the first entry is used if "type" is "certmap".
-            #
-            # Certificate maps and pre-shared certificates are created
-            # outside of Kubernetes either by tenant Terraform modules (certmaps)
-            # or manually (pre-shared).
-            #
-            # Secrets can be created via Certificate resources provisioned by
-            # cert-manager.
-            names:
-              - my-certmap
-
-            # Can be "certmap", "pre-shared", or "secret". Default (and preferred)
-            # is "certmap".
-            type: certmap
+          # Configures certificate details at the listener level. This
+          # overrides global certificate configurations at the gateway level.
+          #certificates:
+          #  names:
+          #    - my-certmap
+          #  type: certmap
 
 
       # Additional annotations

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -1,0 +1,235 @@
+# If disabled, no resources in the chart will be created.
+enabled: true
+
+# Name to be used for all resources if not specified at the resource level.
+# This should match the name of the parent Helm chart.
+#nameOverride:
+
+# Application code. This should match the `app_code` value in your tenant's
+# values.yaml file.
+#appCode:
+
+# Component. This should match the `component` value in your tenant's
+# values.yaml file.
+#component:
+
+# Environment. This should match the `environment` value in your tenant's
+# values-<env>.yaml file.
+#environment:
+
+# TODO: Create backend policies
+# Defines how the backend services of the load balancer should distribute the
+# traffic to the endpoints. This policy is similar to a BackendConfig for an
+# Ingress resource.
+backendPolicies: []
+
+# TODO: Create backend services
+# Defines the backend services to create and their configurations.
+backendServices: []
+
+# Defines the Gateways to create and their configurations.
+gateway:
+  # If disabled, Gateway resources will not be created in the K8s namespace.
+  enabled: false
+
+  gateways:
+    - name: mozcloud-gateway
+
+      # Type can be "internal" or "external". The library chart will
+      # automatically assign the preferred className if not defined here.
+      # Overridden by "className", if defined.
+      #
+      # Read more: https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api#gatewayclass
+      #
+      # Note: Internal and external gateways MUST be created separately.
+      type: external
+
+      # Sets the load balancer scope. Options are "global" or "regional".
+      #
+      # External gateways can be either "global" (default) or "regional".
+      # Internal gateways can only be "regional".
+      #
+      # Overridden by "className", if defined.
+      #scope: global
+
+      # Manually define a className, if desired. By default, the following
+      # classNames will be assigned for each respective gateway type:
+      #
+      #   internal: gke-l7-rilb
+      #   external: gke-l7-global-external-managed
+      #
+      # This will override "type" and "scope" configurations.
+      #className: gke-l7-global-external-managed
+
+      # A list of the named addresses to use on the Gateway. These should match
+      # the named addresses created for the tenant in GCP.
+      addresses:
+        - mozcloud-gateway-dev-ip-v4
+
+      certificates:
+        # A list of the certmap, pre-shared cert, or secret names to use on the
+        # gateway.
+        #
+        # Certificate maps and pre-shared certificates are created
+        # outside of Kubernetes either by tenant Terraform modules (certmaps)
+        # or manually (pre-shared).
+        #
+        # Secrets can be created via Certificate resources provisioned by
+        # cert-manager.
+        names:
+          - my-certmap
+
+        # Can be "certmap", "pre-shared", or "secret". Default (and preferred)
+        # is "certmap".
+        type: certmap
+
+      listeners:
+        # The http listener will be created by default to handle HTTP to HTTPS
+        # redirects.
+        - name: http
+          protocol: HTTP
+          port: 80
+
+        # The https listener is used to handle inbound traffic to the service.
+        # Inbound gateways do not need https listeners.
+        - name: https
+          protocol: HTTPS
+          port: 443
+
+# TODO: Create gateway policies
+# Defines specific parameters of the frontend of the Google Cloud load
+# balancer. This policy is similar to a FrontendConfig for an Ingress resource.
+gatewayPolicies: []
+
+# TODO: Create health check policies
+# Defines the parameters and behavior of the health check used to check the
+# health status of the backend Pods.
+healthCheckPolicies: []
+
+# TODO: Create HTTP Routes
+# Defines how HTTP and HTTPS requests received by a Gateway are directed to
+# Services.
+httpRoute:
+  # If disabled, HTTPRoute resources will not be created in the K8s namespace.
+  enabled: false
+
+  httpRoutes:
+    - name: mozcloud-gateway
+
+      # Hostnames to match against. Hostnames are matched before any other
+      # matches (path, headers) occur.
+      hostnames:
+        - chart.example.local
+        - chart2.example.local
+
+      # If enabled, create an HTTP-to-HTTPS redirect.
+      #httpToHttpsRedirect: true
+
+      # Define parent Gateway resource the HTTPRoute should attach to.
+      parentRefs:
+        - kind: Gateway
+          name: mozcloud-gateway
+
+          # This refers to the name of the listener to use on the gateway. See
+          # gateway.gateways[].listeners[].name for Gateways created using this
+          # chart.
+          section: https
+
+      rules:
+          # A list of the backend services to receive traffic.
+        - backendRefs:
+              # The name of the backend service
+            - name: mozcloud-gateway
+              port: 8080
+
+              # The amount of inbound traffic you want send to this backend
+              # service. This value creates a percentage of the total weights
+              # specified across all backend services in this rule.
+              #
+              # For example, say you have the following backend services
+              # specified:
+              #
+              #   - name: service1
+              #     port: 8080
+              #     weight: 3
+              #   - name: service2
+              #     port: 8080
+              #     weight: 1
+              #
+              # In this example, "service1" would receive roughly 75% of
+              # requests and "service2" would receive roughly 25%.
+              #
+              # If unspecified, each backend service will be assigned a weight
+              # of 1.
+              #
+              # If set to 0, no traffic will be sent to that backend service.
+              #weight:
+
+          # Configures paths or headers to match against when sending traffic to
+          # abackend service. Matches are independent, meaning the rule will
+          # be matched if any matches below are true.
+          #
+          # If no matches are specified, all traffic will be sent to the "/"
+          # path on the backend service pods by default.
+          #matches:
+          #  # Matches path "/path"
+          #  - path: /path
+          #
+          #  # Header match. Contains a list of headers against which to match.
+          #  - headers:
+          #      - X-My-Header
+          #      - X-Another-Header
+          #
+          #  # If a path and header specified in an entry, the rule will be
+          #  # matched if BOTH the path and headers match.
+          #  - path: /foo
+          #    headers:
+          #      - X-My-Header
+          #      - X-Another-Header
+
+          # Configures a path redirect. Overridden by "rewrite".
+          #
+          # Note: Enable or disable HTTP-to-HTTPS redirects using
+          # "httpToHttpsRedirect" parameter in httpRoute definition above.
+          #redirect:
+          #  # Target path for redirect.
+          #  path: /newpath
+          #
+          #  # Type can be "ReplaceFullPath" or "ReplacePrefixMatch".
+          #  #
+          #  # "ReplaceFullPath" will replace full paths specified in the
+          #  # "matches" section with the one specified above.
+          #  # Example: /path/to/endpoint -> /newpath
+          #  #
+          #  # "ReplacePrefixMatch" will replace the prefix specified in the
+          #  # "matches" section with the one specified above.
+          #  # Example: /path/to/endpoint -> /newpath/to/endpoint
+          #  type: ReplaceFullPath
+          #
+          #  # HTTP status code to return. Default is 302.
+          #  #statusCode: 302
+
+          # Configures a rewrite. Overrides "redirect".
+          #rewrite:
+          #  hostname: chart.example2.local
+          #
+          #  # Optionally configure a path redirect when rewriting.
+          #  #path:
+          #  #  name: /newpath
+          #  #
+          #  #  # Type can be "ReplaceFullPath" or "ReplacePrefixMatch".
+          #  #  #
+          #  #  # "ReplaceFullPath" will replace full paths specified in the
+          #  #  # "matches" section with the one specified above.
+          #  #  # Example: /path/to/endpoint -> /newpath
+          #  #  #
+          #  #  # "ReplacePrefixMatch" will replace the prefix specified in the
+          #  #  # "matches" section with the one specified above.
+          #  #  # Example: /path/to/endpoint -> /newpath/to/endpoint
+          #  #  type: ReplaceFullPath
+
+# TODO: Create traffic distribution policies
+# Defines how traffic is distributed across endpoints within a backend. This
+# policy is similar to how you would configure specific traffic balancing
+# algorithms for the backend service that are referenced by an Ingress resource.
+trafficDistributionPolicies: []

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -17,15 +17,105 @@ enabled: true
 # values-<env>.yaml file.
 #environment:
 
-# TODO: Create backend policies
 # Defines how the backend services of the load balancer should distribute the
 # traffic to the endpoints. This policy is similar to a BackendConfig for an
-# Ingress resource.
-backendPolicies: []
+# Ingress resource. These are default values that can be overridden for each
+# backend service in backendServices.
+backendPolicy:
+  # Configures connection draining.
+  #connectionDraining:
+  #  # Ranges from 0 (disabled) to 3600.
+  #  drainingTimeoutSec:
+
+  # Configures Identity-Aware Proxy for the backend. This is not necessary for
+  # most services.
+  #iap:
+  #  enabled: false
+
+  #  # The OAuth2 client ID.
+  #  oauth2ClientId:
+
+  #  # Name of the Kubernetes secret containing the OAuth2 client secret.
+  #  oauth2ClientSecret:
+
+  # Configures HTTP access logging.
+  logging:
+    enable: true
+
+    # Ranges from 0.0 (0%) to 1.0 (100%).
+    sampleRate: 0.1
+
+  #sessionAffinity:
+  #  # Options: CLIENT_IP, GENERATED_COOKIE, NONE
+  #  type: CLIENT_IP
+
+  #  # If "type" is set to "GENERATED_COOKIE", configure the lifetime of cookies
+  #  # in seconds. Min: 0, max: 1209600.
+  #  #cookieTtlSec:
+
+  # Backend service timeout period in seconds.
+  #timeoutSec: 30
 
 # TODO: Create backend services
 # Defines the backend services to create and their configurations.
-backendServices: []
+backendServices:
+  - name: mozcloud-gateway
+    # Definitions for the Kubernetes service.
+    backend:
+      port: 8080
+
+      # Protocol used for service. Default is TCP. More information found
+      # here:
+      # https://kubernetes.io/docs/reference/networking/service-protocols/
+      #protocol: TCP
+
+      # Port name/number of pods the service should target. Default is "http".
+      targetPort: http
+
+      # Labels to use for the service.
+      #labels: {}
+
+      # Selector labels the service should use to match against pods.
+      #selectorLabels: {}
+
+    # Backend policy to apply to this specific backend service. Overrides the
+    # defaults from .Values.backendPolicy
+    #backendPolicy: {}
+
+    # Health check configurations for the load balancer to perform against the
+    # backend service.
+    #
+    # By default, Kubernetes services will perform health checks against pods
+    # using readinessProbes and livenessProbes. This section allows users to
+    # specify health check configurations at the load balancer level, which
+    # provides more fine-grained control over how health checks are performed.
+    healthCheck:
+      # The request path to use for the health check. Default is
+      # "/__lbheartbeat__".
+      path: /__lbheartbeat__
+
+      # The protocol to use for health checks. Options are "http" or "tcp".
+      # Default is "http".
+      protocol: http
+
+      # The port to use for the health check, if different from the service
+      # port. This port must be specified as a number, not a named port.
+      #port:
+
+      # The interval (in seconds) in which the endpoint is probed for a health
+      # check.
+      #checkIntervalSec:
+
+      # The timeout (in seconds) for the health check probe.
+      #timeoutSec:
+
+      # Number of sequential connection attempts that must succeed for a backend
+      # to be considered healthy.
+      #healthyThreshold:
+
+      # Number of sequential connection attempts that must succeed for a backend
+      # to be considered unhealthy.
+      #unhealthyThreshold:
 
 # Defines the Gateways to create and their configurations.
 gateway:
@@ -96,15 +186,12 @@ gateway:
           protocol: HTTPS
           port: 443
 
-# TODO: Create gateway policies
 # Defines specific parameters of the frontend of the Google Cloud load
 # balancer. This policy is similar to a FrontendConfig for an Ingress resource.
-gatewayPolicies: []
-
-# TODO: Create health check policies
-# Defines the parameters and behavior of the health check used to check the
-# health status of the backend Pods.
-healthCheckPolicies: []
+gatewayPolicy:
+  # SSL policy to use. This configures a set of TLS versions and ciphers that
+  # the load balancer uses to terminate HTTPS traffic from clients.
+  sslPolicy: mozilla-intermediate
 
 # TODO: Create HTTP Routes
 # Defines how HTTP and HTTPS requests received by a Gateway are directed to
@@ -228,8 +315,8 @@ httpRoute:
           #  #  # Example: /path/to/endpoint -> /newpath/to/endpoint
           #  #  type: ReplaceFullPath
 
-# TODO: Create traffic distribution policies
+# TODO: Create default traffic distribution policy, add support in backend
 # Defines how traffic is distributed across endpoints within a backend. This
 # policy is similar to how you would configure specific traffic balancing
 # algorithms for the backend service that are referenced by an Ingress resource.
-trafficDistributionPolicies: []
+trafficDistributionPolicy: []

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -155,27 +155,6 @@ gateway:
       addresses:
         - mozcloud-gateway-dev-ip-v4
 
-      # Global certificate details for external gateways. Certificates are only
-      # necessary if one or more listeners use the HTTP procotol.
-      #
-      # This section is overridden by certificates defined at the listener level.
-      certificates:
-        # A list of the certmap, pre-shared cert, or secret names to use on the
-        # gateway. Only the first entry is used if "type" is "certmap".
-        #
-        # Certificate maps and pre-shared certificates are created
-        # outside of Kubernetes either by tenant Terraform modules (certmaps)
-        # or manually (pre-shared).
-        #
-        # Secrets can be created via Certificate resources provisioned by
-        # cert-manager.
-        names:
-          - my-certmap
-
-        # Can be "certmap", "pre-shared", or "secret". Default (and preferred)
-        # is "certmap".
-        type: certmap
-
       listeners:
         # The http listener will be created by default to handle HTTP to HTTPS
         # redirects.
@@ -189,13 +168,27 @@ gateway:
           protocol: HTTPS
           port: 443
 
-          # Configures certificate details at the listener level. This
-          # overrides global certificate configurations at the gateway level.
-          #certificates:
-          #  names:
-          #    - my-certmap
-          #  type: certmap
+      # Global certificate details for external gateways. Certificates MUST be
+      # specified if one or more listener(s) uses the HTTPS procotol.
+      tls:
+        # A list of the certmap, pre-shared cert, or secret names to use on the
+        # gateway. Only the first entry is used if "type" is "certmap".
+        #
+        # Certificate maps and pre-shared certificates are created
+        # outside of Kubernetes either by tenant Terraform modules (certmaps)
+        # or manually (pre-shared).
+        #
+        # Secrets can be created via Certificate resources provisioned by
+        # cert-manager.
+        #
+        # Note: The certs listed below will be applied to ALL listeners in this
+        # gateway.
+        certs:
+          - mozcloud-gateway-certmap
 
+        # Can be "certmap", "pre-shared", or "secret" (cert-manager). Default
+        # (and preferred) is "certmap".
+        type: certmap
 
       # Additional annotations
       #annotations: {}

--- a/mozcloud-gateway/library/.helmignore
+++ b/mozcloud-gateway/library/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.3
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: mozcloud-gateway-lib
+description: A library chart that creates gateways and supporting Gateway API resources
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: library
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+dependencies:
+  - name: mozcloud-labels-lib
+    version: 0.1.0
+    repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts
+  - name: mozcloud-service-lib
+    version: 0.2.0
+    repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-gateway/library/templates/_gateway.yaml
+++ b/mozcloud-gateway/library/templates/_gateway.yaml
@@ -1,6 +1,6 @@
 {{- define "mozcloud-gateway-lib.gateway" -}}
 {{- $gateways := include "mozcloud-gateway-lib.config.gateways" . | fromYaml }}
-{{- range $gateway := $gateways }}
+{{- range $gateway := $gateways.gateways }}
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
@@ -21,7 +21,7 @@ spec:
     - name: {{ $listener.name }}
       protocol: {{ $listener.protocol }}
       port: {{ $listener.port }}
-      {{- if $listener.certificates }}
+      {{- if and (eq $listener.protocol "HTTPS") ($listener.certificates) }}
       tls:
         mode: Terminate
         {{- if eq $listener.certificates.type "certmap" }}

--- a/mozcloud-gateway/library/templates/_gateway.yaml
+++ b/mozcloud-gateway/library/templates/_gateway.yaml
@@ -8,33 +8,48 @@ metadata:
   name: {{ $gateway.name }}
   labels:
     {{- $gateway.labels | toYaml | nindent 4 }}
-  {{- if $gateway.annotations }}
+  {{- /* Only include certmap annotations if there are >= 1 HTTPS listeners */}}
+  {{- $https_listeners := 0 }}
+  {{- range $listener := $gateway.listeners }}
+  {{- if eq (upper $listener.protocol) "HTTPS" }}
+  {{- $https_listeners = add1 $https_listeners }}
+  {{- end }}
+  {{- end }}
+  {{- if or $gateway.annotations (and (eq ($gateway.tls).type "certmap") (gt $https_listeners 0)) }}
   annotations:
+    {{- if $gateway.annotations }}
     {{- $gateway.annotations | toYaml | nindent 4 }}
+    {{- end }}
+    {{- if eq ($gateway.tls).type "certmap" }}
+    networking.gke.io/certmap: {{ $gateway.tls.certs | first }}
+    {{- end }}
   {{- end }}
 spec:
   gatewayClassName: {{ $gateway.className }}
   addresses:
-    {{- $gateway.addresses | toYaml | nindent 4 }}
+    {{- range $address := $gateway.addresses }}
+    - type: NamedAddress
+      value: {{ $address }}
+    {{- end }}
   listeners:
     {{- range $listener := $gateway.listeners }}
-    - name: {{ $listener.name }}
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: {{ $listener.name }}
       protocol: {{ $listener.protocol }}
       port: {{ $listener.port }}
-      {{- if and (eq $listener.protocol "HTTPS") ($listener.certificates) }}
+      {{- if and (eq $listener.protocol "HTTPS") (ne ($gateway.tls).type "certmap") }}
       tls:
         mode: Terminate
-        {{- if eq $listener.certificates.type "certmap" }}
-        options:
-          networking.gke.io/certificate-map: {{ $listener.certificates.names | first | quote }}
-        {{- else if eq $listener.certificates.type "pre-shared" }}
-        options:
-          networking.gke.io/pre-shared-certs: {{ join "," (uniq $listener.certificates.names | sortAlpha) | quote }}
-        {{- else if eq $listener.certificates.type "secret" }}
+        {{- if eq $gateway.tls.type "secret" }}
         certificateRefs:
-          {{- range $cert_name := $listener.certificates.names }}
+          {{- range $cert_name := $gateway.tls.certs }}
           - name: {{ $cert_name | quote }}
           {{- end }}
+        {{- else if eq $gateway.tls.type "pre-shared" }}
+        options:
+          networking.gke.io/pre-shared-certs: {{ join "," (uniq $gateway.tls.certs | sortAlpha) | quote }}
         {{- end }}
       {{- end }}
     {{- end -}}

--- a/mozcloud-gateway/library/templates/_gateway.yaml
+++ b/mozcloud-gateway/library/templates/_gateway.yaml
@@ -1,0 +1,42 @@
+{{- define "mozcloud-gateway-lib.gateway" -}}
+{{- $gateways := include "mozcloud-gateway-lib.config.gateways" . | fromYaml }}
+{{- range $gateway := $gateways }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ $gateway.name }}
+  labels:
+    {{- $gateway.labels | toYaml | nindent 4 }}
+  {{- if $gateway.annotations }}
+  annotations:
+    {{- $gateway.annotations | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ $gateway.className }}
+  addresses:
+    {{- $gateway.addresses | toYaml | nindent 4 }}
+  listeners:
+    {{- range $listener := $gateway.listeners }}
+    - name: {{ $listener.name }}
+      protocol: {{ $listener.protocol }}
+      port: {{ $listener.port }}
+      {{- if $listener.certificates }}
+      tls:
+        mode: Terminate
+        {{- if eq $listener.certificates.type "certmap" }}
+        options:
+          networking.gke.io/certificate-map: {{ $listener.certificates.names | first | quote }}
+        {{- else if eq $listener.certificates.type "pre-shared" }}
+        options:
+          networking.gke.io/pre-shared-certs: {{ join "," (uniq $listener.certificates.names | sortAlpha) | quote }}
+        {{- else if eq $listener.certificates.type "secret" }}
+        certificateRefs:
+          {{- range $cert_name := $listener.certificates.names }}
+          - name: {{ $cert_name | quote }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end -}}
+{{- end }}
+{{- end -}}

--- a/mozcloud-gateway/library/templates/_helpers.tpl
+++ b/mozcloud-gateway/library/templates/_helpers.tpl
@@ -54,7 +54,7 @@ Selector labels
 {{/*
 Template helpers
 */}}
-{{- define "mozcloud-ingress-lib.config.name" -}}
+{{- define "mozcloud-gateway-lib.config.name" -}}
 {{- $name := "" -}}
 {{- if .name -}}
   {{- $name = .name -}}
@@ -93,10 +93,11 @@ Gateway template helpers
 
 {{- define "mozcloud-gateway-lib.config.gateways" -}}
 {{- $defaults := include "mozcloud-gateway-lib.defaults.gateway.config" . | fromYaml -}}
-{{- $gateways := default (list $defaults) .gatewayConfig -}}
+{{- $gateways := default (list $defaults) (.gatewayConfig).gateways -}}
 {{- $output := list -}}
-{{- range $gateway := $gateway_config -}}
-  {{- $gateway_config := mergeOverwrite $defaults $gateway -}}
+{{- range $gateway := $gateways -}}
+  {{- $default_config := include "mozcloud-gateway-lib.defaults.gateway.config" . | fromYaml -}}
+  {{- $gateway_config := mergeOverwrite $default_config $gateway -}}
   {{- /* Use name helper function to populate name using rules hierarchy */ -}}
   {{- $params := dict "gatewayConfig" $gateway_config -}}
   {{- $name_override := default "" $.nameOverride -}}
@@ -107,16 +108,27 @@ Gateway template helpers
   {{- $_ := set $gateway_config "name" $name -}}
   {{- /* Use helper function to determine className if not defined */ -}}
   {{- if not $gateway_config.className -}}
-    {{- $class_name := (include "mozcloud-gateway-lib.config.gateway.className" | fromYaml) -}}
+    {{- $class_name := include "mozcloud-gateway-lib.config.gateway.className" $gateway_config -}}
     {{- $_ = set $gateway_config "className" $class_name -}}
   {{- end -}}
+  {{- /* Set certificate details */ -}}
+  {{- $listeners := list -}}
+  {{- range $listener := $gateway_config.listeners -}}
+    {{- $listener_certs := default (dict) $listener.certificates -}}
+    {{- $global_certs := default (dict) $gateway_config.certificates -}}
+    {{- $certificates := mergeOverwrite $global_certs $listener_certs -}}
+    {{- $_ = set $listener "certificates" $certificates -}}
+    {{- $listeners = append $listeners $listener -}}
+  {{- end -}}
+  {{- $_ = set $gateway_config "listeners" $listeners -}}
   {{- /* Generate labels */ -}}
   {{- $label_params := dict "labels" (default (dict) $gateway_config.labels) -}}
   {{- $labels := (include "mozcloud-gateway-lib.labels" (mergeOverwrite $ $label_params) | fromYaml) -}}
   {{- $_ = set $gateway_config "labels" $labels -}}
-  {{- $_ = append $output $gateway_config -}}
+  {{- $output = append $output $gateway_config -}}
 {{- end -}}
-{{ $output | toYaml }}
+{{- $gateways = dict "gateways" $output -}}
+{{ $gateways | toYaml }}
 {{- end -}}
 
 {{/*
@@ -127,6 +139,10 @@ type: external
 scope: global
 addresses:
   - mozcloud-gateway-dev-ip-v4
+certificates:
+  names:
+    - my-certmap
+  type: certmap
 listeners:
   - name: http
     protocol: HTTP
@@ -134,10 +150,6 @@ listeners:
   - name: https
     protocol: HTTPS
     port: 443
-    certificates:
-      names:
-        - my-certmap
-      type: certmap
 {{- end -}}
 
 {{- define "mozcloud-gateway-lib.defaults.gateway.classes" -}}

--- a/mozcloud-gateway/library/templates/_helpers.tpl
+++ b/mozcloud-gateway/library/templates/_helpers.tpl
@@ -111,16 +111,6 @@ Gateway template helpers
     {{- $class_name := include "mozcloud-gateway-lib.config.gateway.className" $gateway_config -}}
     {{- $_ = set $gateway_config "className" $class_name -}}
   {{- end -}}
-  {{- /* Set certificate details */ -}}
-  {{- $listeners := list -}}
-  {{- range $listener := $gateway_config.listeners -}}
-    {{- $listener_certs := default (dict) $listener.certificates -}}
-    {{- $global_certs := default (dict) $gateway_config.certificates -}}
-    {{- $certificates := mergeOverwrite $global_certs $listener_certs -}}
-    {{- $_ = set $listener "certificates" $certificates -}}
-    {{- $listeners = append $listeners $listener -}}
-  {{- end -}}
-  {{- $_ = set $gateway_config "listeners" $listeners -}}
   {{- /* Generate labels */ -}}
   {{- $label_params := dict "labels" (default (dict) $gateway_config.labels) -}}
   {{- $labels := (include "mozcloud-gateway-lib.labels" (mergeOverwrite $ $label_params) | fromYaml) -}}
@@ -139,10 +129,6 @@ type: external
 scope: global
 addresses:
   - mozcloud-gateway-dev-ip-v4
-certificates:
-  names:
-    - my-certmap
-  type: certmap
 listeners:
   - name: http
     protocol: HTTP
@@ -150,6 +136,10 @@ listeners:
   - name: https
     protocol: HTTPS
     port: 443
+tls:
+  certs:
+    - mozcloud-gateway-certmap
+  type: certmap
 {{- end -}}
 
 {{- define "mozcloud-gateway-lib.defaults.gateway.classes" -}}

--- a/mozcloud-gateway/library/templates/_helpers.tpl
+++ b/mozcloud-gateway/library/templates/_helpers.tpl
@@ -1,0 +1,156 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mozcloud-gateway-lib.name" -}}
+{{- if .nameOverride -}}
+{{- .nameOverride }}
+{{- else -}}
+mozcloud-gateway
+{{- end -}}
+{{- end -}}
+
+{{- /*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mozcloud-gateway-lib.fullname" -}}
+{{- if .fullnameOverride }}
+{{- .fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+{{- include "mozcloud-gateway-lib.name" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mozcloud-gateway-lib.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mozcloud-gateway-lib.labels" -}}
+{{- $labels := include "mozcloud-labels-lib.labels" . | fromYaml -}}
+{{- if .labels -}}
+  {{- $labels = mergeOverwrite $labels .labels -}}
+{{- end }}
+{{- $labels | toYaml }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mozcloud-gateway-lib.selectorLabels" -}}
+{{- $selector_labels := include "mozcloud-labels-lib.selectorLabels" . | fromYaml -}}
+{{- if .selectorLabels -}}
+  {{- $selector_labels = mergeOverwrite $selector_labels .selector_labels -}}
+{{- end }}
+{{- $selector_labels | toYaml }}
+{{- end }}
+
+{{/*
+Template helpers
+*/}}
+{{- define "mozcloud-ingress-lib.config.name" -}}
+{{- $name := "" -}}
+{{- if .name -}}
+  {{- $name = .name -}}
+{{- end -}}
+{{- if and (.gatewayConfig).name (not $name) -}}
+  {{- $name = .gatewayConfig.name -}}
+{{- end -}}
+{{- if and (.nameOverride) (not $name) -}}
+  {{- $name = .nameOverride -}}
+{{- end -}}
+{{- if not $name -}}
+  {{- $name = include "mozcloud-gateway-lib.fullname" $ -}}
+{{- end -}}
+{{- if .prefix -}}
+  {{- $name = printf "%s-%s" .prefix $name -}}
+{{- end -}}
+{{- if .suffixes -}}
+  {{- $suffix := join "-" .suffixes -}}
+  {{- $length := $suffix | len | add1 -}}
+  {{- $name = printf "%s-%s" ($name | trunc (sub 63 $length | int)) $suffix -}}
+{{- end -}}
+{{ $name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+Gateway template helpers
+*/}}
+{{- define "mozcloud-gateway-lib.config.gateway.className" -}}
+{{- $type := .type -}}
+{{- $scope := default "global" .scope -}}
+{{- if eq .type "internal" -}}
+  {{- $scope = "regional" -}}
+{{- end -}}
+{{- index (include "mozcloud-gateway-lib.defaults.gateway.classes" . | fromYaml) $type $scope }}
+{{- end -}}
+
+{{- define "mozcloud-gateway-lib.config.gateways" -}}
+{{- $defaults := include "mozcloud-gateway-lib.defaults.gateway.config" . | fromYaml -}}
+{{- $gateways := default (list $defaults) .gatewayConfig -}}
+{{- $output := list -}}
+{{- range $gateway := $gateway_config -}}
+  {{- $gateway_config := mergeOverwrite $defaults $gateway -}}
+  {{- /* Use name helper function to populate name using rules hierarchy */ -}}
+  {{- $params := dict "gatewayConfig" $gateway_config -}}
+  {{- $name_override := default "" $.nameOverride -}}
+  {{- if $name_override -}}
+    {{- $_ := set $params "nameOverride" $name_override -}}
+  {{- end -}}
+  {{- $name := include "mozcloud-gateway-lib.config.name" $params -}}
+  {{- $_ := set $gateway_config "name" $name -}}
+  {{- /* Use helper function to determine className if not defined */ -}}
+  {{- if not $gateway_config.className -}}
+    {{- $class_name := (include "mozcloud-gateway-lib.config.gateway.className" | fromYaml) -}}
+    {{- $_ = set $gateway_config "className" $class_name -}}
+  {{- end -}}
+  {{- /* Generate labels */ -}}
+  {{- $label_params := dict "labels" (default (dict) $gateway_config.labels) -}}
+  {{- $labels := (include "mozcloud-gateway-lib.labels" (mergeOverwrite $ $label_params) | fromYaml) -}}
+  {{- $_ = set $gateway_config "labels" $labels -}}
+  {{- $_ = append $output $gateway_config -}}
+{{- end -}}
+{{ $output | toYaml }}
+{{- end -}}
+
+{{/*
+Defaults
+*/}}
+{{- define "mozcloud-gateway-lib.defaults.gateway.config" -}}
+type: external
+scope: global
+addresses:
+  - mozcloud-gateway-dev-ip-v4
+listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+  - name: https
+    protocol: HTTPS
+    port: 443
+    certificates:
+      names:
+        - my-certmap
+      type: certmap
+{{- end -}}
+
+{{- define "mozcloud-gateway-lib.defaults.gateway.classes" -}}
+external:
+  global: gke-l7-global-external-managed
+  regional: gke-l7-regional-external-managed
+internal:
+  regional: gke-l7-rilb
+{{- end -}}
+
+{{/*
+Debug helper
+*/}}
+{{- define "mozcloud-gateway-lib.debug" -}}
+{{- . | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
+{{- end -}}

--- a/mozcloud-ingress/application/values.yaml
+++ b/mozcloud-ingress/application/values.yaml
@@ -2,6 +2,7 @@
 enabled: true
 
 # Name to be used for all resources if not specified at the resource level.
+# This should match the name of the parent Helm chart.
 #nameOverride:
 
 # Application code. This should match the `app_code` value in your tenant's

--- a/mozcloud-ingress/application/values.yaml
+++ b/mozcloud-ingress/application/values.yaml
@@ -13,7 +13,7 @@ enabled: true
 #component:
 
 # Environment. This should match the `environment` value in your tenant's
-# values.yaml file.
+# values-<env>.yaml file.
 #environment:
 
 # Global backend configuration. These values can be overridden at the host

--- a/mozcloud-ingress/library/templates/_helpers.tpl
+++ b/mozcloud-ingress/library/templates/_helpers.tpl
@@ -8,6 +8,7 @@ Expand the name of the chart.
 mozcloud-ingress
 {{- end -}}
 {{- end -}}
+
 {{- /*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).


### PR DESCRIPTION
Currently, this only builds Gateway resources.

Values have been added for all of the the upcoming features with the exception of TrafficDistributionPolicy.

This was tested successfully on the mzcld-demo tenant.

Coming soon:
- HTTPRoute support
- GatewayPolicy support
- BackendPolicy support
- Backend Service support (using mozcloud-service library chart)
- TrafficDistributionPolicy support