### PR TITLE
feat(mozcloud-gateway): add support for HTTPRoutes and services

### DIFF
--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.4
+appVersion: 0.1.5
 
 dependencies:
   - name: mozcloud-gateway-lib
-    version: 0.1.4
+    version: 0.1.5
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.3
+appVersion: 0.1.4
 
 dependencies:
   - name: mozcloud-gateway-lib
-    version: 0.1.3
+    version: 0.1.4
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-gateway/application/templates/httproute.yaml
+++ b/mozcloud-gateway/application/templates/httproute.yaml
@@ -1,2 +1,5 @@
 {{- if and .Values.enabled (.Values.httpRoute).enabled }}
+{{- $params := dict "httpRouteConfig" .Values.httpRoute "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $label_params := include "mozcloud-gateway.labelParams" .  | fromYaml }}
+{{ include "mozcloud-gateway-lib.httpRoute" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/service.yaml
+++ b/mozcloud-gateway/application/templates/service.yaml
@@ -1,2 +1,5 @@
 {{- if and .Values.enabled (.Values.httpRoute).enabled }}
+{{- $params := dict "backendConfig" (dict "backends" .Values.backends) "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $label_params := include "mozcloud-gateway.labelParams" . | fromYaml }}
+{{- include "mozcloud-gateway-lib.service" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -56,12 +56,17 @@ backendPolicy:
   # Backend service timeout period in seconds.
   #timeoutSec: 30
 
-# Defines the backend services to create and their configurations.
-backendServices:
-  - name: mozcloud-gateway
+# Defines the backend services to create, backend policies, and healthchecks.
+backends:
     # Definitions for the Kubernetes service.
-    backend:
+  - service:
+      # If disabled, a new Kubernetes will not be created.
+      #create: true
+
       port: 8080
+
+      # Name of the port to create. Default is "http".
+      #portName: http
 
       # Protocol used for service. Default is TCP. More information found
       # here:
@@ -71,11 +76,17 @@ backendServices:
       # Port name/number of pods the service should target. Default is "http".
       targetPort: http
 
+      # Annotations to use for this service.
+      #annotations: {}
+
       # Labels to use for the service.
       #labels: {}
 
       # Selector labels the service should use to match against pods.
       #selectorLabels: {}
+
+    # Set a name for the backend to use for all related components.
+    #name:
 
     # Backend policy to apply to this specific backend service. Overrides the
     # defaults from .Values.backendPolicy

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -119,7 +119,7 @@ backendServices:
 # Defines the Gateways to create and their configurations.
 gateway:
   # If disabled, Gateway resources will not be created in the K8s namespace.
-  enabled: false
+  enabled: true
 
   gateways:
     - name: mozcloud-gateway
@@ -207,29 +207,28 @@ gatewayPolicy:
 # Services.
 httpRoute:
   # If disabled, HTTPRoute resources will not be created in the K8s namespace.
-  enabled: false
+  enabled: true
 
   httpRoutes:
     - name: mozcloud-gateway
 
-      # Hostnames to match against. Hostnames are matched before any other
-      # matches (path, headers) occur.
-      hostnames:
-        - chart.example.local
-        - chart2.example.local
-
-      # If enabled, create an HTTP-to-HTTPS redirect.
-      #httpToHttpsRedirect: true
-
       # Define parent Gateway resource the HTTPRoute should attach to.
-      parentRefs:
-        - kind: Gateway
-          name: mozcloud-gateway
+      gatewayRefs:
+        - name: mozcloud-gateway
 
           # This refers to the name of the listener to use on the gateway. See
           # gateway.gateways[].listeners[].name for Gateways created using this
           # chart.
           section: https
+
+      # Hostnames to match against. Hostnames are matched before any other
+      # matches (path, headers) occur.
+      hostnames:
+        - chart.example.local
+
+      # If enabled, create an HTTP-to-HTTPS redirect. This is enabled by
+      # default.
+      #httpToHttpsRedirect: true
 
       rules:
           # A list of the backend services to receive traffic.
@@ -262,26 +261,38 @@ httpRoute:
               #weight:
 
           # Configures paths or headers to match against when sending traffic to
-          # abackend service. Matches are independent, meaning the rule will
+          # a backend service. Matches are independent, meaning the rule will
           # be matched if any matches below are true.
           #
           # If no matches are specified, all traffic will be sent to the "/"
           # path on the backend service pods by default.
           #matches:
           #  # Matches path "/path"
-          #  - path: /path
+          #  - path:
+          #      value: /path
+          #
+          #      # How to match against the path. Options are "Exact",
+          #      # "PathPrefix", and "RegularExpression". Default is
+          #      # "PathPrefix".
+          #      #type: PathPrefix
+          #
           #
           #  # Header match. Contains a list of headers against which to match.
           #  - headers:
-          #      - X-My-Header
+          #      - name: X-My-Header
+          #        value: header-value-1
           #      - X-Another-Header
+          #        value: header-value-2
           #
-          #  # If a path and header specified in an entry, the rule will be
+          #  # If a path and header are specified in an entry, the rule will be
           #  # matched if BOTH the path and headers match.
-          #  - path: /foo
+          #  - path:
+          #      value: /foo
           #    headers:
-          #      - X-My-Header
+          #      - name: X-My-Header
+          #        value: header-value-1
           #      - X-Another-Header
+          #        value: header-value-1
 
           # Configures a path redirect. Overridden by "rewrite".
           #
@@ -323,6 +334,9 @@ httpRoute:
           #  #  # "matches" section with the one specified above.
           #  #  # Example: /path/to/endpoint -> /newpath/to/endpoint
           #  #  type: ReplaceFullPath
+
+      # Custom labels. Additional labels are generated in templates/_helpers.tpl.
+      #labels: {}
 
 # TODO: Create default traffic distribution policy, add support in backend
 # Defines how traffic is distributed across endpoints within a backend. This

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-gateway/library/templates/_helpers.tpl
+++ b/mozcloud-gateway/library/templates/_helpers.tpl
@@ -46,7 +46,7 @@ Selector labels
 {{- define "mozcloud-gateway-lib.selectorLabels" -}}
 {{- $selector_labels := include "mozcloud-labels-lib.selectorLabels" . | fromYaml -}}
 {{- if .selectorLabels -}}
-  {{- $selector_labels = mergeOverwrite $selector_labels .selector_labels -}}
+  {{- $selector_labels = mergeOverwrite $selector_labels .selectorLabels -}}
 {{- end }}
 {{- $selector_labels | toYaml }}
 {{- end }}
@@ -116,7 +116,7 @@ Gateway template helpers
   {{- end -}}
   {{- /* Generate labels */ -}}
   {{- $label_params := dict "labels" (default (dict) $gateway_config.labels) -}}
-  {{- $labels := (include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml) -}}
+  {{- $labels := include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml -}}
   {{- $_ = set $gateway_config "labels" $labels -}}
   {{- $output = append $output $gateway_config -}}
 {{- end -}}
@@ -144,13 +144,18 @@ HTTPRoute template helpers
   {{- $_ := set $http_route_config "name" $name -}}
   {{- /* Generate labels */ -}}
   {{- $label_params := dict "labels" (default (dict) $http_route_config.labels) -}}
-  {{- $labels := (include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml) -}}
+  {{- $labels := include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml -}}
   {{- $_ = set $http_route_config "labels" $labels -}}
-  {{- /* Set defaults for matches, redirects and rewrites, if defined */ -}}
+  {{- /* 
+  Set defaults for matches, redirects and rewrites, if defined.
+  We will need to recreate the rule list as some items in child lists have
+  optional values and defaults.
+  */ -}}
   {{- $rules := list -}}
   {{- range $rule := $http_route_config.rules -}}
     {{- $rule_defaults := include "mozcloud-gateway-lib.defaults.httpRoute.config" . | fromYaml -}}
     {{- $rule_config := mergeOverwrite ($rule_defaults.rules | first) ($rule | deepCopy) -}}
+    {{- /* Matches */ -}}
     {{- if $rule_config.matches -}}
       {{- $matches := list -}}
       {{- range $match := $rule_config.matches -}}
@@ -163,10 +168,12 @@ HTTPRoute template helpers
       {{- end -}}
       {{- $_ := set $rule_config "matches" $matches -}}
     {{- end -}}
+    {{- /* Redirects */ -}}
     {{- if $rule_config.redirect -}}
       {{- $redirect_config := mergeOverwrite $rule_defaults.redirect $rule_config.redirect -}}
       {{- $_ := set $rule_config "redirect" $redirect_config -}}
     {{- end -}}
+    {{- /* Rewrites */ -}}
     {{- if $rule_config.rewrite -}}
       {{- $rewrite_config := $rule_config.rewrite | deepCopy -}}
       {{- if $rule_config.rewrite.path -}}
@@ -182,6 +189,65 @@ HTTPRoute template helpers
 {{- end -}}
 {{- $http_routes = dict "httpRoutes" $output -}}
 {{ $http_routes | toYaml }}
+{{- end -}}
+
+{{/*
+Service template helpers
+*/}}
+{{- define "mozcloud-gateway-lib.config.service" -}}
+{{- $name_override := default "" .nameOverride -}}
+{{- $backends := default (list) (.backendConfig).backends -}}
+{{- $output := list -}}
+{{- range $backend := $backends -}}
+  {{- $defaults := include "mozcloud-gateway-lib.defaults.service.config" . | fromYaml -}}
+  {{- $service_config := dict -}}
+  {{- $backend_service := $backend.service | deepCopy -}}
+  {{- /* Only create the service if "create" is not "false" */ -}}
+  {{- $create_service := (include "mozcloud-gateway-lib.defaults.service.config" . | fromYaml).create -}}
+  {{- if hasKey $backend_service "create" -}}
+    {{- $create_service = $backend_service.create -}}
+  {{- end -}}
+  {{- $_ := set $service_config "create" $create_service -}}
+  {{- /* Use name helper function to populate name using rules hierarchy */ -}}
+  {{- $params := dict -}}
+  {{- if $backend.name -}}
+    {{- $_ := set $params "name" $backend.name -}}
+  {{- end -}}
+  {{- if $name_override -}}
+    {{- $_ := set $params "nameOverride" $name_override -}}
+  {{- end -}}
+  {{- $name := include "mozcloud-gateway-lib.config.name" $params -}}
+  {{- $_ = set $service_config "fullnameOverride" $name -}}
+  {{- /* Include annotations, if specified */ -}}
+  {{- if $backend_service.annotations -}}
+    {{- $_ := set $service_config "annotations" $backend_service.annotations -}}
+  {{- end -}}
+  {{- /* Generate labels */ -}}
+  {{- $label_params := dict "labels" (default (dict) $backend_service.labels) -}}
+  {{- $labels := include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml -}}
+  {{- $_ = set $service_config "labels" $labels -}}
+  {{- /* Generate selectorLabels */ -}}
+  {{- $selector_label_params := dict "selectorLabels" (default (dict) $backend_service.selectorLabels) -}}
+  {{- $selector_labels := include "mozcloud-gateway-lib.selectorLabels" (mergeOverwrite ($ | deepCopy) $selector_label_params) | fromYaml -}}
+  {{- $_ = set $service_config "selectorLabels" $selector_labels -}}
+  {{- /* Service config */ -}}
+  {{- $config := include "mozcloud-gateway-lib.config.service.config" $backend_service | fromYaml -}}
+  {{- $_ = set $service_config "config" $config -}}
+  {{- $output = append $output $service_config -}}
+{{- end -}}
+{{- $services := dict "services" $output -}}
+{{ $services | toYaml }}
+{{- end -}}
+
+
+{{- define "mozcloud-gateway-lib.config.service.config" -}}
+{{- $defaults := (include "mozcloud-gateway-lib.defaults.service.config" . | fromYaml) -}}
+ports:
+  - port: {{ default $defaults.port .port }}
+    targetPort: {{ default $defaults.targetPort .targetPort }}
+    protocol: {{ default $defaults.protocol .protocol }}
+    name: {{ default $defaults.portName .portName }}
+type: {{ $defaults.type }}
 {{- end -}}
 
 {{/*
@@ -215,7 +281,7 @@ internal:
 
 {{- define "mozcloud-gateway-lib.defaults.httpRoute.config" -}}
 gatewayRefs:
-  - name: mozcloud-gateway
+  - name: {{ include "mozcloud-gateway-lib.config.name" . }}
     section: https
 hostnames:
   - chart.example.local
@@ -233,6 +299,14 @@ rules:
   - backendRefs:
       - name: {{ include "mozcloud-gateway-lib.config.name" . }}
         port: 8080
+{{- end -}}
+
+{{- define "mozcloud-gateway-lib.defaults.service.config" -}}
+create: true
+port: 8080
+portName: http
+protocol: TCP
+targetPort: http
 {{- end -}}
 
 {{/*

--- a/mozcloud-gateway/library/templates/_helpers.tpl
+++ b/mozcloud-gateway/library/templates/_helpers.tpl
@@ -59,6 +59,9 @@ Template helpers
 {{- if .name -}}
   {{- $name = .name -}}
 {{- end -}}
+{{- if and (.httpRouteConfig).name (not $name) -}}
+  {{- $name = .httpRouteConfig.name -}}
+{{- end -}}
 {{- if and (.gatewayConfig).name (not $name) -}}
   {{- $name = .gatewayConfig.name -}}
 {{- end -}}
@@ -96,8 +99,8 @@ Gateway template helpers
 {{- $gateways := default (list $defaults) (.gatewayConfig).gateways -}}
 {{- $output := list -}}
 {{- range $gateway := $gateways -}}
-  {{- $default_config := include "mozcloud-gateway-lib.defaults.gateway.config" . | fromYaml -}}
-  {{- $gateway_config := mergeOverwrite $default_config $gateway -}}
+  {{- $gateway_defaults := include "mozcloud-gateway-lib.defaults.gateway.config" . | fromYaml -}}
+  {{- $gateway_config := mergeOverwrite $gateway_defaults ($gateway | deepCopy) -}}
   {{- /* Use name helper function to populate name using rules hierarchy */ -}}
   {{- $params := dict "gatewayConfig" $gateway_config -}}
   {{- $name_override := default "" $.nameOverride -}}
@@ -113,12 +116,72 @@ Gateway template helpers
   {{- end -}}
   {{- /* Generate labels */ -}}
   {{- $label_params := dict "labels" (default (dict) $gateway_config.labels) -}}
-  {{- $labels := (include "mozcloud-gateway-lib.labels" (mergeOverwrite $ $label_params) | fromYaml) -}}
+  {{- $labels := (include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml) -}}
   {{- $_ = set $gateway_config "labels" $labels -}}
   {{- $output = append $output $gateway_config -}}
 {{- end -}}
 {{- $gateways = dict "gateways" $output -}}
 {{ $gateways | toYaml }}
+{{- end -}}
+
+{{/*
+HTTPRoute template helpers
+*/}}
+{{- define "mozcloud-gateway-lib.config.httpRoutes" -}}
+{{- $defaults := include "mozcloud-gateway-lib.defaults.httpRoute.config" . | fromYaml -}}
+{{- $http_routes := default (list $defaults) (.httpRouteConfig).httpRoutes }}
+{{- $output := list -}}
+{{- range $http_route := $http_routes -}}
+  {{- $http_route_defaults := include "mozcloud-gateway-lib.defaults.httpRoute.config" . | fromYaml -}}
+  {{- $http_route_config := mergeOverwrite $http_route_defaults ($http_route | deepCopy) -}}
+  {{- /* Use name helper function to populate name using rules hierarchy */ -}}
+  {{- $params := dict "httpRouteConfig" $http_route_config -}}
+  {{- $name_override := default "" $.nameOverride -}}
+  {{- if $name_override -}}
+    {{- $_ := set $params "nameOverride" $name_override -}}
+  {{- end -}}
+  {{- $name := include "mozcloud-gateway-lib.config.name" $params -}}
+  {{- $_ := set $http_route_config "name" $name -}}
+  {{- /* Generate labels */ -}}
+  {{- $label_params := dict "labels" (default (dict) $http_route_config.labels) -}}
+  {{- $labels := (include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml) -}}
+  {{- $_ = set $http_route_config "labels" $labels -}}
+  {{- /* Set defaults for matches, redirects and rewrites, if defined */ -}}
+  {{- $rules := list -}}
+  {{- range $rule := $http_route_config.rules -}}
+    {{- $rule_defaults := include "mozcloud-gateway-lib.defaults.httpRoute.config" . | fromYaml -}}
+    {{- $rule_config := mergeOverwrite ($rule_defaults.rules | first) ($rule | deepCopy) -}}
+    {{- if $rule_config.matches -}}
+      {{- $matches := list -}}
+      {{- range $match := $rule_config.matches -}}
+        {{- $match_config := $match | deepCopy -}}
+        {{- if $match.path -}}
+          {{- $type := default ($rule_defaults.match.path.type | deepCopy) $match_config.path.type -}}
+          {{- $_ := set $match_config.path "type" $type -}}
+        {{- end -}}
+        {{- $matches = append $matches $match_config -}}
+      {{- end -}}
+      {{- $_ := set $rule_config "matches" $matches -}}
+    {{- end -}}
+    {{- if $rule_config.redirect -}}
+      {{- $redirect_config := mergeOverwrite $rule_defaults.redirect $rule_config.redirect -}}
+      {{- $_ := set $rule_config "redirect" $redirect_config -}}
+    {{- end -}}
+    {{- if $rule_config.rewrite -}}
+      {{- $rewrite_config := $rule_config.rewrite | deepCopy -}}
+      {{- if $rule_config.rewrite.path -}}
+        {{- $rewrite_path_type := default $rule_defaults.rewrite.path.type $rule_config.rewrite.path.type -}}
+        {{- $_ := set $rewrite_config.path "type" $rewrite_path_type -}}
+      {{- end -}}
+      {{- $_ := set $rule_config "rewrite" $rewrite_config -}}
+    {{- end -}}
+    {{- $rules = append $rules $rule_config -}}
+  {{- end -}}
+  {{- $_ = set $http_route_config "rules" $rules -}}
+  {{- $output = append $output $http_route_config -}}
+{{- end -}}
+{{- $http_routes = dict "httpRoutes" $output -}}
+{{ $http_routes | toYaml }}
 {{- end -}}
 
 {{/*
@@ -148,6 +211,28 @@ external:
   regional: gke-l7-regional-external-managed
 internal:
   regional: gke-l7-rilb
+{{- end -}}
+
+{{- define "mozcloud-gateway-lib.defaults.httpRoute.config" -}}
+gatewayRefs:
+  - name: mozcloud-gateway
+    section: https
+hostnames:
+  - chart.example.local
+httpToHttpsRedirect: true
+match:
+  path:
+    type: PathPrefix
+redirect:
+  statusCode: 302
+  type: ReplaceFullPath
+rewrite:
+  path:
+    type: ReplaceFullPath
+rules:
+  - backendRefs:
+      - name: {{ include "mozcloud-gateway-lib.config.name" . }}
+        port: 8080
 {{- end -}}
 
 {{/*

--- a/mozcloud-gateway/library/templates/_httproute.yaml
+++ b/mozcloud-gateway/library/templates/_httproute.yaml
@@ -95,7 +95,7 @@ spec:
     {{- range $gateway_ref := $http_route.gatewayRefs }}
     - kind: Gateway
       name: {{ $gateway_ref.name }}
-      sectionName: {{ $gateway_ref.section }}
+      sectionName: http
     {{- end }}
   hostnames:
     {{- range $hostname := $http_route.hostnames }}

--- a/mozcloud-gateway/library/templates/_httproute.yaml
+++ b/mozcloud-gateway/library/templates/_httproute.yaml
@@ -1,0 +1,111 @@
+{{- define "mozcloud-gateway-lib.httpRoute" -}}
+{{- $http_routes := include "mozcloud-gateway-lib.config.httpRoutes" . | fromYaml }}
+{{- range $http_route := $http_routes.httpRoutes }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: {{ $http_route.name }}
+  labels:
+    {{- $http_route.labels | toYaml | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range $gateway_ref := $http_route.gatewayRefs }}
+    - kind: Gateway
+      name: {{ $gateway_ref.name }}
+      sectionName: {{ $gateway_ref.section }}
+    {{- end }}
+  hostnames:
+    {{- range $hostname := $http_route.hostnames }}
+    - {{ $hostname }}
+    {{- end }}
+  rules:
+    {{- range $rule := $http_route.rules }}
+    - backendRefs:
+      {{- range $backend_ref := $rule.backendRefs }}
+      - name: {{ $backend_ref.name }}
+        port: {{ $backend_ref.port }}
+        {{- if $backend_ref.weight }}
+        weight: {{ $backend_ref.weight }}
+        {{- end }}
+      {{- end }}
+      {{- if $rule.matches }}
+      matches:
+        {{- range $match := $rule.matches }}
+        {{- if and $match.path $match.headers }}
+        - path:
+            type: {{ $match.path.type }}
+            value: {{ $match.path.value }}
+          headers:
+            {{- range $header := $match.headers }}
+            - name: {{ $header.name }}
+              value: {{ $header.value }}
+            {{- end }}
+        {{- else if $match.path }}
+        - path:
+            type: {{ $match.path.type }}
+            value: {{ $match.path.value }}
+        {{- else if $match.headers }}
+        - headers:
+            {{- range $header := $match.headers }}
+            - name: {{ $header.name }}
+              value: {{ $header.value }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- if $rule.rewrite }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: {{ $rule.rewrite.hostname }}
+            {{- if $rule.rewrite.path }}
+            path:
+              type: {{ $rule.rewrite.path.type }}
+              {{- if eq $rule.rewrite.path.type "ReplaceFullPath" }}
+              replaceFullPath: {{ $rule.rewrite.path.name }}
+              {{- else if eq $rule.rewrite.path.type "ReplacePrefixMatch" }}
+              replacePrefixMatch: {{ $rule.rewrite.path.name }}
+              {{- end }}
+            {{- end }}
+      {{- else if $rule.redirect }}
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: {{ $rule.redirect.type }}
+              {{- if eq $rule.redirect.type "ReplaceFullPath" }}
+              replaceFullPath: {{ $rule.redirect.path }}
+              {{- else if eq $rule.redirect.type "ReplacePrefixMatch" }}
+              replacePrefixMatch: {{ $rule.redirect.path }}
+              {{- end }}
+              statusCode: {{ $rule.redirect.statusCode }}
+      {{- end }}
+    {{- end }}
+{{- if $http_route.httpToHttpsRedirect }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: {{ $http_route.name }}-http-redirect
+  labels:
+    {{- $http_route.labels | toYaml | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range $gateway_ref := $http_route.gatewayRefs }}
+    - kind: Gateway
+      name: {{ $gateway_ref.name }}
+      sectionName: {{ $gateway_ref.section }}
+    {{- end }}
+  hostnames:
+    {{- range $hostname := $http_route.hostnames }}
+    - {{ $hostname }}
+    {{- end }}
+  rules:
+    - filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/mozcloud-gateway/library/templates/_service.yaml
+++ b/mozcloud-gateway/library/templates/_service.yaml
@@ -1,0 +1,11 @@
+{{- define "mozcloud-gateway-lib.service" -}}
+{{- $service_config := include "mozcloud-gateway-lib.config.service" . | fromYaml }}
+{{- /* Prevent the creation of duplicate services */}}
+{{- $services := list }}
+{{- range $service := $service_config.services }}
+{{- if and (not (has $service.fullNameOverride $services)) $service.create }}
+{{- include "mozcloud-service-lib.service" $service }}
+{{- $services = append $services $service.fullNameOverride }}
+{{- end }}
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
This adds the HTTPRoute and Service resources necessary to route traffic from Gateways to Pods. At this point, users of this chart should be able to stand up functional Gateways.

Coming up next:
- Backend Policies
- Healthcheck Policies