### PR TITLE
feat(mozcloud-gateway): add support for all the policy resources

### DIFF
--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.0
+appVersion: 0.2.1
 
 dependencies:
   - name: mozcloud-gateway-lib
-    version: 0.2.0
+    version: 0.2.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.1
+appVersion: 0.2.2
 
 dependencies:
   - name: mozcloud-gateway-lib
-    version: 0.2.1
+    version: 0.2.2
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.5
+appVersion: 0.2.0
 
 dependencies:
   - name: mozcloud-gateway-lib
-    version: 0.1.5
+    version: 0.2.0
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-gateway/application/templates/backendpolicy.yaml
+++ b/mozcloud-gateway/application/templates/backendpolicy.yaml
@@ -1,2 +1,5 @@
 {{- if and .Values.enabled (.Values.httpRoute).enabled }}
+{{- $params := dict "backendConfig" (dict "backends" .Values.backends) "backendPolicyConfig" .Values.backendPolicy "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $label_params := include "mozcloud-gateway.labelParams" . | fromYaml }}
+{{- include "mozcloud-gateway-lib.backendPolicy" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/gatewaypolicy.yaml
+++ b/mozcloud-gateway/application/templates/gatewaypolicy.yaml
@@ -1,2 +1,5 @@
 {{- if and .Values.enabled (.Values.gateway).enabled }}
+{{- $params := dict "gatewayConfig" .Values.gateway "gatewayPolicyConfig" .Values.gatewayPolicy "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $label_params := include "mozcloud-gateway.labelParams" .  | fromYaml }}
+{{ include "mozcloud-gateway-lib.gatewayPolicy" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/healthcheckpolicy.yaml
+++ b/mozcloud-gateway/application/templates/healthcheckpolicy.yaml
@@ -1,0 +1,5 @@
+{{- if and .Values.enabled (.Values.httpRoute).enabled }}
+{{- $params := dict "backendConfig" (dict "backends" .Values.backends) "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $label_params := include "mozcloud-gateway.labelParams" . | fromYaml }}
+{{- include "mozcloud-gateway-lib.healthCheckPolicy" (mergeOverwrite $params $label_params) }}
+{{- end }}

--- a/mozcloud-gateway/application/templates/httpcheckpolicy.yaml
+++ b/mozcloud-gateway/application/templates/httpcheckpolicy.yaml
@@ -1,2 +1,0 @@
-{{- if and .Values.enabled (.Values.httpRoute).enabled }}
-{{- end }}

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -40,7 +40,7 @@ backendPolicy:
 
   # Configures HTTP access logging.
   logging:
-    enable: true
+    enabled: true
 
     # Ranges from 0.0 (0%) to 1.0 (100%).
     sampleRate: 0.1
@@ -104,9 +104,9 @@ backends:
       # "/__lbheartbeat__".
       path: /__lbheartbeat__
 
-      # The protocol to use for health checks. Options are "http" or "tcp".
-      # Default is "http".
-      protocol: http
+      # The protocol to use for health checks. Options are "HTTP" or "TCP".
+      # Default is "HTTP".
+      protocol: HTTP
 
       # The port to use for the health check, if different from the service
       # port. This port must be specified as a number, not a named port.
@@ -126,6 +126,10 @@ backends:
       # Number of sequential connection attempts that must succeed for a backend
       # to be considered unhealthy.
       #unhealthyThreshold:
+
+    # Labels for the backend resources. Overridden for services by
+    # "service.labels".
+    #labels: {}
 
 # Defines the Gateways to create and their configurations.
 gateway:

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -42,8 +42,9 @@ backendPolicy:
   logging:
     enabled: true
 
-    # Ranges from 0.0 (0%) to 1.0 (100%).
-    sampleRate: 0.1
+    # Ranges from 0 (0%) to 1,000,000 (100%). GCP divides this number by
+    # 1,000,000.
+    sampleRate: 100000
 
   #sessionAffinity:
   #  # Options: CLIENT_IP, GENERATED_COOKIE, NONE

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -44,6 +44,7 @@ backendPolicy:
 
     # Ranges from 0 (0%) to 1,000,000 (100%). GCP divides this number by
     # 1,000,000.
+    # Default is 100,000 (10%). 
     sampleRate: 100000
 
   #sessionAffinity:

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-gateway/library/templates/_backendpolicy.yaml
+++ b/mozcloud-gateway/library/templates/_backendpolicy.yaml
@@ -1,0 +1,19 @@
+{{- define "mozcloud-gateway-lib.backendPolicy" -}}
+{{- $backend_policies := include "mozcloud-gateway-lib.config.backendPolicies" . | fromYaml }}
+{{- range $backend_policy := $backend_policies.backendPolicies }}
+---
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: {{ $backend_policy.name }}
+  labels:
+    {{- $backend_policy.labels | toYaml | nindent 4 }}
+spec:
+  default:
+    {{- $backend_policy.config | toYaml | nindent 4 }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $backend_policy.targetService }}
+{{- end }}
+{{- end -}}

--- a/mozcloud-gateway/library/templates/_backendpolicy.yaml
+++ b/mozcloud-gateway/library/templates/_backendpolicy.yaml
@@ -10,7 +10,30 @@ metadata:
     {{- $backend_policy.labels | toYaml | nindent 4 }}
 spec:
   default:
-    {{- $backend_policy.config | toYaml | nindent 4 }}
+    {{- $config := $backend_policy.config }}
+    {{- if ($config.connectionDraining).drainingTimeoutSec }}
+    connectionDraining:
+      drainingTimeoutSec: {{ $config.connectionDraining.drainingTimeoutSec }}
+    {{- end }}
+    {{- if $config.iap }}
+    iap:
+      enabled: {{ $config.iap.enabled }}
+      oauth2ClientId: {{ $config.iap.oauth2ClientId }}
+      oauth2ClientSecret: {{ $config.iap.oauth2ClientSecret }}
+    {{- end }}
+    logging:
+      enabled: {{ $config.logging.enabled }}
+      sampleRate: {{ $config.logging.sampleRate }}
+    {{- if $config.sessionAffinity }}
+    sessionAffinity:
+      type: {{ $config.sessionAffinity.type }}
+      {{- if $config.sessionAffinity.cookieTtlSec }}
+      cookieTtlSec: {{ $config.sessionAffinity.cookieTtlSec }}
+      {{- end }}
+    {{- end }}
+    {{- if $config.timeoutSec }}
+    timeoutSec: {{ $config.timeoutSec }}
+    {{- end }}
   targetRef:
     group: ""
     kind: Service

--- a/mozcloud-gateway/library/templates/_gatewaypolicy.yaml
+++ b/mozcloud-gateway/library/templates/_gatewaypolicy.yaml
@@ -1,0 +1,19 @@
+{{- define "mozcloud-gateway-lib.gatewayPolicy" -}}
+{{- $gateway_policies := include "mozcloud-gateway-lib.config.gatewayPolicies" . | fromYaml }}
+{{- range $gateway_policy := $gateway_policies.gatewayPolicies }}
+---
+apiVersion: networking.gke.io/v1
+kind: GCPGatewayPolicy
+metadata:
+  name: {{ $gateway_policy.name }}
+  labels:
+    {{- $gateway_policy.labels | toYaml | nindent 4 }}
+spec:
+  default:
+    {{- $gateway_policy.config | toYaml | nindent 4 }}
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ $gateway_policy.gatewayName }}
+{{- end }}
+{{- end -}}

--- a/mozcloud-gateway/library/templates/_healthcheckpolicy.yaml
+++ b/mozcloud-gateway/library/templates/_healthcheckpolicy.yaml
@@ -1,0 +1,38 @@
+{{- define "mozcloud-gateway-lib.healthCheckPolicy" -}}
+{{- $health_check_policies := include "mozcloud-gateway-lib.config.healthCheckPolicies" . | fromYaml }}
+{{- range $health_check_policy := $health_check_policies.healthCheckPolicies }}
+{{- $config := $health_check_policy.config }}
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ $health_check_policy.name }}
+  labels:
+    {{- $health_check_policy.labels | toYaml | nindent 4 }}
+spec:
+  default:
+    {{- if $config.checkIntervalSec }}
+    checkIntervalSec: {{ $config.checkIntervalSec }}
+    {{- end }}
+    {{- if $config.timeoutSec }}
+    timeoutSec: {{ $config.timeoutSec }}
+    {{- end }}
+    {{- if $config.healthyThreshold }}
+    healthyThreshold: {{ $config.healthyThreshold }}
+    {{- end }}
+    {{- if $config.unhealthyThreshold }}
+    unhealthyThreshold: {{ $config.unhealthyThreshold }}
+    {{- end }}
+    config:
+      type: {{ $config.protocol }}
+      {{ $config.protocolProperty }}:
+        path: {{ $config.path }}
+        {{- if $config.port }}
+        port: {{ $config.port }}
+        {{- end }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $health_check_policy.targetService }}
+{{- end }}
+{{- end -}}

--- a/mozcloud-gateway/library/templates/_healthcheckpolicy.yaml
+++ b/mozcloud-gateway/library/templates/_healthcheckpolicy.yaml
@@ -26,10 +26,10 @@ spec:
     config:
       type: {{ $config.protocol }}
       {{ $config.protocolProperty }}:
-        path: {{ $config.path }}
         {{- if $config.port }}
         port: {{ $config.port }}
         {{- end }}
+        requestPath: {{ $config.path }}
   targetRef:
     group: ""
     kind: Service

--- a/mozcloud-gateway/library/templates/_helpers.tpl
+++ b/mozcloud-gateway/library/templates/_helpers.tpl
@@ -380,7 +380,7 @@ Defaults
 {{- define "mozcloud-gateway-lib.defaults.backendPolicy.config" -}}
 logging:
   enabled: true
-  sampleRate: 0.1
+  sampleRate: 100000
 {{- end -}}
 
 {{- define "mozcloud-gateway-lib.defaults.gateway.config" -}}


### PR DESCRIPTION
This adds support for the following resource types:

- GCPBackendPolicy
- GCPGatewayPolicy
- HealthCheckPolicy

With this, the Gateway chart should be ready to test on a tenant.