### PR TITLE
feat(mozcloud-workload-core): add support for cm, es, sa resources

### DIFF
--- a/mozcloud-workload-core/library/Chart.yaml
+++ b/mozcloud-workload-core/library/Chart.yaml
@@ -15,4 +15,4 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1

--- a/mozcloud-workload-core/library/Chart.yaml
+++ b/mozcloud-workload-core/library/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: mozcloud-workload-core-lib
+description: A library chart that creates core components needed for MozCloud workloads
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: library
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0

--- a/mozcloud-workload-core/library/templates/_configmap.yaml
+++ b/mozcloud-workload-core/library/templates/_configmap.yaml
@@ -1,0 +1,20 @@
+{{- define "mozcloud-workload-core-lib.configMap" -}}
+{{- if .configMaps }}
+{{- $config_maps := include "mozcloud-workload-core-lib.config.configMaps" . | fromYaml }}
+{{- range $config_map := $config_maps.configMaps }}
+{{- if gt (keys $config_map.data | len) 0 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $config_map.name }}
+  labels:
+    {{- $config_map.labels | toYaml | nindent 4 }}
+data:
+  {{- range $key, $value := $config_map.data }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/mozcloud-workload-core/library/templates/_externalsecret.yaml
+++ b/mozcloud-workload-core/library/templates/_externalsecret.yaml
@@ -1,0 +1,26 @@
+{{- define "mozcloud-workload-core-lib.externalSecret" -}}
+{{- if .externalSecrets }}
+{{- $external_secrets := include "mozcloud-workload-core-lib.config.externalSecrets" . | fromYaml }}
+{{- range $external_secret := $external_secrets.externalSecrets }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $external_secret.name }}
+  labels:
+    {{- $external_secret.labels | toYaml | nindent 4 }}
+spec:
+  refreshInterval: {{ $external_secret.refreshInterval }}
+  secretStoreRef:
+    kind: SecretStore
+    name: secret-store
+  target:
+    name: {{ $external_secret.target }}
+    creationPolicy: owner
+  dataFrom:
+    - extract:
+        key: {{ $external_secret.gsm.secret }}
+        version: {{ $external_secret.gsm.version }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/mozcloud-workload-core/library/templates/_externalsecret.yaml
+++ b/mozcloud-workload-core/library/templates/_externalsecret.yaml
@@ -16,11 +16,11 @@ spec:
     name: secret-store
   target:
     name: {{ $external_secret.target }}
-    creationPolicy: owner
+    creationPolicy: Owner
   dataFrom:
     - extract:
         key: {{ $external_secret.gsm.secret }}
-        version: {{ $external_secret.gsm.version }}
+        version: {{ $external_secret.gsm.version | quote }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/mozcloud-workload-core/library/templates/_helpers.tpl
+++ b/mozcloud-workload-core/library/templates/_helpers.tpl
@@ -108,7 +108,7 @@ ConfigMap template helpers
   {{- $params := dict "config" $config_map_config "context" ($ | deepCopy) "labels" $labels -}}
   {{- $common := include "mozcloud-workload-core-lib.config.common" $params | fromYaml -}}
   {{- $config_map_config = mergeOverwrite $config_map_config $common -}}
-  {{- /* Create configMaps[].data if it doesn't exist */ -}}
+  {{- /* Create configMaps[].data if it does not exist */ -}}
   {{- $config_map_data := default (dict) $config_map_config.data -}}
   {{- $_ := set $config_map_config "data" $config_map_data -}}
   {{- $output = append $output $config_map_config -}}

--- a/mozcloud-workload-core/library/templates/_helpers.tpl
+++ b/mozcloud-workload-core/library/templates/_helpers.tpl
@@ -1,0 +1,207 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mozcloud-workload-core-lib.name" -}}
+{{- if .nameOverride -}}
+{{- .nameOverride }}
+{{- else -}}
+mozcloud-workload-core
+{{- end -}}
+{{- end -}}
+
+{{- /*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mozcloud-workload-core-lib.fullname" -}}
+{{- if .fullnameOverride }}
+{{- .fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+{{- include "mozcloud-workload-core-lib.name" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mozcloud-workload-core-lib.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mozcloud-workload-core-lib.labels" -}}
+{{- $labels := include "mozcloud-labels-lib.labels" . | fromYaml -}}
+{{- if .labels -}}
+  {{- $labels = mergeOverwrite $labels .labels -}}
+{{- end }}
+{{- $labels | toYaml }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mozcloud-workload-core-lib.selectorLabels" -}}
+{{- $selector_labels := include "mozcloud-labels-lib.selectorLabels" . | fromYaml -}}
+{{- if .selectorLabels -}}
+  {{- $selector_labels = mergeOverwrite $selector_labels .selectorLabels -}}
+{{- end }}
+{{- $selector_labels | toYaml }}
+{{- end }}
+
+{{/*
+Template helpers
+*/}}
+{{- define "mozcloud-workload-core-lib.config.common" -}}
+{{- $name_override := default "" .nameOverride -}}
+{{- $output := dict -}}
+{{- /* Use name helper function to populate name using rules hierarchy */ -}}
+{{- $config := .config -}}
+{{- if $name_override -}}
+  {{- $_ := set $config "nameOverride" $name_override -}}
+{{- end -}}
+{{- $name := include "mozcloud-workload-core-lib.config.name" $config -}}
+{{- $_ := set $output "name" $name -}}
+{{- /* Generate labels */ -}}
+{{- $label_params := mergeOverwrite .context (dict "labels" .labels) -}}
+{{- $labels := include "mozcloud-workload-core-lib.labels" $label_params | fromYaml -}}
+{{- $_ = set $output "labels" $labels -}}
+{{- /* Return output */ -}}
+{{ $output | toYaml }}
+{{- end -}}
+
+{{- define "mozcloud-workload-core-lib.config.name" -}}
+{{- $name := "" -}}
+{{- if .name -}}
+  {{- $name = .name -}}
+{{- end -}}
+{{- if and (.nameOverride) (not $name) -}}
+  {{- $name = .nameOverride -}}
+{{- end -}}
+{{- if not $name -}}
+  {{- $name = include "mozcloud-workload-core-lib.fullname" $ -}}
+{{- end -}}
+{{- if .prefix -}}
+  {{- $name = printf "%s-%s" .prefix $name -}}
+{{- end -}}
+{{- if .suffixes -}}
+  {{- $suffix := join "-" .suffixes -}}
+  {{- $length := $suffix | len | add1 -}}
+  {{- $name = printf "%s-%s" ($name | trunc (sub 63 $length | int)) $suffix -}}
+{{- end -}}
+{{ $name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+ConfigMap template helpers
+*/}}
+{{- define "mozcloud-workload-core-lib.config.configMaps" -}}
+{{- $config_maps := .configMaps -}}
+{{- $labels := default (dict) .labels -}}
+{{- $name_override := default "" .nameOverride -}}
+{{- $output := list -}}
+{{- range $config_map := $config_maps -}}
+  {{- $config_map_config := $config_map | deepCopy -}}
+  {{- /* Configure name and labels */ -}}
+  {{- $params := dict "config" $config_map_config "context" ($ | deepCopy) "labels" $labels -}}
+  {{- $common := include "mozcloud-workload-core-lib.config.common" $params | fromYaml -}}
+  {{- $config_map_config = mergeOverwrite $config_map_config $common -}}
+  {{- /* Create configMaps[].data if it doesn't exist */ -}}
+  {{- $config_map_data := default (dict) $config_map_config.data -}}
+  {{- $_ := set $config_map_config "data" $config_map_data -}}
+  {{- $output = append $output $config_map_config -}}
+{{- end -}}
+{{- $config_maps = dict "configMaps" $output -}}
+{{ $config_maps | toYaml }}
+{{- end -}}
+
+{{/*
+ExternalSecret template helpers
+*/}}
+{{- define "mozcloud-workload-core-lib.config.externalSecrets" -}}
+{{- $app_code := default "" .appCode -}}
+{{- $environment := default "" .environment -}}
+{{- $external_secrets := .externalSecrets -}}
+{{- $labels := default (dict) .labels -}}
+{{- $name_override := default "" .nameOverride -}}
+{{- $output := list -}}
+{{- range $external_secret := $external_secrets -}}
+  {{- $defaults := include "mozcloud-workload-core-lib.defaults.externalSecret.config" $ | fromYaml -}}
+  {{- $external_secret_config := mergeOverwrite $defaults $external_secret -}}
+  {{- /* Configure name and labels */ -}}
+  {{- $params := dict "config" $external_secret_config "context" ($ | deepCopy) "labels" $labels -}}
+  {{- $common := include "mozcloud-workload-core-lib.config.common" $params | fromYaml -}}
+  {{- $external_secret_config = mergeOverwrite $external_secret_config $common -}}
+  {{- /* Populate ExternalSecret-specific fields, if not specified */ -}}
+  {{- if and (not $external_secret.target) $app_code -}}
+    {{- /* Prefer to construct the target name using .appCode if specified, otherwise use default */ -}}
+    {{- $target_name := printf "%s-secrets" $app_code -}}
+    {{- $_ := set $external_secret_config "target" $target_name -}}
+  {{- end -}}
+  {{- if and (not ($external_secret.gsm).secret) $environment -}}
+    {{- /* Prefer to construct the GSM secret name using .environment if specified, otherwise use default */ -}}
+    {{- $gsm_secret := printf "%s-gke-app-secrets" $environment -}}
+    {{- $_ := set $external_secret_config.gsm "secret" $gsm_secret -}}
+  {{- end -}}
+  {{- $output = append $output $external_secret_config -}}
+{{- end -}}
+{{- $external_secrets = dict "externalSecrets" $output -}}
+{{ $external_secrets | toYaml }}
+{{- end -}}
+
+{{/*
+ServiceAccount template helpers
+*/}}
+{{- define "mozcloud-workload-core-lib.config.serviceAccount.gcpServiceAccount" -}}
+{{- $output := "" -}}
+{{- if .fullName -}}
+  {{- $output = .fullName -}}
+{{- else if and .name .projectId -}}
+  {{- $output = printf "%s@%s.iam.gserviceaccount.com" .name .projectId -}}
+{{- end -}}
+{{ $output }}
+{{- end -}}
+
+{{- define "mozcloud-workload-core-lib.config.serviceAccounts" -}}
+{{- $labels := default (dict) .labels -}}
+{{- $name_override := default "" .nameOverride -}}
+{{- $service_accounts := .serviceAccounts -}}
+{{- $output := list -}}
+{{- range $service_account := $service_accounts -}}
+  {{- $defaults := include "mozcloud-workload-core-lib.defaults.serviceAccount.config" $ | fromYaml -}}
+  {{- $service_account_config := mergeOverwrite $defaults $service_account -}}
+  {{- /* Configure name and labels */ -}}
+  {{- $params := dict "config" $service_account_config "context" ($ | deepCopy) "labels" $labels -}}
+  {{- $common := include "mozcloud-workload-core-lib.config.common" $params | fromYaml -}}
+  {{- $service_account_config = mergeOverwrite $service_account_config $common -}}
+  {{- /* Generate gcpServiceAccount, if applicable */ -}}
+  {{- if $service_account_config.gcpServiceAccount -}}
+    {{- $gcp_service_account := include "mozcloud-workload-core-lib.config.serviceAccount.gcpServiceAccount" $service_account_config.gcpServiceAccount -}}
+    {{- /* Only set if either .fullName is specified or .name and .projectId are both specified */ -}}
+    {{- if $gcp_service_account -}}
+      {{- $_ := set $service_account_config "gcpServiceAccount" $gcp_service_account -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $output = append $output $service_account_config -}}
+{{- end -}}
+{{- $service_accounts = dict "serviceAccounts" $output -}}
+{{ $service_accounts | toYaml }}
+{{- end -}}
+
+{{/*
+Defaults
+*/}}
+{{- define "mozcloud-workload-core-lib.defaults.externalSecret.config" -}}
+name: {{ include "mozcloud-workload-core-lib.config.name" . }}
+refreshInterval: 5m
+target: {{ include "mozcloud-workload-core-lib.config.name" . }}-secrets
+gsm:
+  secret: dev-gke-app-secrets
+  version: latest
+{{- end -}}
+
+{{- define "mozcloud-workload-core-lib.defaults.serviceAccount.config" -}}
+name: {{ include "mozcloud-workload-core-lib.config.name" . }}
+{{- end -}}

--- a/mozcloud-workload-core/library/templates/_serviceaccount.yaml
+++ b/mozcloud-workload-core/library/templates/_serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- define "mozcloud-workload-core-lib.serviceAccount" -}}
+{{- if .serviceAccounts }}
+{{- $service_accounts := include "mozcloud-workload-core-lib.config.serviceAccounts" . | fromYaml }}
+{{- range $service_account := $service_accounts.serviceAccounts }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $service_account.name }}
+  labels:
+    {{- $service_account.labels | toYaml | nindent 4 }}
+  {{- if $service_account.gcpServiceAccount }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ $service_account.gcpServiceAccount }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/mozcloud-workload-core/library/values.yaml.example
+++ b/mozcloud-workload-core/library/values.yaml.example
@@ -1,0 +1,69 @@
+# Example values showing a visual representation of the parameters accepted by
+# this library chart.
+
+# This is used to populate the default value for "target" for ExternalSecret
+# resources.
+appCode: tenant-name
+
+# This is used to populate the default value for "gsm.secret" for ExternalSecret
+# resources.
+environment: dev
+
+# If you set this, it will be the default name for all resources if not
+# specified at the resource level.
+nameOverride: name-to-use-for-everything
+
+configMaps:
+  - name: config-map1
+
+    # The "data" section contains your environment variables in KEY:VALUE
+    # format.
+    data:
+      KEY: value
+      KEY2: value2
+  - name: config-map2
+    data:
+      KEY: value
+
+externalSecrets:
+  - name: external-secret1
+
+    # Defaults to 5m.
+    #refreshInterval: 10m
+
+    # Name of the K8s secret where the external secret is synced to. Optional
+    # if you specify "appCode".
+    target: my-k8s-secret
+
+    # This section is optional if you specify "environment" and are fine with
+    # "version" being "latest".
+    gsm:
+      secret: dev-gke-custom-secrets
+      version: latest
+
+serviceAccounts:
+  - name: mozcloud-workload-core
+
+    # If this service account should authenticate with GCP using Workload
+    # Identity, some of these details will need to be filled out.
+    #
+    # There are 2 approaches you can take here:
+    #
+    #   1. fullName: Use this if you want to specify the full email address of
+    #                the GCP service account.
+    #
+    #   2. name & projectId: Use these together to automatically construct the
+    #                        GCP service account email address.
+    gcpServiceAccount:
+      #fullName:
+
+      # The name of the GCP service account (everything before "@" in the email
+      # address.
+      name: my-gcp-service-account
+
+      # GCP project ID.
+      projectId: moz-fx-tenant-name-nonprod
+
+# Specifying labels here will apply them to all resources created in this
+# library chart.
+labels: {}

--- a/mozcloud-workload-core/library/values.yaml.example
+++ b/mozcloud-workload-core/library/values.yaml.example
@@ -11,6 +11,23 @@ environment: dev
 
 # If you set this, it will be the default name for all resources if not
 # specified at the resource level.
+#
+# Ideally, resources would be named in a way that follows this hierarchy:
+#
+#    1. Name set at the subcomponent/most specific level (eg. backend service
+#       name), if applicable.
+#    2. Name set at the component/parent level (eg. HTTPRoute).
+#    3. Name of the chart (equivalent to "application.fullname"). <- we are here
+#    4. Default name of the library chart (eg. mozcloud-gateway).
+#
+# Subcharts cannot pull metadata or values from parent charts unless the parent
+# chart passes them in as parameters. Rather than asking users to specify their
+# chart name as part of their values files, I went with the approach of
+# allowing users to specify a name that would be used if component/subcomponent
+# names were not set.
+#
+# If no names are set at all in this chart, the default library chart name will
+# be used: mozcloud-workload-core.
 nameOverride: name-to-use-for-everything
 
 configMaps:


### PR DESCRIPTION
This creates the mozcloud-workload-core library chart and includes support for the following K8s resources:

- ConfigMap
- ExternalSecret
- ServiceAccount

See values.yaml.example for details about the parameters this library chart accepts.

This is intended to be used by the upcoming `mozcloud-workload-stateless` (Deployment, Rollout) and `mozcloud-workload-stateful` (StatefulSet) charts.