### PR TITLE
feat(mozcloud-job,workload-core): support serviceAccount, securityContext, resources

### DIFF
--- a/mozcloud-job/application/Chart.yaml
+++ b/mozcloud-job/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.3
+appVersion: 0.2.0
 
 dependencies:
   - name: mozcloud-job-lib
-    version: 0.1.3
+    version: 0.2.0
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-job/application/values.yaml
+++ b/mozcloud-job/application/values.yaml
@@ -140,6 +140,13 @@ jobs: []
   #        memory:
   #          requests: 64Mi
   #          #limits: 128Mi
+  #
+  #       # User and/or group to use for the container SecurityContext, if
+  #       # applicable. Defaults to 10001 for both user and group. Only change
+  #       # this if you know what you are doing.
+  #       #securityContext:
+  #       #  user:
+  #       #  group:
 
 
   #  # Configuration settings for jobs.
@@ -166,6 +173,38 @@ jobs: []
   #    # This determines if the job should be restarted if the job fails.
   #    # Options are "Never" and "OnFailure". Default is "Never".
   #    #restartPolicy: Never
+  #
+  #    # User and/or group to use for the pod SecurityContext, if applicable.
+  #    # Defaults to 10001 for both user and group. Only change this if you
+  #    # know what you are doing.
+  #    #securityContext:
+  #    #  #user:
+  #    #  #group:
+  #
+  #    # The service account to use for the job, if applicable.
+  #    #serviceAccount:
+  #    #  # The name of the service account.
+  #    #  name:
+  #    #
+  #    #  # If enabled, the service account will be created.
+  #    #  create: false
+  #    #
+  #    #  # If create is "true", we can also populate the details necessary to
+  #    #  # configure GCP service account authentication via Workload Identity.
+  #    #  #gcpServiceAccount:
+  #    #  #  # Use this if you want to specify the full email address of the
+  #    #  #  # GCP service account.
+  #    #  #  #fullName:
+  #    #  #
+  #    #  #  # Use "name" and "projectId" instead of "fullName" to
+  #    #  #  # automatically construct the GCP service account email address.
+  #    #  #
+  #    #  #  # The name of the GCP service account (everything before "@" in
+  #    #  #  # the email address.
+  #    #  #  #name:
+  #    #  #
+  #    #  #  # GCP project ID.
+  #    #  #  #projectId
   #
   #    # When Kubernetes creates Job resources, the Job controller will
   #    # immediately begin executing the job by creating pods. If "suspend" is

--- a/mozcloud-job/library/Chart.yaml
+++ b/mozcloud-job/library/Chart.yaml
@@ -15,9 +15,12 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.0
 
 dependencies:
   - name: mozcloud-labels-lib
     version: 0.1.0
+    repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts
+  - name: mozcloud-workload-core-lib
+    version: 0.2.0
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-job/library/templates/_helpers.tpl
+++ b/mozcloud-job/library/templates/_helpers.tpl
@@ -112,9 +112,18 @@ CronJob template helpers
   {{- /* Configure job defaults */ -}}
   {{- $job_defaults := include "mozcloud-job-lib.defaults.job.config" . | fromYaml -}}
   {{- $job_config := mergeOverwrite $job_defaults.config (default (dict) $cron_job.jobConfig) -}}
-  {{- $_ := set $cron_job_config "jobConfig" $job_config -}}
+  {{- /* Configure pod securityContext */ -}}
+  {{- $pod_security_context_params := dict -}}
+  {{- if ($job_config.securityContext).user -}}
+    {{- $_ := set $pod_security_context_params "user" $job_config.securityContext.user -}}
+  {{- end -}}
+  {{- if ($job_config.securityContext).group -}}
+    {{- $_ := set $pod_security_context_params "group" $job_config.securityContext.group -}}
+  {{- end -}}
+  {{- $_ := set $job_config "securityContext" (include "mozcloud-workload-core-lib.pod.securityContext" $pod_security_context_params | fromYaml) -}}
+  {{- $_ = set $cron_job_config "jobConfig" $job_config -}}
   {{- /*
-  Configure default tag and resource limits, if not specified.
+  Configure default tag and container settings.
   */ -}}
   {{- $containers := default (list) $cron_job_config.containers -}}
   {{- $container_output := list -}}
@@ -122,8 +131,17 @@ CronJob template helpers
     {{- $container_defaults := include "mozcloud-job-lib.defaults.job.container.config" . | fromYaml -}}
     {{- $container_config := mergeOverwrite $container_defaults $container -}}
     {{- $resource_params := $container_config.resources -}}
-    {{- $resources := include "mozcloud-job-lib.defaults.job.container.resources" $resource_params | fromYaml -}}
+    {{- $resources := include "mozcloud-workload-core-lib.pod.container.resources" $resource_params | fromYaml -}}
     {{- $_ := set $container_config "resources" $resources -}}
+    {{/* Configure container securityContext */ -}}
+    {{- $container_security_context_params := dict -}}
+    {{- if ($container_config.securityContext).user -}}
+      {{- $_ := set $container_security_context_params "user" $container_config.securityContext.user -}}
+    {{- end -}}
+    {{- if ($container_config.securityContext).group -}}
+      {{- $_ := set $container_security_context_params "group" $container_config.securityContext.group -}}
+    {{- end -}}
+    {{- $_ = set $container_config "securityContext" (include "mozcloud-workload-core-lib.pod.container.securityContext" $container_security_context_params | fromYaml) -}}
     {{- $container_output = append $container_output $container_config -}}
   {{- end -}}
   {{- $_ := set $cron_job_config "containers" $container_output -}}
@@ -148,8 +166,17 @@ Job template helpers
   {{- $params := dict "config" $job_config "context" ($ | deepCopy) "labels" $labels -}}
   {{- $common := include "mozcloud-job-lib.config.common" $params | fromYaml -}}
   {{- $job_config = mergeOverwrite $job_config $common -}}
+  {{- /* Configure pod securityContext */ -}}
+  {{- $pod_security_context_params := dict -}}
+  {{- if ($job_config.config.securityContext).user -}}
+    {{- $_ := set $pod_security_context_params "user" $job_config.config.securityContext.user -}}
+  {{- end -}}
+  {{- if ($job_config.config.securityContext).group -}}
+    {{- $_ := set $pod_security_context_params "group" $job_config.config.securityContext.group -}}
+  {{- end -}}
+  {{- $_ := set $job_config.config "securityContext" (include "mozcloud-workload-core-lib.pod.securityContext" $pod_security_context_params | fromYaml) -}}
   {{- /*
-  Configure default tag and resource limits, if not specified.
+  Configure default tag and container settings.
   */ -}}
   {{- $containers := default (list) $job_config.containers -}}
   {{- $container_output := list -}}
@@ -157,8 +184,17 @@ Job template helpers
     {{- $container_defaults := include "mozcloud-job-lib.defaults.job.container.config" . | fromYaml -}}
     {{- $container_config := mergeOverwrite $container_defaults $container -}}
     {{- $resource_params := $container_config.resources -}}
-    {{- $resources := include "mozcloud-job-lib.defaults.job.container.resources" $resource_params | fromYaml -}}
+    {{- $resources := include "mozcloud-workload-core-lib.pod.container.resources" $resource_params | fromYaml -}}
     {{- $_ := set $container_config "resources" $resources -}}
+    {{/* Configure container securityContext */ -}}
+    {{- $container_security_context_params := dict -}}
+    {{- if ($container_config.securityContext).user -}}
+      {{- $_ := set $container_security_context_params "user" $container_config.securityContext.user -}}
+    {{- end -}}
+    {{- if ($container_config.securityContext).group -}}
+      {{- $_ := set $container_security_context_params "group" $container_config.securityContext.group -}}
+    {{- end -}}
+    {{- $_ = set $container_config "securityContext" (include "mozcloud-workload-core-lib.pod.container.securityContext" $container_security_context_params | fromYaml) -}}
     {{- $container_output = append $container_output $container_config -}}
   {{- end -}}
   {{- $_ := set $job_config "containers" $container_output -}}
@@ -185,6 +221,8 @@ config:
   backoffLimit: 6
   parallelism: 1
   restartPolicy: Never
+  serviceAccount:
+    create: false
 generateName: false
 {{- end -}}
 
@@ -194,104 +232,6 @@ resources:
     cpu: 10m
     memory: 64Mi
 tag: latest
-{{- end -}}
-
-{{- define "mozcloud-job-lib.defaults.job.container.resources" -}}
-{{- $requests := .requests -}}
-{{- $limits := default (dict) .limits -}}
-{{- $resources := dict "requests" .requests "limits" $limits -}}
-{{- /* Validate CPU requests and limits */ -}}
-{{- $request_suffix := "" -}}
-{{- $request := $requests.cpu | toString -}}
-{{- /*
-CPU resources can only be integers/floats for an entire CPU or millicpu (m)
-*/ -}}
-{{- if hasSuffix "m" $request -}}
-  {{- $request_suffix = "m" }}
-  {{- $request = trimSuffix "m" $request -}}
-{{- end -}}
-{{- if and (not $request_suffix) (or (regexFind "[a-zA-Z]$" $request) (le (float64 $request) 0.0)) -}}
-  {{- fail (printf "CPU requests must be positive and use one of the following formats: int, float, or millicpu notation (eg. 100m)") -}}
-{{- end -}}
-{{- if $limits.cpu -}}
-  {{- $limit_suffix := "" -}}
-  {{- $limit := $limits.cpu | toString -}}
-  {{- /*
-  CPU resources can only be integers/floats for an entire CPU or millicpu (m)
-  */ -}}
-  {{- if hasSuffix "m" $limit -}}
-    {{- $limit_suffix = "m" }}
-    {{- $limit = trimSuffix "m" $limit -}}
-  {{- end -}}
-  {{- if and (not $limit_suffix) (or (regexFind "[a-zA-Z]$" $limit) (le (float64 $limit) 0.0)) -}}
-    {{- fail (printf "CPU limits must be positive and use one of the following formats: int, float, or millicpu notation (eg. 100m)") -}}
-  {{- end -}}
-  {{- if or $limit_suffix (eq (float64 $limit) (floor (float64 $limit))) -}}
-    {{- /*
-    Using "ceil" function here to round up any limits using millicpu
-    notations with decimals. For example, "1.5m" becomes "2m".
-    */ -}}
-    {{- $limit = ceil (float64 $limit) -}}
-    {{- $_ := set $resources.limits "cpu" (printf "%d%s" (int $limit) $limit_suffix) -}}
-  {{- end -}}
-{{- end -}}
-{{- /* Configure CPU limits, if not set */}}
-{{- if not $limits.cpu -}}
-  {{- $limit := "" -}}
-  {{- /* Keep ints as ints to create cleaner output */ -}}
-  {{- if or $request_suffix (eq (float64 $request) (floor (float64 $request))) -}}
-    {{- /*
-    Using "ceil" function here to round up any requests using millicpu
-    notations with decimals. For example, "1.5m" becomes "2m".
-    */ -}}
-    {{- $request = ceil (float64 $request) -}}
-    {{- $_ := set $resources.requests "cpu" (printf "%d%s" (int $request) $request_suffix) -}}
-    {{- $limit = printf "%d%s" (mul 2 (int $request)) $request_suffix -}}
-  {{- else -}}
-    {{- $limit = printf "%.3f" (mulf 2 (float64 $request)) -}}
-  {{- end -}}
-  {{- $_ := set $resources.limits "cpu" $limit -}}
-{{- end -}}
-{{- /* Validate memory requests and limits */ -}}
-{{- $request_suffix = "" -}}
-{{- /* Only allow the following unit types: K, Ki, M, Mi, G, Gi */ -}}
-{{- $memory_suffixes := list "K" "Ki" "M" "Mi" "G" "Gi" -}}
-{{- $request = $requests.memory | toString -}}
-{{- range $memory_suffix := $memory_suffixes -}}
-  {{- if hasSuffix $memory_suffix $request -}}
-    {{- $request_suffix = $memory_suffix }}
-    {{- $request = trimSuffix $request_suffix $request -}}
-  {{- end -}}
-{{- end -}}
-{{- if or (not $request_suffix) (le (float64 $request) 0.0) -}}
-  {{- fail (printf "Memory requests must be positive and use one of the following unit types: %s" (join ", " $memory_suffixes)) -}}
-{{- end -}}
-{{- if $limits.memory -}}
-  {{- $limit_suffix := "" -}}
-  {{- $limit := $limits.memory | toString -}}
-  {{- range $memory_suffix := $memory_suffixes -}}
-    {{- if hasSuffix $memory_suffix $limit -}}
-      {{- $limit_suffix = $memory_suffix }}
-      {{- $limit = trimSuffix $limit_suffix $limit -}}
-    {{- end -}}
-  {{- end -}}
-  {{- if or (not $limit_suffix) (le (float64 $limit) 0.0) -}}
-    {{- fail (printf "Memory limits must be positive and use one of the following unit types: %s" (join ", " $memory_suffixes)) -}}
-  {{- end -}}
-{{- end -}}
-{{- /* Configure memory limits, if not set */ -}}
-{{- if not $limits.memory -}}
-  {{- $limit := "" -}}
-  {{- /* Keep ints as ints to create cleaner output */ -}}
-  {{- if eq (float64 $request) (floor (float64 $request)) -}}
-    {{- $limit = printf "%d%s" (mul 2 (int $request)) $request_suffix -}}
-  {{- else -}}
-    {{- $limit = printf "%.3f%s" (mulf 2 (float64 $request)) $request_suffix -}}
-  {{- end -}}
-  {{- $_ := set $resources.limits "memory" $limit -}}
-{{- end -}}
-{{- /* Return resources */}}
-{{ $resources | toYaml }}
 {{- end -}}
 
 {{/*

--- a/mozcloud-workload-core/library/Chart.yaml
+++ b/mozcloud-workload-core/library/Chart.yaml
@@ -15,4 +15,4 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0

--- a/mozcloud-workload-core/library/templates/_pod.yaml
+++ b/mozcloud-workload-core/library/templates/_pod.yaml
@@ -1,0 +1,121 @@
+{{- define "mozcloud-workload-core-lib.pod.container.resources" -}}
+{{- $requests := .requests -}}
+{{- $limits := default (dict) .limits -}}
+{{- $resources := dict "requests" .requests "limits" $limits -}}
+{{- /* Validate CPU requests and limits */ -}}
+{{- $request_suffix := "" -}}
+{{- $request := $requests.cpu | toString -}}
+{{- /*
+CPU resources can only be integers/floats for an entire CPU or millicpu (m)
+*/ -}}
+{{- if hasSuffix "m" $request -}}
+  {{- $request_suffix = "m" }}
+  {{- $request = trimSuffix "m" $request -}}
+{{- end -}}
+{{- if and (not $request_suffix) (or (regexFind "[a-zA-Z]$" $request) (le (float64 $request) 0.0)) -}}
+  {{- fail (printf "CPU requests must be positive and use one of the following formats: int, float, or millicpu notation (eg. 100m)") -}}
+{{- end -}}
+{{- if $limits.cpu -}}
+  {{- $limit_suffix := "" -}}
+  {{- $limit := $limits.cpu | toString -}}
+  {{- /*
+  CPU resources can only be integers/floats for an entire CPU or millicpu (m)
+  */ -}}
+  {{- if hasSuffix "m" $limit -}}
+    {{- $limit_suffix = "m" }}
+    {{- $limit = trimSuffix "m" $limit -}}
+  {{- end -}}
+  {{- if and (not $limit_suffix) (or (regexFind "[a-zA-Z]$" $limit) (le (float64 $limit) 0.0)) -}}
+    {{- fail (printf "CPU limits must be positive and use one of the following formats: int, float, or millicpu notation (eg. 100m)") -}}
+  {{- end -}}
+  {{- if or $limit_suffix (eq (float64 $limit) (floor (float64 $limit))) -}}
+    {{- /*
+    Using "ceil" function here to round up any limits using millicpu
+    notations with decimals. For example, "1.5m" becomes "2m".
+    */ -}}
+    {{- $limit = ceil (float64 $limit) -}}
+    {{- $_ := set $resources.limits "cpu" (printf "%d%s" (int $limit) $limit_suffix) -}}
+  {{- end -}}
+{{- end -}}
+{{- /* Configure CPU limits, if not set */}}
+{{- if not $limits.cpu -}}
+  {{- $limit := "" -}}
+  {{- /* Keep ints as ints to create cleaner output */ -}}
+  {{- if or $request_suffix (eq (float64 $request) (floor (float64 $request))) -}}
+    {{- /*
+    Using "ceil" function here to round up any requests using millicpu
+    notations with decimals. For example, "1.5m" becomes "2m".
+    */ -}}
+    {{- $request = ceil (float64 $request) -}}
+    {{- $_ := set $resources.requests "cpu" (printf "%d%s" (int $request) $request_suffix) -}}
+    {{- $limit = printf "%d%s" (mul 2 (int $request)) $request_suffix -}}
+  {{- else -}}
+    {{- $limit = printf "%.3f" (mulf 2 (float64 $request)) -}}
+  {{- end -}}
+  {{- $_ := set $resources.limits "cpu" $limit -}}
+{{- end -}}
+{{- /* Validate memory requests and limits */ -}}
+{{- $request_suffix = "" -}}
+{{- /* Only allow the following unit types: K, Ki, M, Mi, G, Gi */ -}}
+{{- $memory_suffixes := list "K" "Ki" "M" "Mi" "G" "Gi" -}}
+{{- $request = $requests.memory | toString -}}
+{{- range $memory_suffix := $memory_suffixes -}}
+  {{- if hasSuffix $memory_suffix $request -}}
+    {{- $request_suffix = $memory_suffix }}
+    {{- $request = trimSuffix $request_suffix $request -}}
+  {{- end -}}
+{{- end -}}
+{{- if or (not $request_suffix) (le (float64 $request) 0.0) -}}
+  {{- fail (printf "Memory requests must be positive and use one of the following unit types: %s" (join ", " $memory_suffixes)) -}}
+{{- end -}}
+{{- if $limits.memory -}}
+  {{- $limit_suffix := "" -}}
+  {{- $limit := $limits.memory | toString -}}
+  {{- range $memory_suffix := $memory_suffixes -}}
+    {{- if hasSuffix $memory_suffix $limit -}}
+      {{- $limit_suffix = $memory_suffix }}
+      {{- $limit = trimSuffix $limit_suffix $limit -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if or (not $limit_suffix) (le (float64 $limit) 0.0) -}}
+    {{- fail (printf "Memory limits must be positive and use one of the following unit types: %s" (join ", " $memory_suffixes)) -}}
+  {{- end -}}
+{{- end -}}
+{{- /* Configure memory limits, if not set */ -}}
+{{- if not $limits.memory -}}
+  {{- $limit := "" -}}
+  {{- /* Keep ints as ints to create cleaner output */ -}}
+  {{- if eq (float64 $request) (floor (float64 $request)) -}}
+    {{- $limit = printf "%d%s" (mul 2 (int $request)) $request_suffix -}}
+  {{- else -}}
+    {{- $limit = printf "%.3f%s" (mulf 2 (float64 $request)) $request_suffix -}}
+  {{- end -}}
+  {{- $_ := set $resources.limits "memory" $limit -}}
+{{- end -}}
+{{- /* Return resources */}}
+{{ $resources | toYaml }}
+{{- end -}}
+
+{{- define "mozcloud-workload-core-lib.pod.container.securityContext" -}}
+allowPrivilegeEscalation: false
+capabilities:
+  drop: ["ALL"]
+{{- if .user }}
+runAsUser: {{ .user }}
+{{- end }}
+{{- if .group }}
+runAsGroup: {{ .group }}
+{{- end }}
+seccompProfile:
+  type: "RuntimeDefault"
+{{- end -}}
+
+{{- define "mozcloud-workload-core-lib.pod.securityContext" -}}
+# PSS https://kubernetes.io/docs/concepts/security/pod-security-standards/
+# restricted profile
+seccompProfile:
+  type: "RuntimeDefault"
+runAsNonRoot: true
+runAsUser: {{ default 10001 .user }}
+runAsGroup: {{ default 10001 .group }}
+{{- end -}}


### PR DESCRIPTION
I changed 2 charts here.

mozcloud-job:
- Move resource helper to mozcloud-workload-core chart
- Add support for service accounts in jobs and cronjobs
- Add option to create service accounts with GCP service account annotations
- Enforce security context for pods and containers in jobs and cron jobs
- Bump versions

mozcloud-workload-core:
- Create _pods.yaml file with pod-related templates
- Import pod resources template from mozcloud-job
- Create pod and container security context template
- Bump versions

This was implemented here: https://github.com/mozilla/webservices-infra/pull/6950

Related ticket: https://mozilla-hub.atlassian.net/browse/MZCLD-815