### PR TITLE
feat(mozcloud-workload-core,job): annotation support, fix sync wave ordering

### DIFF
--- a/mozcloud-job/application/Chart.yaml
+++ b/mozcloud-job/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.0
+appVersion: 0.2.1
 
 dependencies:
   - name: mozcloud-job-lib
-    version: 0.2.0
+    version: 0.2.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-job/library/Chart.yaml
+++ b/mozcloud-job/library/Chart.yaml
@@ -15,12 +15,12 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 dependencies:
   - name: mozcloud-labels-lib
     version: 0.1.0
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts
   - name: mozcloud-workload-core-lib
-    version: 0.2.0
+    version: 0.3.0
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-charts

--- a/mozcloud-job/library/templates/_job.tpl
+++ b/mozcloud-job/library/templates/_job.tpl
@@ -19,19 +19,9 @@ metadata:
   labels:
     {{- $job.labels | toYaml | nindent 4 }}
   {{- $argo := ($job.argo) }}
-  {{- if or $argo.hookDeletionPolicy $argo.hooks $argo.syncWave }}
+  {{- if $job.annotations }}
   annotations:
-    {{- if $argo.hooks }}
-    argocd.argoproj.io/hook: {{ $argo.hooks }}
-    {{- else if and $argo.hookDeletionPolicy $argo.syncWave }}
-    argocd.argoproj.io/hook: Sync
-    {{- end }}
-    {{- if $argo.hookDeletionPolicy }}
-    argocd.argoproj.io/hook-delete-policy: {{ $argo.hookDeletionPolicy }}
-    {{- end }}
-    {{- if $argo.syncWave }}
-    argocd.argoproj.io/sync-wave: {{ $argo.syncWave | quote }}
-    {{- end }}
+    {{- $job.annotations | toYaml | nindent 4 }}
   {{- end }}
 spec:
   {{- $config := ($job.config) }}

--- a/mozcloud-workload-core/library/Chart.yaml
+++ b/mozcloud-workload-core/library/Chart.yaml
@@ -15,4 +15,4 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0

--- a/mozcloud-workload-core/library/templates/_configmap.yaml
+++ b/mozcloud-workload-core/library/templates/_configmap.yaml
@@ -10,6 +10,10 @@ metadata:
   name: {{ $config_map.name }}
   labels:
     {{- $config_map.labels | toYaml | nindent 4 }}
+  {{- if $config_map.annotations }}
+  annotations:
+    {{- $config_map.annotations | toYaml | nindent 4 }}
+  {{- end }}
 data:
   {{- range $key, $value := $config_map.data }}
   {{ $key }}: {{ $value | quote }}

--- a/mozcloud-workload-core/library/templates/_externalsecret.yaml
+++ b/mozcloud-workload-core/library/templates/_externalsecret.yaml
@@ -9,6 +9,10 @@ metadata:
   name: {{ $external_secret.name }}
   labels:
     {{- $external_secret.labels | toYaml | nindent 4 }}
+  {{- if $external_secret.annotations }}
+  annotations:
+    {{- $external_secret.annotations | toYaml | nindent 4 }}
+  {{- end }}
 spec:
   refreshInterval: {{ $external_secret.refreshInterval }}
   secretStoreRef:

--- a/mozcloud-workload-core/library/templates/_serviceaccount.yaml
+++ b/mozcloud-workload-core/library/templates/_serviceaccount.yaml
@@ -9,9 +9,14 @@ metadata:
   name: {{ $service_account.name }}
   labels:
     {{- $service_account.labels | toYaml | nindent 4 }}
-  {{- if $service_account.gcpServiceAccount }}
+  {{- if or $service_account.gcpServiceAccount $service_account.annotations }}
   annotations:
+    {{- if $service_account.gcpServiceAccount }}
     iam.gke.io/gcp-service-account: {{ $service_account.gcpServiceAccount }}
+    {{- end }}
+    {{- if $service_account.annotations }}
+    {{- $service_account.annotations | toYaml | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/mozcloud-workload-core/library/values.yaml.example
+++ b/mozcloud-workload-core/library/values.yaml.example
@@ -38,6 +38,10 @@ configMaps:
     data:
       KEY: value
       KEY2: value2
+
+    # Any annotations that should be added, if applicable. One common use case
+    # would be annotations for Argo CD, such as sync waves.
+    #annotations: {}
   - name: config-map2
     data:
       KEY: value
@@ -57,6 +61,10 @@ externalSecrets:
     gsm:
       secret: dev-gke-custom-secrets
       version: latest
+
+    # Any annotations that should be added, if applicable. One common use case
+    # would be annotations for Argo CD, such as sync waves.
+    #annotations: {}
 
 serviceAccounts:
   - name: mozcloud-workload-core
@@ -80,6 +88,10 @@ serviceAccounts:
 
       # GCP project ID.
       projectId: moz-fx-tenant-name-nonprod
+
+    # Any annotations that should be added, if applicable. One common use case
+    # would be annotations for Argo CD, such as sync waves.
+    #annotations: {}
 
 # Specifying labels here will apply them to all resources created in this
 # library chart.


### PR DESCRIPTION
We have two changes here.

**mozcloud-workload-core**:
- Added support for resource level annotations

**mozcloud-job**:
- Changed the way we create annotations
- Ensure service accounts used by jobs are created before the jobs themselves