### PR TITLE
fix(mozcloud-preview): updated library chart version to match main branch

### DIFF
--- a/mozcloud-preview/application/Chart.yaml
+++ b/mozcloud-preview/application/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
 - name: mozcloud-preview-lib
-  version: 0.2.2
+  version: 0.2.3
   repository: file://../library


### PR DESCRIPTION
**CHANGES:**
* mozcloud-preview chart had the incorrect dependency version 
* Updated to match mozcloud-preview-lib version 