### PR TITLE
feat: use global values for labels on all charts

### DIFF
--- a/mozcloud-deployment/application/templates/_labels.tpl
+++ b/mozcloud-deployment/application/templates/_labels.tpl
@@ -1,6 +1,6 @@
 {{- define "mozcloud-deployment.labels" -}}
-moz.cloud/domain: {{ .Values.global.labels.domain }}
-moz.cloud/app_code: {{ .Values.global.labels.app_code }}
-moz.cloud/realm: {{ .Values.global.labels.realm }}
-moz.cloud/env: {{ .Values.global.labels.env }}
+moz.cloud/domain: {{ .Values.global.mozcloud.domain }}
+moz.cloud/app_code: {{ .Values.global.mozcloud.app_code }}
+moz.cloud/realm: {{ .Values.global.mozcloud.realm }}
+moz.cloud/env: {{ .Values.global.mozcloud.env }}
 {{- end -}}

--- a/mozcloud-deployment/application/templates/deployments.yaml
+++ b/mozcloud-deployment/application/templates/deployments.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "mozcloud-deployment.labels" . | nindent 4 }}
 
-  name: {{ .Values.global.labels.app_code }}-deployment
+  name: {{ .Values.global.mozcloud.app_code }}-deployment
 
 spec:
   selector:
@@ -20,8 +20,8 @@ spec:
 
     spec:
       containers:
-        - name: {{ .Values.global.labels.app_code }}-deployment-app
-          {{- with .Values.global.mozcloud_deployment  }}
+        - name: {{ .Values.global.mozcloud.app_code }}-deployment-app
+          {{- with .Values.mozcloud-deployment  }}
           image: {{ printf "%s:%s" .image .tag | quote }}
           imagePullPolicy: IfNotPresent
           {{- end }}

--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.6
+appVersion: 0.2.7
 
 dependencies:
   - name: mozcloud-gateway-lib
-    version: 0.2.6
+    version: 0.2.7
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts

--- a/mozcloud-gateway/application/templates/_helpers.tpl
+++ b/mozcloud-gateway/application/templates/_helpers.tpl
@@ -66,10 +66,10 @@ Create label parameters to be used in library chart if defined as values.
 */}}
 {{- define "mozcloud-gateway.labelParams" -}}
 {{- $params := dict "chartName" (include "mozcloud-gateway.name" .) -}}
-{{- $label_params := list "appCode" "component" "environment" -}}
+{{- $label_params := list "app_code" "chart" "component_code" "environment" -}}
 {{- range $label_param := $label_params -}}
-  {{- if index $.Values $label_param -}}
-    {{- $_ := set $params $label_param (index $.Values $label_param) -}}
+  {{- if index $.Values.global $label_param -}}
+    {{- $_ := set $params $label_param (index $.Values.global $label_param) -}}
   {{- end }}
 {{- end }}
 {{- $params | toYaml }}

--- a/mozcloud-gateway/application/templates/_helpers.tpl
+++ b/mozcloud-gateway/application/templates/_helpers.tpl
@@ -65,11 +65,11 @@ Create the name of the service account to use
 Create label parameters to be used in library chart if defined as values.
 */}}
 {{- define "mozcloud-gateway.labelParams" -}}
-{{- $params := dict "chartName" (include "mozcloud-gateway.name" .) -}}
+{{- $params := dict "chart" (include "mozcloud-gateway.name" .) -}}
 {{- $label_params := list "app_code" "chart" "component_code" "environment" -}}
 {{- range $label_param := $label_params -}}
-  {{- if index $.Values.global $label_param -}}
-    {{- $_ := set $params $label_param (index $.Values.global $label_param) -}}
+  {{- if index $.Values.global.mozcloud $label_param -}}
+    {{- $_ := set $params $label_param (index $.Values.global.mozcloud $label_param) -}}
   {{- end }}
 {{- end }}
 {{- $params | toYaml }}

--- a/mozcloud-gateway/application/templates/backendpolicy.yaml
+++ b/mozcloud-gateway/application/templates/backendpolicy.yaml
@@ -1,5 +1,8 @@
 {{- if and .Values.enabled (.Values.httpRoute).enabled }}
-{{- $params := dict "backendConfig" (dict "backends" .Values.backends) "backendPolicyConfig" .Values.backendPolicy "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "backendConfig" (dict "backends" .Values.backends) "backendPolicyConfig" .Values.backendPolicy "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-gateway.labelParams" . | fromYaml }}
 {{- include "mozcloud-gateway-lib.backendPolicy" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/gateway.yaml
+++ b/mozcloud-gateway/application/templates/gateway.yaml
@@ -1,5 +1,8 @@
 {{- if and .Values.enabled (.Values.gateway).enabled }}
-{{- $params := dict "gatewayConfig" .Values.gateway "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "gatewayConfig" .Values.gateway "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-gateway.labelParams" .  | fromYaml }}
 {{ include "mozcloud-gateway-lib.gateway" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/gatewaypolicy.yaml
+++ b/mozcloud-gateway/application/templates/gatewaypolicy.yaml
@@ -1,5 +1,8 @@
 {{- if and .Values.enabled (.Values.gateway).enabled }}
-{{- $params := dict "gatewayConfig" .Values.gateway "gatewayPolicyConfig" .Values.gatewayPolicy "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "gatewayConfig" .Values.gateway "gatewayPolicyConfig" .Values.gatewayPolicy "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-gateway.labelParams" .  | fromYaml }}
 {{ include "mozcloud-gateway-lib.gatewayPolicy" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/healthcheckpolicy.yaml
+++ b/mozcloud-gateway/application/templates/healthcheckpolicy.yaml
@@ -1,5 +1,8 @@
 {{- if and .Values.enabled (.Values.httpRoute).enabled }}
-{{- $params := dict "backendConfig" (dict "backends" .Values.backends) "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "backendConfig" (dict "backends" .Values.backends) "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-gateway.labelParams" . | fromYaml }}
 {{- include "mozcloud-gateway-lib.healthCheckPolicy" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/httproute.yaml
+++ b/mozcloud-gateway/application/templates/httproute.yaml
@@ -1,5 +1,8 @@
 {{- if and .Values.enabled (.Values.httpRoute).enabled }}
-{{- $params := dict "httpRouteConfig" .Values.httpRoute "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "httpRouteConfig" .Values.httpRoute "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-gateway.labelParams" .  | fromYaml }}
 {{ include "mozcloud-gateway-lib.httpRoute" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/templates/service.yaml
+++ b/mozcloud-gateway/application/templates/service.yaml
@@ -1,5 +1,8 @@
 {{- if and .Values.enabled (.Values.httpRoute).enabled }}
-{{- $params := dict "backendConfig" (dict "backends" .Values.backends) "nameOverride" (include "mozcloud-gateway.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "backendConfig" (dict "backends" .Values.backends) "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-gateway.labelParams" . | fromYaml }}
 {{- include "mozcloud-gateway-lib.service" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -1,21 +1,25 @@
 # If disabled, no resources in the chart will be created.
 enabled: true
 
-# Name to be used for all resources if not specified at the resource level.
-# This should match the name of the parent Helm chart.
-#nameOverride:
-
-# Application code. This should match the `app_code` value in your tenant's
-# values.yaml file.
-#appCode:
-
-# Component. This should match the `component` value in your tenant's
-# values.yaml file.
-#component:
-
-# Environment. This should match the `environment` value in your tenant's
-# values-<env>.yaml file.
-#environment:
+# app_code, chart, component_code, and environment should all be defined as
+# global values in the parent Helm chart's values file(s) outside the scope of
+# this Helm chart.
+#
+# For example:
+#
+#   # my-app/values.yaml
+#   global:
+#     mozcloud:
+#       app_code: my-app    # should match app_code in tenant file
+#       chart: my-chart     # the name of the chart
+#       component_code: web # should match component_code in tenant file
+#
+#   # my-app/values-dev.yaml
+#   global:
+#     mozcloud:
+#       environment: dev    # should match .Values.environment
+#
+# These are used to populate labels and metadata in MozCloud charts.
 
 # Defines how the backend services of the load balancer should distribute the
 # traffic to the endpoints. This policy is similar to a BackendConfig for an

--- a/mozcloud-gateway/application/values.yaml
+++ b/mozcloud-gateway/application/values.yaml
@@ -21,6 +21,11 @@ enabled: true
 #
 # These are used to populate labels and metadata in MozCloud charts.
 
+# Name to be used for all resources if not specified at the resource level.
+# This overrides the chart name set in .Values.global.mozcloud.chart but is
+# overridden by names defined at the resource level.
+#nameOverride:
+
 # Defines how the backend services of the load balancer should distribute the
 # traffic to the endpoints. This policy is similar to a BackendConfig for an
 # Ingress resource. These are default values that can be overridden for each

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -19,8 +19,8 @@ version: 0.2.6
 
 dependencies:
   - name: mozcloud-labels-lib
-    version: 0.1.0
+    version: 0.1.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
   - name: mozcloud-service-lib
-    version: 0.2.1
+    version: 0.2.2
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-gateway/library/templates/_helpers.tpl
+++ b/mozcloud-gateway/library/templates/_helpers.tpl
@@ -68,6 +68,9 @@ Template helpers
 {{- if and (.nameOverride) (not $name) -}}
   {{- $name = .nameOverride -}}
 {{- end -}}
+{{- if and (.chart) (not $name) -}}
+  {{- $name = .chart -}}
+{{- end -}}
 {{- if not $name -}}
   {{- $name = include "mozcloud-gateway-lib.fullname" $ -}}
 {{- end -}}
@@ -102,7 +105,7 @@ BackendPolicy template helpers
   {{- end -}}
   {{- $_ := set $backend_policy_config "config" $merged_policy -}}
   {{- /* Use name helper function to populate name and targetService using rules hierarchy */ -}}
-  {{- $params := dict -}}
+  {{- $params := $ | deepCopy -}}
   {{- if $backend.name -}}
     {{- $_ := set $params "name" $backend.name -}}
   {{- end -}}
@@ -142,13 +145,14 @@ Gateway template helpers
   {{- $gateway_defaults := include "mozcloud-gateway-lib.defaults.gateway.config" . | fromYaml -}}
   {{- $gateway_config := mergeOverwrite $gateway_defaults $gateway -}}
   {{- /* Use name helper function to populate name using rules hierarchy */ -}}
-  {{- $params := dict "gatewayConfig" $gateway_config -}}
+  {{- $params := $ | deepCopy -}}
+  {{- $_ := set $params "gatewayConfig" $gateway_config -}}
   {{- $name_override := default "" $.nameOverride -}}
   {{- if $name_override -}}
     {{- $_ := set $params "nameOverride" $name_override -}}
   {{- end -}}
   {{- $name := include "mozcloud-gateway-lib.config.name" $params -}}
-  {{- $_ := set $gateway_config "name" $name -}}
+  {{- $_ = set $gateway_config "name" $name -}}
   {{- /* Use helper function to determine className if not defined */ -}}
   {{- if not $gateway_config.className -}}
     {{- $class_name := include "mozcloud-gateway-lib.config.gateway.className" $gateway_config -}}
@@ -183,9 +187,10 @@ GatewayPolicy template helpers
       {{- $https_listener = true -}}
     {{- end -}}
   {{- end -}}
+  {{- $context := $ | deepCopy -}}
   {{- if $https_listener -}}
     {{- /* Use name helper function to populate name using rules hierarchy */ -}}
-    {{- $params := dict "gatewayConfig" $gateway_config -}}
+    {{- $params := mergeOverwrite $context (dict "gatewayConfig" $gateway_config) -}}
     {{- $name_override := default "" $.nameOverride -}}
     {{- if $name_override -}}
       {{- $_ := set $params "nameOverride" $name_override -}}
@@ -226,7 +231,7 @@ HealthCheckPolicy template helpers
   {{- $_ = set $config "protocolProperty" (index $protocol_property $config.protocol) -}}
   {{- $_ = set $health_check_policy_config "config" $config -}}
   {{- /* Use name helper function to populate name and targetService using rules hierarchy */ -}}
-  {{- $params := dict -}}
+  {{- $params := $ | deepCopy -}}
   {{- if $backend.name -}}
     {{- $_ := set $params "name" $backend.name -}}
   {{- end -}}
@@ -257,13 +262,14 @@ HTTPRoute template helpers
   {{- $http_route_defaults := include "mozcloud-gateway-lib.defaults.httpRoute.config" . | fromYaml -}}
   {{- $http_route_config := mergeOverwrite $http_route_defaults ($http_route | deepCopy) -}}
   {{- /* Use name helper function to populate name using rules hierarchy */ -}}
-  {{- $params := dict "httpRouteConfig" $http_route_config -}}
+  {{- $params := $ | deepCopy -}}
+  {{- $_ := set $params "httpRouteConfig" $http_route_config -}}
   {{- $name_override := default "" $.nameOverride -}}
   {{- if $name_override -}}
     {{- $_ := set $params "nameOverride" $name_override -}}
   {{- end -}}
   {{- $name := include "mozcloud-gateway-lib.config.name" $params -}}
-  {{- $_ := set $http_route_config "name" $name -}}
+  {{- $_ = set $http_route_config "name" $name -}}
   {{- /* Generate labels */ -}}
   {{- $label_params := dict "labels" (default (dict) $http_route_config.labels) -}}
   {{- $labels := include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml -}}

--- a/mozcloud-ingress/application/Chart.yaml
+++ b/mozcloud-ingress/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.2
+appVersion: 0.2.0
 
 dependencies:
   - name: mozcloud-ingress-lib
-    version: 0.2.2
+    version: 0.2.3
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts

--- a/mozcloud-ingress/application/Chart.yaml
+++ b/mozcloud-ingress/application/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.2.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.0
+appVersion: 0.2.2
 
 dependencies:
   - name: mozcloud-ingress-lib

--- a/mozcloud-ingress/application/templates/_helpers.tpl
+++ b/mozcloud-ingress/application/templates/_helpers.tpl
@@ -34,11 +34,11 @@ Create chart name and version as used by the chart label.
 Create label parameters to be used in library chart if defined as values.
 */}}
 {{- define "mozcloud-ingress.labelParams" -}}
-{{- $params := dict "chartName" (include "mozcloud-ingress.name" .) -}}
+{{- $params := dict "chart" (include "mozcloud-ingress.name" .) -}}
 {{- $label_params := list "app_code" "chart" "component_code" "environment" -}}
 {{- range $label_param := $label_params -}}
-  {{- if index $.Values.global $label_param -}}
-    {{- $_ := set $params $label_param (index $.Values.global $label_param) -}}
+  {{- if index $.Values.global.mozcloud $label_param -}}
+    {{- $_ := set $params $label_param (index $.Values.global.mozcloud $label_param) -}}
   {{- end }}
 {{- end }}
 {{- $params | toYaml }}

--- a/mozcloud-ingress/application/templates/_helpers.tpl
+++ b/mozcloud-ingress/application/templates/_helpers.tpl
@@ -35,10 +35,10 @@ Create label parameters to be used in library chart if defined as values.
 */}}
 {{- define "mozcloud-ingress.labelParams" -}}
 {{- $params := dict "chartName" (include "mozcloud-ingress.name" .) -}}
-{{- $label_params := list "appCode" "component" "environment" -}}
+{{- $label_params := list "app_code" "chart" "component_code" "environment" -}}
 {{- range $label_param := $label_params -}}
-  {{- if index $.Values $label_param -}}
-    {{- $_ := set $params $label_param (index $.Values $label_param) -}}
+  {{- if index $.Values.global $label_param -}}
+    {{- $_ := set $params $label_param (index $.Values.global $label_param) -}}
   {{- end }}
 {{- end }}
 {{- $params | toYaml }}

--- a/mozcloud-ingress/application/templates/backendconfig.yaml
+++ b/mozcloud-ingress/application/templates/backendconfig.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.enabled }}
-{{- $params := dict "ingressConfig" .Values.ingresses "defaults" .Values.backendConfig "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "ingressConfig" .Values.ingresses "defaults" .Values.backendConfig "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-ingress.labelParams" .  | fromYaml }}
 {{- include "mozcloud-ingress-lib.backendConfig" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/templates/frontendconfig.yaml
+++ b/mozcloud-ingress/application/templates/frontendconfig.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.enabled }}
-{{- $params := dict "frontendConfig" .Values.frontendConfig "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "frontendConfig" .Values.frontendConfig "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-ingress.labelParams" .  | fromYaml }}
 {{- include "mozcloud-ingress-lib.frontendConfig" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/templates/ingress.yaml
+++ b/mozcloud-ingress/application/templates/ingress.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.enabled }}
-{{- $params := dict "defaults" .Values.backendConfig "ingressConfig" .Values.ingresses "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "defaults" .Values.backendConfig "ingressConfig" .Values.ingresses "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-ingress.labelParams" .  | fromYaml }}
 {{- include "mozcloud-ingress-lib.ingress" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/templates/managedcertificate.yaml
+++ b/mozcloud-ingress/application/templates/managedcertificate.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.enabled }}
-{{- $params := dict "ingressConfig" .Values.ingresses "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "ingressConfig" .Values.ingresses "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-ingress.labelParams" .  | fromYaml }}
 {{- include "mozcloud-ingress-lib.managedCertificate" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/templates/service.yaml
+++ b/mozcloud-ingress/application/templates/service.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.enabled }}
-{{- $params := dict "ingressConfig" .Values.ingresses "nameOverride" (include "mozcloud-ingress.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "ingressConfig" .Values.ingresses "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-ingress.labelParams" . | fromYaml }}
 {{- include "mozcloud-ingress-lib.service" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-ingress/application/values.yaml
+++ b/mozcloud-ingress/application/values.yaml
@@ -21,6 +21,11 @@ enabled: true
 #
 # These are used to populate labels and metadata in MozCloud charts.
 
+# Name to be used for all resources if not specified at the resource level.
+# This overrides the chart name set in .Values.global.mozcloud.chart but is
+# overridden by names defined at the resource level.
+#nameOverride:
+
 # Global backend configuration. These values can be overridden at the host
 # level in the ingress definitions: .Values.ingresses[].hosts[].backend
 backendConfig:

--- a/mozcloud-ingress/application/values.yaml
+++ b/mozcloud-ingress/application/values.yaml
@@ -1,21 +1,25 @@
 # If enabled, all mozcloud-ingress templates will be included.
 enabled: true
 
-# Name to be used for all resources if not specified at the resource level.
-# This should match the name of the parent Helm chart.
-#nameOverride:
-
-# Application code. This should match the `app_code` value in your tenant's
-# values.yaml file.
-#appCode:
-
-# Component. This should match the `component` value in your tenant's
-# values.yaml file.
-#component:
-
-# Environment. This should match the `environment` value in your tenant's
-# values-<env>.yaml file.
-#environment:
+# app_code, chart, component_code, and environment should all be defined as
+# global values in the parent Helm chart's values file(s) outside the scope of
+# this Helm chart.
+#
+# For example:
+#
+#   # my-app/values.yaml
+#   global:
+#     mozcloud:
+#       app_code: my-app    # should match app_code in tenant file
+#       chart: my-chart     # the name of the chart
+#       component_code: web # should match component_code in tenant file
+#
+#   # my-app/values-dev.yaml
+#   global:
+#     mozcloud:
+#       environment: dev    # should match .Values.environment
+#
+# These are used to populate labels and metadata in MozCloud charts.
 
 # Global backend configuration. These values can be overridden at the host
 # level in the ingress definitions: .Values.ingresses[].hosts[].backend

--- a/mozcloud-ingress/library/Chart.yaml
+++ b/mozcloud-ingress/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-ingress/library/Chart.yaml
+++ b/mozcloud-ingress/library/Chart.yaml
@@ -19,8 +19,8 @@ version: 0.2.2
 
 dependencies:
   - name: mozcloud-labels-lib
-    version: 0.1.0
+    version: 0.1.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
   - name: mozcloud-service-lib
-    version: 0.2.1
+    version: 0.2.2
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts

--- a/mozcloud-ingress/library/templates/_backendconfig.yaml
+++ b/mozcloud-ingress/library/templates/_backendconfig.yaml
@@ -1,6 +1,7 @@
 {{- define "mozcloud-ingress-lib.backendConfig" -}}
 {{- $backend_config := include "mozcloud-ingress-lib.config.backends" . | fromYaml }}
 {{- $backends := list }}
+{{- $context := . | deepCopy }}
 {{- range $backend := $backend_config.backends -}}
 {{- if not (has $backend.name $backends) }}
 ---
@@ -9,7 +10,7 @@ kind: BackendConfig
 metadata:
   name: {{ $backend.name }}
   labels:
-    {{- $label_params := dict "labels" (default (default (dict) $backend.ingressConfig.labels) $backend.labels) }}
+    {{- $label_params := mergeOverwrite $context (dict "labels" (default (default (dict) $backend.ingressConfig.labels) $backend.labels)) }}
     {{- $labels := include "mozcloud-ingress-lib.labels" (mergeOverwrite $ $label_params) | fromYaml }}
     {{- $labels | toYaml | nindent 4 }}
 spec:

--- a/mozcloud-ingress/library/templates/_frontendconfig.yaml
+++ b/mozcloud-ingress/library/templates/_frontendconfig.yaml
@@ -6,7 +6,7 @@ kind: FrontendConfig
 metadata:
   name: {{ $frontend_config.name }}
   labels:
-    {{- $label_params := dict "labels" (default (dict) $frontend_config.labels) }}
+    {{- $label_params := mergeOverwrite ($ | deepCopy) (dict "labels" (default (dict) $frontend_config.labels)) }}
     {{- $labels := include "mozcloud-ingress-lib.labels" (mergeOverwrite . $label_params) | fromYaml }}
     {{- $labels | toYaml | nindent 4 }}
 spec:

--- a/mozcloud-ingress/library/templates/_ingress.yaml
+++ b/mozcloud-ingress/library/templates/_ingress.yaml
@@ -16,7 +16,7 @@ kind: Ingress
 metadata:
   name: {{ $ingress_name }}
   labels:
-    {{- $label_params := dict "labels" (default (dict) $ingress.labels) }}
+    {{- $label_params := mergeOverwrite ($ | deepCopy) (dict "labels" (default (dict) $ingress.labels)) }}
     {{- $labels := include "mozcloud-ingress-lib.labels" (mergeOverwrite $ $label_params) | fromYaml }}
     {{- $labels | toYaml | nindent 4 }}
   annotations:

--- a/mozcloud-ingress/library/templates/_managedcertificate.yaml
+++ b/mozcloud-ingress/library/templates/_managedcertificate.yaml
@@ -1,5 +1,5 @@
 {{- define "mozcloud-ingress-lib.managedCertificate" -}}
-{{- $dot := . }}
+{{- $context := . }}
 {{- $managed_certificates := include "mozcloud-ingress-lib.config.managedCertificates" . | fromYamlArray }}
 {{- range $managed_certificate := $managed_certificates }}
 {{- if $managed_certificate.createCertificate }}
@@ -9,7 +9,7 @@ kind: ManagedCertificate
 metadata:
   name: {{ $managed_certificate.name }}
   labels:
-    {{- include "mozcloud-ingress-lib.labels" $dot | nindent 4 }}
+    {{- include "mozcloud-ingress-lib.labels" ($context | deepCopy) | nindent 4 }}
 spec:
   domains:
     {{- range $domain := $managed_certificate.domains }}

--- a/mozcloud-job/application/Chart.yaml
+++ b/mozcloud-job/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.1
+appVersion: 0.2.3
 
 dependencies:
   - name: mozcloud-job-lib
-    version: 0.2.2
+    version: 0.2.3
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts

--- a/mozcloud-job/application/templates/_helpers.tpl
+++ b/mozcloud-job/application/templates/_helpers.tpl
@@ -34,11 +34,11 @@ Create chart name and version as used by the chart label.
 Create label parameters to be used in library chart if defined as values.
 */}}
 {{- define "mozcloud-job.labelParams" -}}
-{{- $params := dict "chartName" (include "mozcloud-job.name" .) -}}
+{{- $params := dict "chart" (include "mozcloud-job.name" .) -}}
 {{- $label_params := list "app_code" "chart" "component_code" "environment" -}}
 {{- range $label_param := $label_params -}}
-  {{- if index $.Values.global $label_param -}}
-    {{- $_ := set $params $label_param (index $.Values.global $label_param) -}}
+  {{- if index $.Values.global.mozcloud $label_param -}}
+    {{- $_ := set $params $label_param (index $.Values.global.mozcloud $label_param) -}}
   {{- end }}
 {{- end }}
 {{- $params | toYaml }}

--- a/mozcloud-job/application/templates/_helpers.tpl
+++ b/mozcloud-job/application/templates/_helpers.tpl
@@ -35,10 +35,10 @@ Create label parameters to be used in library chart if defined as values.
 */}}
 {{- define "mozcloud-job.labelParams" -}}
 {{- $params := dict "chartName" (include "mozcloud-job.name" .) -}}
-{{- $label_params := list "appCode" "component" "environment" -}}
+{{- $label_params := list "app_code" "chart" "component_code" "environment" -}}
 {{- range $label_param := $label_params -}}
-  {{- if index $.Values $label_param -}}
-    {{- $_ := set $params $label_param (index $.Values $label_param) -}}
+  {{- if index $.Values.global $label_param -}}
+    {{- $_ := set $params $label_param (index $.Values.global $label_param) -}}
   {{- end }}
 {{- end }}
 {{- $params | toYaml }}

--- a/mozcloud-job/application/templates/cronjob.yaml
+++ b/mozcloud-job/application/templates/cronjob.yaml
@@ -1,5 +1,8 @@
 {{- if gt (len .Values.cronJobs) 0 }}
-{{- $params := dict "cronJobConfig" (dict "cronJobs" .Values.cronJobs) "nameOverride" (include "mozcloud-job.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "cronJobConfig" (dict "cronJobs" .Values.cronJobs) "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-job.labelParams" . | fromYaml }}
 {{- include "mozcloud-job-lib.cronJob" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-job/application/templates/job.yaml
+++ b/mozcloud-job/application/templates/job.yaml
@@ -1,5 +1,8 @@
 {{- if gt (len .Values.jobs) 0 }}
-{{- $params := dict "jobConfig" (dict "jobs" .Values.jobs) "nameOverride" (include "mozcloud-job.name" .) "Chart" .Chart "Release" .Release }}
+{{- $params := dict "jobConfig" (dict "jobs" .Values.jobs) "Chart" .Chart "Release" .Release }}
+{{- if .Values.nameOverride }}
+  {{- $_ := set $params "nameOverride" .Values.nameOverride }}
+{{- end }}
 {{- $label_params := include "mozcloud-job.labelParams" . | fromYaml }}
 {{- include "mozcloud-job-lib.job" (mergeOverwrite $params $label_params) }}
 {{- end }}

--- a/mozcloud-job/application/values.yaml
+++ b/mozcloud-job/application/values.yaml
@@ -1,18 +1,22 @@
-# Name to be used for all resources if not specified at the resource level.
-# This should match the name of the parent Helm chart.
-#nameOverride:
-
-# Application code. This should match the `app_code` value in your tenant's
-# values.yaml file.
-#appCode:
-
-# Component. This should match the `component` value in your tenant's
-# values.yaml file.
-#component:
-
-# Environment. This should match the `environment` value in your tenant's
-# values-<env>.yaml file.
-#environment:
+# app_code, chart, component_code, and environment should all be defined as
+# global values in the parent Helm chart's values file(s) outside the scope of
+# this Helm chart.
+#
+# For example:
+#
+#   # my-app/values.yaml
+#   global:
+#     mozcloud:
+#       app_code: my-app    # should match app_code in tenant file
+#       chart: my-chart     # the name of the chart
+#       component_code: web # should match component_code in tenant file
+#
+#   # my-app/values-dev.yaml
+#   global:
+#     mozcloud:
+#       environment: dev    # should match .Values.environment
+#
+# These are used to populate labels and metadata in MozCloud charts.
 
 # Define your cron jobs here. These are jobs intended to be run on a schedule.
 cronJobs: []

--- a/mozcloud-job/application/values.yaml
+++ b/mozcloud-job/application/values.yaml
@@ -18,6 +18,11 @@
 #
 # These are used to populate labels and metadata in MozCloud charts.
 
+# Name to be used for all resources if not specified at the resource level.
+# This overrides the chart name set in .Values.global.mozcloud.chart but is
+# overridden by names defined at the resource level.
+#nameOverride:
+
 # Define your cron jobs here. These are jobs intended to be run on a schedule.
 cronJobs: []
   #- name: my-cronjob

--- a/mozcloud-job/library/Chart.yaml
+++ b/mozcloud-job/library/Chart.yaml
@@ -15,12 +15,12 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 dependencies:
   - name: mozcloud-labels-lib
-    version: 0.1.0
+    version: 0.1.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
   - name: mozcloud-workload-core-lib
-    version: 0.3.0
+    version: 0.3.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts

--- a/mozcloud-job/library/Chart.yaml
+++ b/mozcloud-job/library/Chart.yaml
@@ -22,5 +22,5 @@ dependencies:
     version: 0.1.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
   - name: mozcloud-workload-core-lib
-    version: 0.3.1
+    version: 0.4.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts

--- a/mozcloud-job/library/templates/_cronjob.tpl
+++ b/mozcloud-job/library/templates/_cronjob.tpl
@@ -71,7 +71,9 @@ spec:
           serviceAccountName: {{ $job_config.serviceAccount.name }}
           {{- end }}
 {{- if ($job_config.serviceAccount).create }}
-{{- $service_accounts = append $service_accounts (omit $job_config.serviceAccount "create") }}
+{{- $service_account := omit $job_config.serviceAccount "create" -}}
+{{- $_ := set $service_account "labels" $cron_job.labels -}}
+{{- $service_accounts = append $service_accounts $service_account }}
 {{- end }}
 {{- end }}
 {{- if gt (len $service_accounts) 0 }}

--- a/mozcloud-job/library/templates/_job.tpl
+++ b/mozcloud-job/library/templates/_job.tpl
@@ -77,7 +77,9 @@ spec:
       serviceAccountName: {{ $config.serviceAccount.name }}
       {{- end }}
 {{- if ($config.serviceAccount).create }}
-{{- $service_accounts = append $service_accounts (omit $config.serviceAccount "create") }}
+{{- $service_account := omit $config.serviceAccount "create" -}}
+{{- $_ := set $service_account "labels" $job.labels -}}
+{{- $service_accounts = append $service_accounts $service_account }}
 {{- end }}
 {{- end }}
 {{- if gt (len $service_accounts) 0 }}

--- a/mozcloud-kit/application/Chart.yaml
+++ b/mozcloud-kit/application/Chart.yaml
@@ -9,11 +9,11 @@
 apiVersion: v2
 name: mozcloud-kit
 description: mozcloud opinionated bundle of helm charts
-version: 0.2.0
+version: 0.2.1
 type: application
 dependencies:
   - name: mozcloud-labels-lib
-    version: 0.1.0
+    version: 0.1.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
 
   - name: mozcloud-deployment

--- a/mozcloud-labels/library/Chart.yaml
+++ b/mozcloud-labels/library/Chart.yaml
@@ -15,4 +15,4 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1

--- a/mozcloud-labels/library/templates/_labels.yaml
+++ b/mozcloud-labels/library/templates/_labels.yaml
@@ -1,7 +1,7 @@
 {{- define "mozcloud-labels-lib.labels" -}}
 {{- $chart_name := "" }}
-{{- if .chartName }}
-  {{- $chart_name = .chartName }}
+{{- if .chart }}
+  {{- $chart_name = .chart }}
 {{- else if (.Chart).Name }}
   {{- $chart_name = .Chart.Name }}
 {{- else if (.Chart).name }}

--- a/mozcloud-labels/library/templates/_selectorlabels.yaml
+++ b/mozcloud-labels/library/templates/_selectorlabels.yaml
@@ -1,11 +1,5 @@
 {{- define "mozcloud-labels-lib.selectorLabels" -}}
-{{- if .appCode }}
-app.kubernetes.io/name: {{ .appCode }}
-{{- end -}}
-{{- if .component }}
-app.kubernetes.io/component: {{ .component }}
-{{- end -}}
-{{- if .environment }}
+app.kubernetes.io/name: {{ .app_code }}
+app.kubernetes.io/component: {{ .component_code }}
 env_code: {{ .environment }}
-{{- end -}}
 {{- end -}}

--- a/mozcloud-preview/library/Chart.yaml
+++ b/mozcloud-preview/library/Chart.yaml
@@ -19,10 +19,10 @@ version: 0.2.4
 
 dependencies:
   - name: mozcloud-labels-lib
-    version: 0.1.0
+    version: 0.1.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
   - name: mozcloud-service-lib
-    version: 0.2.1
+    version: 0.2.2
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
   - name: mozcloud-gateway-lib
     version: 0.2.6

--- a/mozcloud-service/library/Chart.yaml
+++ b/mozcloud-service/library/Chart.yaml
@@ -15,9 +15,9 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 dependencies:
   - name: mozcloud-labels-lib
-    version: 0.1.0
+    version: 0.1.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts

--- a/mozcloud-workload-core/library/Chart.yaml
+++ b/mozcloud-workload-core/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-workload-core/library/templates/_helpers.tpl
+++ b/mozcloud-workload-core/library/templates/_helpers.tpl
@@ -99,12 +99,12 @@ ConfigMap template helpers
 */}}
 {{- define "mozcloud-workload-core-lib.config.configMaps" -}}
 {{- $config_maps := .configMaps -}}
-{{- $labels := default (dict) .labels -}}
 {{- $name_override := default "" .nameOverride -}}
 {{- $output := list -}}
 {{- range $config_map := $config_maps -}}
   {{- $config_map_config := $config_map | deepCopy -}}
   {{- /* Configure name and labels */ -}}
+  {{- $labels := default (dict) $config_map_config.labels -}}
   {{- $params := dict "config" $config_map_config "context" ($ | deepCopy) "labels" $labels -}}
   {{- $common := include "mozcloud-workload-core-lib.config.common" $params | fromYaml -}}
   {{- $config_map_config = mergeOverwrite $config_map_config $common -}}
@@ -124,13 +124,13 @@ ExternalSecret template helpers
 {{- $app_code := default "" .appCode -}}
 {{- $environment := default "" .environment -}}
 {{- $external_secrets := .externalSecrets -}}
-{{- $labels := default (dict) .labels -}}
 {{- $name_override := default "" .nameOverride -}}
 {{- $output := list -}}
 {{- range $external_secret := $external_secrets -}}
   {{- $defaults := include "mozcloud-workload-core-lib.defaults.externalSecret.config" $ | fromYaml -}}
   {{- $external_secret_config := mergeOverwrite $defaults $external_secret -}}
   {{- /* Configure name and labels */ -}}
+  {{- $labels := default (dict) $external_secret_config.labels -}}
   {{- $params := dict "config" $external_secret_config "context" ($ | deepCopy) "labels" $labels -}}
   {{- $common := include "mozcloud-workload-core-lib.config.common" $params | fromYaml -}}
   {{- $external_secret_config = mergeOverwrite $external_secret_config $common -}}
@@ -165,7 +165,6 @@ ServiceAccount template helpers
 {{- end -}}
 
 {{- define "mozcloud-workload-core-lib.config.serviceAccounts" -}}
-{{- $labels := default (dict) .labels -}}
 {{- $name_override := default "" .nameOverride -}}
 {{- $service_accounts := .serviceAccounts -}}
 {{- $output := list -}}
@@ -173,6 +172,7 @@ ServiceAccount template helpers
   {{- $defaults := include "mozcloud-workload-core-lib.defaults.serviceAccount.config" $ | fromYaml -}}
   {{- $service_account_config := mergeOverwrite $defaults $service_account -}}
   {{- /* Configure name and labels */ -}}
+  {{- $labels := default (dict) $service_account_config.labels -}}
   {{- $params := dict "config" $service_account_config "context" ($ | deepCopy) "labels" $labels -}}
   {{- $common := include "mozcloud-workload-core-lib.config.common" $params | fromYaml -}}
   {{- $service_account_config = mergeOverwrite $service_account_config $common -}}
@@ -204,4 +204,11 @@ gsm:
 
 {{- define "mozcloud-workload-core-lib.defaults.serviceAccount.config" -}}
 name: {{ include "mozcloud-workload-core-lib.config.name" . }}
+{{- end -}}
+
+{{/*
+Debug helper
+*/}}
+{{- define "mozcloud-workload-core-lib.debug" -}}
+{{- . | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
 {{- end -}}

--- a/mozcloud-workload-core/library/values.yaml.example
+++ b/mozcloud-workload-core/library/values.yaml.example
@@ -33,6 +33,10 @@ configMaps:
     # Any annotations that should be added, if applicable. One common use case
     # would be annotations for Argo CD, such as sync waves.
     #annotations: {}
+
+    # Any labels that should be added.
+    #labels: {}
+
   - name: config-map2
     data:
       KEY: value
@@ -44,7 +48,7 @@ externalSecrets:
     #refreshInterval: 10m
 
     # Name of the K8s secret where the external secret is synced to. Optional
-    # if you specify ".Values.global.appCode" in your parent chart.
+    # if you specify ".Values.global.mozcloud.appCode" in your parent chart.
     target: my-k8s-secret
 
     # This section is optional if you specify "environment" and are fine with
@@ -56,6 +60,9 @@ externalSecrets:
     # Any annotations that should be added, if applicable. One common use case
     # would be annotations for Argo CD, such as sync waves.
     #annotations: {}
+
+    # Any labels that should be added.
+    #labels: {}
 
 serviceAccounts:
   - name: mozcloud-workload-core
@@ -84,6 +91,5 @@ serviceAccounts:
     # would be annotations for Argo CD, such as sync waves.
     #annotations: {}
 
-# Specifying labels here will apply them to all resources created in this
-# library chart.
-labels: {}
+    # Any labels that should be added.
+    #labels: {}

--- a/mozcloud-workload-core/library/values.yaml.example
+++ b/mozcloud-workload-core/library/values.yaml.example
@@ -21,6 +21,11 @@
 #
 # These are used to populate labels and metadata in MozCloud charts.
 
+# Name to be used for all resources if not specified at the resource level.
+# This overrides the chart name set in .Values.global.mozcloud.chart but is
+# overridden by names defined at the resource level.
+#nameOverride:
+
 configMaps:
   - name: config-map1
 

--- a/mozcloud-workload-core/library/values.yaml.example
+++ b/mozcloud-workload-core/library/values.yaml.example
@@ -1,34 +1,25 @@
 # Example values showing a visual representation of the parameters accepted by
 # this library chart.
 
-# This is used to populate the default value for "target" for ExternalSecret
-# resources.
-appCode: tenant-name
-
-# This is used to populate the default value for "gsm.secret" for ExternalSecret
-# resources.
-environment: dev
-
-# If you set this, it will be the default name for all resources if not
-# specified at the resource level.
+# app_code, chart, component_code, and environment should all be defined as
+# global values in the parent Helm chart's values file(s) outside the scope of
+# this Helm chart.
 #
-# Ideally, resources would be named in a way that follows this hierarchy:
+# For example:
 #
-#    1. Name set at the subcomponent/most specific level (eg. backend service
-#       name), if applicable.
-#    2. Name set at the component/parent level (eg. HTTPRoute).
-#    3. Name of the chart (equivalent to "application.fullname"). <- we are here
-#    4. Default name of the library chart (eg. mozcloud-gateway).
+#   # my-app/values.yaml
+#   global:
+#     mozcloud:
+#       app_code: my-app    # should match app_code in tenant file
+#       chart: my-chart     # the name of the chart
+#       component_code: web # should match component_code in tenant file
 #
-# Subcharts cannot pull metadata or values from parent charts unless the parent
-# chart passes them in as parameters. Rather than asking users to specify their
-# chart name as part of their values files, I went with the approach of
-# allowing users to specify a name that would be used if component/subcomponent
-# names were not set.
+#   # my-app/values-dev.yaml
+#   global:
+#     mozcloud:
+#       environment: dev    # should match .Values.environment
 #
-# If no names are set at all in this chart, the default library chart name will
-# be used: mozcloud-workload-core.
-nameOverride: name-to-use-for-everything
+# These are used to populate labels and metadata in MozCloud charts.
 
 configMaps:
   - name: config-map1
@@ -53,7 +44,7 @@ externalSecrets:
     #refreshInterval: 10m
 
     # Name of the K8s secret where the external secret is synced to. Optional
-    # if you specify "appCode".
+    # if you specify ".Values.global.appCode" in your parent chart.
     target: my-k8s-secret
 
     # This section is optional if you specify "environment" and are fine with


### PR DESCRIPTION
Several changes here:
- Use global values on all Helm charts (`.Values.global.mozcloud`)
- Use `app_code` and `component_code` labels to match current standards
- Look for chart name in `$.Values.global.mozcloud.chart` first now
- Define labels at the resource level in the `mozcloud-workload-core-lib` chart
- Version bumps for all affected Helm charts