### PR TITLE
Mzcld 883 update httproute hosts

### DIFF
--- a/mozcloud-gateway/application/Chart.yaml
+++ b/mozcloud-gateway/application/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.4
+appVersion: 0.2.6
 
 dependencies:
   - name: mozcloud-gateway-lib
-    version: 0.2.5
+    version: 0.2.6
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts

--- a/mozcloud-gateway/library/Chart.yaml
+++ b/mozcloud-gateway/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-gateway/library/templates/_httproute.yaml
+++ b/mozcloud-gateway/library/templates/_httproute.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   parentRefs:
     {{- range $gateway_ref := $http_route.gatewayRefs }}
-    - kind: Gateway
+    - group: gateway.networking.k8s.io
+      kind: Gateway
       name: {{ $gateway_ref.name }}
       {{- if $gateway_ref.namespace }}
       namespace: {{ $gateway_ref.namespace }}
@@ -26,7 +27,9 @@ spec:
     {{- range $rule := $http_route.rules }}
     - backendRefs:
       {{- range $backend_ref := $rule.backendRefs }}
-      - name: {{ $backend_ref.name }}
+      - group: ''
+        kind: Service
+        name: {{ $backend_ref.name }}
         port: {{ $backend_ref.port }}
         {{- if $backend_ref.weight }}
         weight: {{ $backend_ref.weight }}
@@ -96,7 +99,8 @@ metadata:
 spec:
   parentRefs:
     {{- range $gateway_ref := $http_route.gatewayRefs }}
-    - kind: Gateway
+    - group: gateway.networking.k8s.io
+      kind: Gateway
       name: {{ $gateway_ref.name }}
       {{- if $gateway_ref.namespace }}
       namespace: {{ $gateway_ref.namespace }}
@@ -112,6 +116,11 @@ spec:
       - type: RequestRedirect
         requestRedirect:
           scheme: https
+          statusCode: 302
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/mozcloud-preview/application/Chart.yaml
+++ b/mozcloud-preview/application/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
 - name: mozcloud-preview-lib
-  version: 0.2.3
+  version: 0.2.4
   repository: file://../library

--- a/mozcloud-preview/application/values.yaml
+++ b/mozcloud-preview/application/values.yaml
@@ -105,3 +105,8 @@ httpRoute:
               # The name of the backend service
             - name: mozcloud-gateway
               port: 8080
+              weight: 1
+          matches:
+            - path:
+                type: PathPrefix
+                value: /

--- a/mozcloud-preview/library/Chart.yaml
+++ b/mozcloud-preview/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 dependencies:
   - name: mozcloud-labels-lib
@@ -25,5 +25,5 @@ dependencies:
     version: 0.2.1
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
   - name: mozcloud-gateway-lib
-    version: 0.2.5
+    version: 0.2.6
     repository: file://../../mozcloud-gateway/library

--- a/mozcloud-preview/library/templates/_httproute.yaml
+++ b/mozcloud-preview/library/templates/_httproute.yaml
@@ -6,8 +6,6 @@
 
 {{- $svcName := printf "pr%s-%s" $previewPr .Chart.Name -}}
 
-
-
 {{- range $route := $rawRoutes }}
   {{- $newHostnames := list }}
 

--- a/mozcloud-preview/library/templates/_httproute.yaml
+++ b/mozcloud-preview/library/templates/_httproute.yaml
@@ -6,12 +6,21 @@
 
 {{- $svcName := printf "pr%s-%s" $previewPr .Chart.Name -}}
 
+
+
 {{- range $route := $rawRoutes }}
   {{- $newHostnames := list }}
 
   {{- range $i, $hostname := $route.hostnames }}
     {{- $prefix := first (splitList "." (print $hostname)) }}
-    {{- $prefixed := printf "%s-%s" $prefix $previewHost }}
+
+    {{- $prefixed := "" -}}
+    {{- if gt (len $rawRoutes) 1 }}
+      {{- $prefixed = printf "%s-%s" $prefix $previewHost }}
+    {{- else }}
+      {{- $prefixed = printf "%s" $previewHost }}
+    {{- end }}
+
     {{- $newHostnames = append $newHostnames $prefixed }}
   {{- end }}
 


### PR DESCRIPTION
**CHANGES:** 

**mozcloud-gateway:** 
* Incremented versions 
* added missing group, and kind. These were being added by the gateway controller but were causing sync loops in Argo 
* added static status code and matches to HTTP redirect, this is also the default that is added by the gw controller 


**mozcloud-preview:**
* added default weight and path 
* updated httproute hosts to exclude prefix if we only have one backend 
* using updated mozcloud-gateway chart