### PR TITLE
Mzcld 907 include pr based selector

### DIFF
--- a/mozcloud-preview/application/Chart.yaml
+++ b/mozcloud-preview/application/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mozcloud-preview/application/templates/preview.yaml
+++ b/mozcloud-preview/application/templates/preview.yaml
@@ -12,6 +12,16 @@
     "httpRoutes" $httpRoutes
 }}
 
+{{- $transformedBackends := list }}
+{{- range .Values.backends }}
+  {{- $be := deepCopy . }}
+  {{- $base := default (dict) $be.service.selectorLabels -}}
+  {{- $labels := merge (dict) $base -}}
+  {{- $_ := set $labels "app.preview/pr" $previewPr -}}
+  {{- $_ := set $be.service "selectorLabels" $labels -}}
+  {{- $transformedBackends = append $transformedBackends $be -}}
+{{- end }}
+
 {{- $params := dict
     "httpRouteConfig" $httpRouteConfig
     "backendConfig" (dict "backends" .Values.backends)
@@ -21,6 +31,8 @@
     "previewPr" $previewPr
     "previewHost" (.Values.global.preview.host | toString)
 }}
+
+{{- include "mozcloud-preview-lib.debug" $transformedBackends  -}}
 
 {{- include "mozcloud-preview-lib.httpRoute" $params }}
 {{- include "mozcloud-preview-lib.endpointcheck" $params }}

--- a/mozcloud-preview/application/templates/preview.yaml
+++ b/mozcloud-preview/application/templates/preview.yaml
@@ -24,7 +24,7 @@
 
 {{- $params := dict
     "httpRouteConfig" $httpRouteConfig
-    "backendConfig" (dict "backends" .Values.backends)
+    "backendConfig" (dict "backends" $transformedBackends)
     "nameOverride" (printf "pr%s-%s" $previewPr (include "mozcloud-preview.name" .))
     "Chart" .Chart
     "Release" .Release

--- a/mozcloud-preview/application/templates/preview.yaml
+++ b/mozcloud-preview/application/templates/preview.yaml
@@ -32,8 +32,6 @@
     "previewHost" (.Values.global.preview.host | toString)
 }}
 
-{{- include "mozcloud-preview-lib.debug" $transformedBackends  -}}
-
 {{- include "mozcloud-preview-lib.httpRoute" $params }}
 {{- include "mozcloud-preview-lib.endpointcheck" $params }}
 {{- include "mozcloud-gateway-lib.service" $params }}


### PR DESCRIPTION
**CHANGES:** 
* Incremented mozcloud-preview chart 
* Appending pr number to selector labels dict to ensure we are only selecting deployments within the matching pr 