### PR TITLE
fix(mozcloud-preview): fix version of gateway dependency

### DIFF
--- a/mozcloud-preview/library/Chart.yaml
+++ b/mozcloud-preview/library/Chart.yaml
@@ -25,5 +25,5 @@ dependencies:
     version: 0.2.2
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
   - name: mozcloud-gateway-lib
-    version: 0.2.6
+    version: 0.2.7
     repository: file://../../mozcloud-gateway/library


### PR DESCRIPTION
This should fix https://github.com/mozilla/helm-charts/actions/runs/17411119003/job/49428283925