### PR TITLE
feat(mozcloud-preview): use updated dependency charts requiring dicts

### DIFF
--- a/mozcloud-preview/application/Chart.yaml
+++ b/mozcloud-preview/application/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.8
+version: 0.3.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: 1.16.0
 
 dependencies:
   - name: mozcloud-preview-lib
-    version: 0.2.9
+    version: 0.2.10
     repository: file://../library

--- a/mozcloud-preview/application/templates/preview.yaml
+++ b/mozcloud-preview/application/templates/preview.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.enabled }}
 {{- $previewPr := .Values.global.preview.pr | toString }}
-{{- $httpRoutes := list }}
-{{- range .Values.httpRoute.httpRoutes }}
-  {{- $route := deepCopy . }}
-  {{- $_ := set $route "name" (printf "pr%s-%s" $previewPr .name) }}
-  {{- $httpRoutes = append $httpRoutes $route }}
+{{- $httpRoutes := dict }}
+{{- range $name, $config := .Values.httpRoute.httpRoutes }}
+  {{- $route := deepCopy $config }}
+  {{- $name = printf "pr%s-%s" $previewPr $name }}
+  {{- $_ := set $httpRoutes $name $route }}
 {{- end }}
 
 {{- $httpRouteConfig := dict
@@ -12,14 +12,15 @@
     "httpRoutes" $httpRoutes
 }}
 
-{{- $transformedBackends := list }}
-{{- range .Values.backends }}
-  {{- $be := deepCopy . }}
+{{- $transformedBackends := dict }}
+{{- range $name, $config := .Values.backends }}
+  {{- $name = printf "pr%s-%s" $previewPr (include "mozcloud-preview.name" $) }}
+  {{- $be := deepCopy $config }}
   {{- $base := default (dict) $be.service.selectorLabels -}}
   {{- $labels := merge (dict) $base -}}
   {{- $_ := set $labels "app.preview/pr" $previewPr -}}
-  {{- $_ := set $be.service "selectorLabels" $labels -}}
-  {{- $transformedBackends = append $transformedBackends $be -}}
+  {{- $_ = set $be.service "selectorLabels" $labels -}}
+  {{- $_ = set $transformedBackends $name $be -}}
 {{- end }}
 
 {{- $label_params := include "mozcloud-preview.labelParams" . | fromYaml }}

--- a/mozcloud-preview/application/values.yaml
+++ b/mozcloud-preview/application/values.yaml
@@ -9,8 +9,10 @@ global:
 
 # Defines the backend services to create, backend policies, and healthchecks.
 backends:
+  # The name of the backend service.
+  mozcloud-gateway:
     # Definitions for the Kubernetes service.
-  - service:
+    service:
       # If disabled, a new Kubernetes will not be created.
       #create: true
 
@@ -35,9 +37,6 @@ backends:
 
       # Selector labels the service should use to match against pods.
       #selectorLabels: {}
-
-    # Set a name for the backend to use for all related components.
-    #name:
 
     # Backend policy to apply to this specific backend service. Overrides the
     # defaults from .Values.backendPolicy
@@ -89,7 +88,8 @@ httpRoute:
   enabled: true
 
   httpRoutes:
-    - name: mozcloud-gateway
+    # The name of the HTTPRoute to create.
+    mozcloud-gateway:
       # Hostnames to match against. Hostnames are matched before any other
       # matches (path, headers) occur.
       hostnames:

--- a/mozcloud-preview/library/Chart.yaml
+++ b/mozcloud-preview/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.9
+version: 0.2.10
 
 dependencies:
   - name: mozcloud-labels-lib
@@ -27,5 +27,5 @@ dependencies:
     repository: file://../../mozcloud-service/library
 
   - name: mozcloud-gateway-lib
-    version: 0.3.3
+    version: 0.4.2
     repository: file://../../mozcloud-gateway/library

--- a/mozcloud-preview/library/templates/_httproute.yaml
+++ b/mozcloud-preview/library/templates/_httproute.yaml
@@ -2,11 +2,11 @@
 {{- $rawRoutes := .httpRouteConfig.httpRoutes }}
 {{- $previewHost := .previewHost }}
 {{- $previewPr := .previewPr }}
-{{- $transformedRoutes := list }}
+{{- $transformedRoutes := dict }}
 
 {{- $svcName := printf "pr%s-%s" $previewPr .Chart.Name -}}
 
-{{- range $route := $rawRoutes }}
+{{- range $name, $route := $rawRoutes }}
   {{- $newHostnames := list }}
 
   {{- range $i, $hostname := $route.hostnames }}
@@ -41,7 +41,7 @@
     ))
     "rules" $transformedRules
   ) }}
-  {{- $transformedRoutes = append $transformedRoutes $updatedRoute }}
+  {{- $_ := set $transformedRoutes $name $updatedRoute }}
 {{- end }}
 
 {{- $transformedConfig := dict "httpRoutes" $transformedRoutes }}


### PR DESCRIPTION
This implements the changes from https://github.com/mozilla/helm-charts/pull/75 into the mozcloud-preview chart. As part of this, I needed to do some mild reworks of how we generate parameters for the gateway library chart.