### PR TITLE
fix(mozcloud-preview): include mozcloud-preview-lib name in mozcloud-preview endpoint check

### DIFF
--- a/mozcloud-preview/application/Chart.yaml
+++ b/mozcloud-preview/application/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.9
+version: 0.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: 1.16.0
 
 dependencies:
   - name: mozcloud-preview-lib
-    version: 0.2.10
+    version: 0.2.11
     repository: file://../library

--- a/mozcloud-preview/library/Chart.yaml
+++ b/mozcloud-preview/library/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-preview/library/templates/_endpointcheck.yaml
+++ b/mozcloud-preview/library/templates/_endpointcheck.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: pr{{ $config.pr -}}-endpoint-check
+  name: {{ include "mozcloud-preview-lib.name" $ -}}-endpoint-check
   labels:
     {{- $config.labels | toYaml | nindent 4 }}
   annotations:


### PR DESCRIPTION
**CHANGES:** 
* Include full `"mozcloud-preview-lib.name"` in endpoint check resource name 
* Incremented chart versions 