### PR TITLE
feat: ConfigMap tpl improvements

### DIFF
--- a/mozcloud/application/Chart.yaml
+++ b/mozcloud/application/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mozcloud
 description: Opinionated application chart used to deploy MozCloud Kubernetes 
   resources supporting resources
-version: 1.6.2
+version: 1.6.3
 type: application
 dependencies:
   - name: mozcloud-gateway-lib

--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -1,6 +1,6 @@
 # mozcloud
 
-![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.6.3](https://img.shields.io/badge/Version-1.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Opinionated application chart used to deploy MozCloud Kubernetes resources supporting resources
 
@@ -19,7 +19,7 @@ version: 0.1.0
 type: application
 dependencies:
   - name: mozcloud
-    version: ~1.6.2
+    version: ~1.6.3
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
 ```
 

--- a/mozcloud/application/templates/configmap/_helpers.tpl
+++ b/mozcloud/application/templates/configmap/_helpers.tpl
@@ -69,7 +69,7 @@ Example:
     {{- if $config.tplEnabled }}
       {{- $params := dict "data" $config.data "context" $context }}
       {{- $transformedData := include "mozcloud.configMap.formatter.renderTpl" $params | fromYaml -}}
-      {{- $config = mergeOverwrite $config (dict "data" $transformedData) -}}
+      {{- $_ := set $config "data" $transformedData -}}
     {{- $_ := set $output $name $config}}
     {{- end -}}
   {{- end -}}
@@ -77,24 +77,29 @@ Example:
 {{- end -}}
 
 {{- /*
-  Ranges over a dictionary and looks for an embedded template in the value string
-  If found it checks for compliance and if that passes calls the `tpl` function rendering
-  the embedded template.
+  Ranges over a dictionary and renders template expressions in values using `tpl`.
+  Blocks dangerous functions (lookup, env) via a blocklist. If a rendered value
+  is empty, the key is omitted from the output.
 */ -}}
 {{- define "mozcloud.configMap.formatter.renderTpl" }}
 {{- $ctx := .context }}
 {{- $output := deepCopy .data }}
-{{- $simpleRegexp := `{{-?\s*[^}]+}}`}}
-{{- $filterRegexp := `{{-?\s*(?:default\s+"[^"]*"\s+)?\.Values(?:\.[a-zA-Z_]\w*)*\s*-?}}` }}
+{{- $tplRegexp := `{{-?\s*[^}]+}}` }}
+{{- $blockRegexp := `\b(lookup|env|expandenv|getHostByName)\b` }}
 {{- range $key, $value := .data }}
-  {{- $hasTpl := false }}
-  {{- /* Checks all template matches to see if they match the expected form */ -}}
-  {{- range $_, $match := regexFindAll $simpleRegexp (toString $value) -1 }}
-    {{- $hasTpl =  regexMatch $filterRegexp $match }}
-  {{- end }}
-  {{- if $hasTpl }}
+  {{- $matches := regexFindAll $tplRegexp (toString $value) -1 }}
+  {{- if $matches }}
+    {{- range $_, $match := $matches }}
+      {{- if regexMatch $blockRegexp $match }}
+        {{- fail (printf "configMap tplEnabled: expression %q in key %q uses a blocked function" $match $key) }}
+      {{- end }}
+    {{- end }}
     {{- $newVal := tpl $value $ctx }}
-    {{- $_ := set $output $key $newVal }}
+    {{- if and (ne $newVal "") (ne $newVal "<nil>") (ne $newVal "<no value>") }}
+      {{- $_ := set $output $key $newVal }}
+    {{- else }}
+      {{- $_ := unset $output $key }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{ $output | toYaml }}

--- a/mozcloud/application/templates/configmap/_helpers.tpl
+++ b/mozcloud/application/templates/configmap/_helpers.tpl
@@ -94,12 +94,7 @@ Example:
         {{- fail (printf "configMap tplEnabled: expression %q in key %q uses a blocked function" $match $key) }}
       {{- end }}
     {{- end }}
-    {{- $newVal := tpl $value $ctx }}
-    {{- if and (ne $newVal "") (ne $newVal "<nil>") (ne $newVal "<no value>") }}
-      {{- $_ := set $output $key $newVal }}
-    {{- else }}
-      {{- $_ := unset $output $key }}
-    {{- end }}
+    {{- $_ := set $output $key (tpl $value $ctx) }}
   {{- end }}
 {{- end }}
 {{ $output | toYaml }}

--- a/mozcloud/application/tests/__snapshot__/configmap-tpl_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/configmap-tpl_test.yaml.snap
@@ -1,0 +1,25 @@
+Snapshot of full rendered ConfigMap:
+  1: |
+    apiVersion: v1
+    data:
+      MIXED_VALUE: prefix-dev-suffix
+      MULTI_VAL: 1,2
+      NULL_VALUE: ""
+      RESOLVED_VALUE: mozcloud-test
+      STATIC_KEY: no-template-here
+    kind: ConfigMap
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-wave: "-11"
+      labels:
+        app.kubernetes.io/component: configmap
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: configmap
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-tpl-configmap

--- a/mozcloud/application/tests/configmap-tpl_test.yaml
+++ b/mozcloud/application/tests/configmap-tpl_test.yaml
@@ -1,0 +1,58 @@
+---
+suite: "mozcloud: ConfigMap tpl rendering"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/configmap-tpl.yaml
+templates:
+  - configmap/configmap.yaml
+tests:
+  - it: Ensure no failures occur
+    asserts:
+      - notFailedTemplate: {}
+  - it: Resolves template expressions to their values
+    asserts:
+      - equal:
+          path: data.RESOLVED_VALUE
+          value: "mozcloud-test"
+  - it: Omits keys where the template expression resolves to null
+    asserts:
+      - notExists:
+          path: data.NULL_VALUE
+  - it: Preserves static values without template expressions
+    asserts:
+      - equal:
+          path: data.STATIC_KEY
+          value: "no-template-here"
+  - it: Resolves template expressions embedded in a larger string
+    asserts:
+      - equal:
+          path: data.MIXED_VALUE
+          value: "prefix-dev-suffix"
+  - it: Omits keys where the value is explicitly null
+    asserts:
+      - notExists:
+          path: data.NULL_EXCLUDED
+  - it: Omits keys where default returns nil
+    asserts:
+      - notExists:
+          path: data.NIL_EXCLUDED
+  - it: Resolves piped template expressions
+    asserts:
+      - equal:
+          path: data.MULTI_VAL
+          value: "1,2"
+  - it: Fails when a blocked function is used
+    set:
+      configMaps:
+        test-tpl-configmap:
+          tplEnabled: true
+          data:
+            BAD_KEY: '{{ lookup "v1" "Secret" "default" "mysecret" }}'
+    asserts:
+      - failedTemplate:
+          errorPattern: "uses a blocked function"

--- a/mozcloud/application/tests/configmap-tpl_test.yaml
+++ b/mozcloud/application/tests/configmap-tpl_test.yaml
@@ -19,10 +19,11 @@ tests:
       - equal:
           path: data.RESOLVED_VALUE
           value: "mozcloud-test"
-  - it: Omits keys where the template expression resolves to null
+  - it: Renders empty string for null template expressions
     asserts:
-      - notExists:
+      - equal:
           path: data.NULL_VALUE
+          value: ""
   - it: Preserves static values without template expressions
     asserts:
       - equal:
@@ -33,14 +34,6 @@ tests:
       - equal:
           path: data.MIXED_VALUE
           value: "prefix-dev-suffix"
-  - it: Omits keys where the value is explicitly null
-    asserts:
-      - notExists:
-          path: data.NULL_EXCLUDED
-  - it: Omits keys where default returns nil
-    asserts:
-      - notExists:
-          path: data.NIL_EXCLUDED
   - it: Resolves piped template expressions
     asserts:
       - equal:

--- a/mozcloud/application/tests/configmap-tpl_test.yaml
+++ b/mozcloud/application/tests/configmap-tpl_test.yaml
@@ -39,6 +39,9 @@ tests:
       - equal:
           path: data.MULTI_VAL
           value: "1,2"
+  - it: Snapshot of full rendered ConfigMap
+    asserts:
+      - matchSnapshot: {}
   - it: Fails when a blocked function is used
     set:
       configMaps:

--- a/mozcloud/application/tests/values/configmap-tpl.yaml
+++ b/mozcloud/application/tests/values/configmap-tpl.yaml
@@ -1,0 +1,28 @@
+---
+global:
+  config:
+    endpoint: null
+    multi_val:
+      - 1
+      - 2
+
+workloads:
+  test-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+
+configMaps:
+  test-tpl-configmap:
+    tplEnabled: true
+    data:
+      RESOLVED_VALUE: "{{ .Values.global.mozcloud.app_code }}"
+      NULL_VALUE: "{{ .Values.nonexistent }}"
+      STATIC_KEY: "no-template-here"
+      MIXED_VALUE: "prefix-{{ .Values.global.mozcloud.env_code }}-suffix"
+      NIL_EXCLUDED: "{{ default nil .Values.global.mozcloud.nonexistent }}"
+      NULL_EXCLUDED: "{{ .Values.global.config.endpoint }}"
+      MULTI_VAL: '{{ .Values.global.config.multi_val | join "," }}'

--- a/mozcloud/application/tests/values/configmap-tpl.yaml
+++ b/mozcloud/application/tests/values/configmap-tpl.yaml
@@ -1,7 +1,6 @@
 ---
 global:
   config:
-    endpoint: null
     multi_val:
       - 1
       - 2
@@ -23,6 +22,4 @@ configMaps:
       NULL_VALUE: "{{ .Values.nonexistent }}"
       STATIC_KEY: "no-template-here"
       MIXED_VALUE: "prefix-{{ .Values.global.mozcloud.env_code }}-suffix"
-      NIL_EXCLUDED: "{{ default nil .Values.global.mozcloud.nonexistent }}"
-      NULL_EXCLUDED: "{{ .Values.global.config.endpoint }}"
       MULTI_VAL: '{{ .Values.global.config.multi_val | join "," }}'


### PR DESCRIPTION


## Summary

- **Replaced allowlist with blocklist in `renderTpl`**: The `tplEnabled` configmap helper previously used a narrow regex allowlist that only allowed simple `.Values.x.y` expressions, silently skipping anything else. Now any template expression is allowed except dangerous functions (`lookup`, `env`, `expandenv`, `getHostByName`), which fail loudly.
- **Fixed `mergeOverwrite` preventing data updates**: `formatter.tpl` used `mergeOverwrite` which did a deep merge of the data dict, preventing key changes from propagating. Replaced with `set` for direct assignment.

## Test plan

- [x] New test suite `configmap-tpl_test.yaml` covering: resolved values, null-to-empty-string rendering, static passthrough, mixed expressions, piped functions, and blocked function rejection
- [x] All existing test suites pass via `make unit-tests`