### PR TITLE
feat: Add image helper and `registry` parameter

### DIFF
--- a/mozcloud/application/Chart.yaml
+++ b/mozcloud/application/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mozcloud
 description: Opinionated application chart used to deploy MozCloud Kubernetes 
   resources supporting resources
-version: 1.3.0
+version: 1.4.0
 type: application
 dependencies:
   - name: mozcloud-gateway-lib

--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -1,6 +1,6 @@
 # mozcloud
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Opinionated application chart used to deploy MozCloud Kubernetes resources supporting resources
 
@@ -19,7 +19,7 @@ version: 0.1.0
 type: application
 dependencies:
   - name: mozcloud
-    version: ~1.3.0
+    version: ~1.4.0
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
 ```
 

--- a/mozcloud/application/templates/_helpers.tpl
+++ b/mozcloud/application/templates/_helpers.tpl
@@ -95,6 +95,48 @@ Returns:
   Never returns — always fails with the JSON-serialized value as the error
   message.
 */ -}}
+{{- /*
+Resolves and renders a fully qualified container image string (repository:tag).
+
+Resolution order for both repository and tag:
+  1. Container-level image config (per-workload override).
+  2. Global image config (.Values.global.mozcloud.image).
+  3. Fail with a descriptive error if neither is set.
+
+If globalImage.registry is set, it is prepended to the resolved repository
+as "registry/repository" — unless the repository already starts with the
+registry value (to avoid double-prefixing).
+
+Params:
+  containerImage (dict): The container-level image config (image.repository, image.tag).
+  globalImage    (dict): The global image config (.Values.global.mozcloud.image).
+  workloadName   (string): Name of the workload (for error messages).
+  containerName  (string): Name of the container (for error messages).
+
+Returns:
+  (string) A fully qualified image reference, e.g. "registry/repo:tag".
+*/ -}}
+{{- define "mozcloud.image" -}}
+{{- $containerImage := default dict .containerImage }}
+{{- $globalImage := default dict .globalImage }}
+{{- $workloadName := .workloadName }}
+{{- $containerName := .containerName }}
+{{- $repo := default ($globalImage.repository) ($containerImage.repository) }}
+{{- if not $repo }}
+  {{- fail (printf "Container image repository must be set for workload %q container %q. Set .Values.mozcloud.workloads.%s.containers.%s.image.repository or .Values.global.mozcloud.image.repository." $workloadName $containerName $workloadName $containerName) }}
+{{- end }}
+{{- $tag := default ($globalImage.tag) ($containerImage.tag) }}
+{{- if not $tag }}
+  {{- fail (printf "Container image tag must be set for workload %q container %q. Set .Values.mozcloud.workloads.%s.containers.%s.image.tag or .Values.global.mozcloud.image.tag." $workloadName $containerName $workloadName $containerName) }}
+{{- end }}
+{{- $registry := default ($globalImage.registry) ($containerImage.registry) | default "" }}
+{{- if and $registry (not (hasPrefix $registry $repo)) }}
+  {{- $repo = printf "%s/%s" $registry $repo }}
+{{- end }}
+{{- printf "%s:%s" $repo $tag }}
+{{- end }}
+
+
 {{- define "mozcloud.debug" -}}
 {{- . | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
 {{- end -}}

--- a/mozcloud/application/templates/_helpers.tpl
+++ b/mozcloud/application/templates/_helpers.tpl
@@ -104,8 +104,9 @@ Resolution order for both repository and tag:
   3. Fail with a descriptive error if neither is set.
 
 If globalImage.registry is set, it is prepended to the resolved repository
-as "registry/repository" — unless the repository already starts with the
-registry value (to avoid double-prefixing).
+as "registry/repository" — unless the repository already contains a registry
+hostname (detected by a "." in the first path segment, following Docker's
+convention).
 
 Params:
   containerImage (dict): The container-level image config (image.repository, image.tag).
@@ -130,7 +131,8 @@ Returns:
   {{- fail (printf "Container image tag must be set for workload %q container %q. Set .Values.mozcloud.workloads.%s.containers.%s.image.tag or .Values.global.mozcloud.image.tag." $workloadName $containerName $workloadName $containerName) }}
 {{- end }}
 {{- $registry := default ($globalImage.registry) ($containerImage.registry) | default "" }}
-{{- if and $registry (not (hasPrefix $registry $repo)) }}
+{{- $repoHasRegistry := regexMatch `^[^/]*\.[^/]+/` $repo }}
+{{- if and $registry (not $repoHasRegistry) }}
   {{- $repo = printf "%s/%s" $registry $repo }}
 {{- end }}
 {{- printf "%s:%s" $repo $tag }}

--- a/mozcloud/application/templates/task/_jobTemplate.yaml
+++ b/mozcloud/application/templates/task/_jobTemplate.yaml
@@ -80,15 +80,8 @@ template:
         {{- $containerConfig = mergeOverwrite (deepCopy (default dict $common.container)) $containerConfig }}
       - name: {{ $containerName }}
         {{- $globalImage := default dict $context.Values.global.mozcloud.image }}
-        {{- $imageRepo := default (($globalImage).repository) ($containerConfig.image).repository }}
-        {{- $imageTag := default (($globalImage).tag) ($containerConfig.image).tag }}
-        {{- if not $imageRepo }}
-        {{- fail (printf "%sContainer image repository must be set! You can set this in either .Values.mozcloud.tasks.jobs.%s.containers[].image.repository or .Values.global.mozcloud.image.repository" $jobConfig.name) }}
-        {{- end }}
-        {{- if not $imageTag }}
-        {{- fail (printf "%sContainer image tag must be set! You can set this in either .Values.mozcloud.tasks.jobs.%s.containers[].image.tag or .Values.global.mozcloud.image.tag" $jobConfig.name) }}
-        {{- end }}
-        image: {{ $imageRepo }}:{{ $imageTag }}
+        {{- $imageParams := dict "containerImage" $containerConfig.image "globalImage" $globalImage "workloadName" $jobConfig.name "containerName" $containerName }}
+        image: {{ include "mozcloud.image" $imageParams }}
         imagePullPolicy: {{ $containerConfig.imagePullPolicy }}
         {{- if $containerConfig.command }}
         command:

--- a/mozcloud/application/templates/workload/deployment.yaml
+++ b/mozcloud/application/templates/workload/deployment.yaml
@@ -162,24 +162,8 @@ spec:
         {{- range $containerName, $containerConfig := $containers }}
         {{- $portName := include "mozcloud.portName" $containerName }}
         - name: {{ $containerName }}
-          {{- /*
-          We first look for an image and tag in the container config YAML. If
-          those are not defined, we default to image.repository and image.tag
-          in .Values.global.mozcloud. These can be configured in tenant files.
-
-          If neither is defined, we want to throw errors.
-          */}}
-          {{- if and (not ($containerConfig.image).repository) (not ($globals.image).repository) }}
-            {{- $failMessage := printf "A fully qualified image path must be configured in either \".Values.mozcloud.workloads.%s.containers.%s.image.repository\" or \".Values.global.mozcloud.image.repository\"." $workloadName $containerName }}
-            {{- fail $failMessage }}
-          {{- end }}
-          {{- $image := default ($globals.image).repository ($containerConfig.image).repository }}
-          {{- if and (not ($containerConfig.image).tag) (not ($globals.image).tag) }}
-            {{- $failMessage := printf "An image tag must be configured in either \".Values.mozcloud.workloads.%s.containers.%s.image.tag\" or \".Values.global.mozcloud.image.tag\".      " $workloadName $containerName }}
-            {{- fail $failMessage }}
-          {{- end }}
-          {{- $tag := default ($globals.image).tag ($containerConfig.image).tag }}
-          image: {{ printf "%s:%s" $image $tag }}
+          {{- $imageParams := dict "containerImage" $containerConfig.image "globalImage" $globals.image "workloadName" $workloadName "containerName" $containerName }}
+          image: {{ include "mozcloud.image" $imageParams }}
           imagePullPolicy: {{ $containerConfig.imagePullPolicy }}
           {{- if $containerConfig.command }}
           command:
@@ -325,24 +309,8 @@ spec:
         {{- range $containerName, $containerConfig := $initContainers }}
         {{- $portName := include "mozcloud.portName" $containerName }}
         - name: {{ $containerName }}
-          {{- /*
-          We first look for an image and tag in the container config YAML. If
-          those are not defined, we default to image.repository and image.tag
-          in .Values.global.mozcloud. These can be configured in tenant files.
-
-          If neither is defined, we want to throw errors.
-          */}}
-          {{- if and (not ($containerConfig.image).repository) (not ($globals.image).repository) }}
-            {{- $failMessage := printf "A fully qualified image path must be configured in either \".Values.mozcloud.workloads.%s.initContainers.%s.image.repository\" or \".Values.global.mozcloud.image.repository\"." $workloadName $containerName }}
-            {{- fail $failMessage }}
-          {{- end }}
-          {{- $image := default ($globals.image).repository ($containerConfig.image).repository }}
-          {{- if and (not ($containerConfig.image).tag) (not ($globals.image).tag) }}
-            {{- $failMessage := printf "An image tag must be configured in either \".Values.mozcloud.workloads.%s.initContainers.%s.image.tag\" or \".Values.global.mozcloud.image.tag\".      " $workloadName $containerName }}
-            {{- fail $failMessage }}
-          {{- end }}
-          {{- $tag := default ($globals.image).tag ($containerConfig.image).tag }}
-          image: {{ printf "%s:%s" $image $tag }}
+          {{- $imageParams := dict "containerImage" $containerConfig.image "globalImage" $globals.image "workloadName" $workloadName "containerName" $containerName }}
+          image: {{ include "mozcloud.image" $imageParams }}
           imagePullPolicy: {{ $containerConfig.imagePullPolicy }}
           {{- if $containerConfig.command }}
           command:

--- a/mozcloud/application/templates/workload/rollout.yaml
+++ b/mozcloud/application/templates/workload/rollout.yaml
@@ -168,24 +168,8 @@ spec:
         {{- range $containerName, $containerConfig := $containers }}
         {{- $portName := include "mozcloud.portName" $containerName }}
         - name: {{ $containerName }}
-          {{- /*
-          We first look for an image and tag in the container config YAML. If
-          those are not defined, we default to image.repository and image.tag
-          in .Values.global.mozcloud. These can be configured in tenant files.
-
-          If neither is defined, we want to throw errors.
-          */}}
-          {{- if and (not ($containerConfig.image).repository) (not ($globals.image).repository) }}
-            {{- $failMessage := printf "A fully qualified image path must be configured in either \".Values.mozcloud.workloads.%s.containers.%s.image.repository\" or \".Values.global.mozcloud.image.repository\"." $workloadName $containerName }}
-            {{- fail $failMessage }}
-          {{- end }}
-          {{- $image := default ($globals.image).repository ($containerConfig.image).repository }}
-          {{- if and (not ($containerConfig.image).tag) (not ($globals.image).tag) }}
-            {{- $failMessage := printf "An image tag must be configured in either \".Values.mozcloud.workloads.%s.containers.%s.image.tag\" or \".Values.global.mozcloud.image.tag\".      " $workloadName $containerName }}
-            {{- fail $failMessage }}
-          {{- end }}
-          {{- $tag := default ($globals.image).tag ($containerConfig.image).tag }}
-          image: {{ printf "%s:%s" $image $tag }}
+          {{- $imageParams := dict "containerImage" $containerConfig.image "globalImage" $globals.image "workloadName" $workloadName "containerName" $containerName }}
+          image: {{ include "mozcloud.image" $imageParams }}
           imagePullPolicy: {{ $containerConfig.imagePullPolicy }}
           {{- if $containerConfig.command }}
           command:

--- a/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
@@ -1,0 +1,134 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: web
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: web
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: web
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: web
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-images/myapp:1.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: app
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/other-images/sidecar:2.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: sidecar
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: sidecar
+              ports:
+                - containerPort: 8000
+                  name: sidecar
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: sidecar
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test

--- a/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
@@ -132,3 +132,95 @@ Configuration matches entire snapshot:
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: mozcloud-test
+  2: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: api
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service-2
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: api
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: api
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: api
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: us-west1-docker.pkg.dev/moz-fx-fx-testing/fx-testing-prod/api-image:1.0.1
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: app
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test

--- a/mozcloud/application/tests/image-registry_test.yaml
+++ b/mozcloud/application/tests/image-registry_test.yaml
@@ -1,0 +1,59 @@
+---
+suite: "mozcloud: Image registry prefix"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/image-registry.yaml
+templates:
+  - workload/deployment.yaml
+tests:
+  - it: Ensure no failures occur
+    asserts:
+      - notFailedTemplate: {}
+  - it: Prepends global registry to short repository paths
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "app")].image
+          value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-images/myapp:1.0.0"
+  - it: Does not double-prefix when repository already contains the registry
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "sidecar")].image
+          value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/other-images/sidecar:2.0.0"
+  - it: Works without registry set (backwards compatible)
+    set:
+      global:
+        mozcloud:
+          app_code: mozcloud-test
+          artifact_id: abcd1234
+          chart: test-chart
+          env_code: dev
+          project_id: moz-fx-mozcloud-test-nonprod
+          realm: nonprod
+          image:
+            registry: ""
+      workloads:
+        test-service:
+          component: web
+          containers:
+            app:
+              image:
+                repository: us-docker.pkg.dev/my-project/my-image
+                tag: "3.0.0"
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "app")].image
+          value: "us-docker.pkg.dev/my-project/my-image:3.0.0"

--- a/mozcloud/application/tests/image-registry_test.yaml
+++ b/mozcloud/application/tests/image-registry_test.yaml
@@ -14,6 +14,9 @@ tests:
   - it: Ensure no failures occur
     asserts:
       - notFailedTemplate: {}
+  - it: Configuration matches entire snapshot
+    asserts:
+      - matchSnapshot: {}
   - it: Prepends global registry to short repository paths
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name

--- a/mozcloud/application/tests/image-registry_test.yaml
+++ b/mozcloud/application/tests/image-registry_test.yaml
@@ -33,6 +33,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "sidecar")].image
           value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/other-images/sidecar:2.0.0"
+  - it: Does not double-prefix when repository already contains a different registry
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service-2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "app")].image
+          value: "us-west1-docker.pkg.dev/moz-fx-fx-testing/fx-testing-prod/api-image:1.0.1"
   - it: Works without registry set (backwards compatible)
     set:
       global:

--- a/mozcloud/application/tests/values/image-registry.yaml
+++ b/mozcloud/application/tests/values/image-registry.yaml
@@ -1,0 +1,18 @@
+---
+global:
+  mozcloud:
+    image:
+      registry: us-west1-docker.pkg.dev/moz-fx-platform-artifacts
+
+workloads:
+  test-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: platform-images/myapp
+          tag: "1.0.0"
+      sidecar:
+        image:
+          repository: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/other-images/sidecar
+          tag: "2.0.0"

--- a/mozcloud/application/tests/values/image-registry.yaml
+++ b/mozcloud/application/tests/values/image-registry.yaml
@@ -16,3 +16,10 @@ workloads:
         image:
           repository: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/other-images/sidecar
           tag: "2.0.0"
+  test-service-2:
+    component: api
+    containers:
+      app:
+        image:
+          repository: us-west1-docker.pkg.dev/moz-fx-fx-testing/fx-testing-prod/api-image
+          tag: "1.0.1"

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -31,6 +31,10 @@
               "description": "The container image repository and tag. This can be managed by Argo Image Updater.",
               "type": "object",
               "properties": {
+                "registry": {
+                  "description": "Default registry prefix prepended to image repository paths (e.g. us-west1-docker.pkg.dev/my-project).",
+                  "type": "string"
+                },
                 "repository": {
                   "type": "string"
                 },
@@ -1198,6 +1202,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "registry": {
+              "description": "Registry prefix prepended to the repository path. Overrides the global registry for this container.",
+              "type": "string"
+            },
             "repository": {
               "type": "string"
             },

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1080,6 +1080,11 @@ workloads:
         #
         # See the tenant definition document for details:
         # https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/588742735/Tenant+Definition
+        #
+        # If global.mozcloud.image.registry is set, it is prepended to
+        # repository as "registry/repository" (unless repository already
+        # starts with the registry value). This lets you set the registry
+        # once globally and use short repository paths per-container.
         image:
           repository: ''
           tag: ''
@@ -1559,6 +1564,11 @@ workloads:
         #
         # See the tenant definition document for details:
         # https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/588742735/Tenant+Definition
+        #
+        # If global.mozcloud.image.registry is set, it is prepended to
+        # repository as "registry/repository" (unless repository already
+        # starts with the registry value). This lets you set the registry
+        # once globally and use short repository paths per-container.
         image:
           repository: ''
           tag: ''


### PR DESCRIPTION
## Summary

- **Consolidated image rendering into shared `mozcloud.image` helper**: Image resolution logic (container → global fallback, validation, rendering) was duplicated across deployment, rollout, and job templates. Extracted into a single named template in `_helpers.tpl`.
- **Added `global.mozcloud.image.registry` support**: Optional registry prefix prepended to image repository paths. Avoids double-prefixing when the repository already starts with the registry value. Also supported per-container via `image.registry`.

## Test plan

- [x] New `image-registry_test.yaml` covering: registry prepend, no double-prefix, backwards compat without registry
- [x] All existing test suites pass via `make unit-tests` with no snapshot changes