### PR TITLE
fix: support string image values

### DIFF
--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -170,7 +170,8 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.initContainers.default.sidecar | bool | `false` |  |
 | workloads.default.labels | object | `{}` |  |
 | workloads.default.nginx.enabled | bool | `true` |  |
-| workloads.default.nginx.image | string | `"us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29"` |  |
+| workloads.default.nginx.image.repository | string | `"us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged"` |  |
+| workloads.default.nginx.image.tag | string | `"1.29"` |  |
 | workloads.default.nodeSelector | object | `{}` |  |
 | workloads.default.otel.autoInstrumentation.enabled | bool | `false` |  |
 | workloads.default.otel.autoInstrumentation.language | string | `""` |  |

--- a/mozcloud/application/templates/_helpers.tpl
+++ b/mozcloud/application/templates/_helpers.tpl
@@ -109,8 +109,7 @@ hostname (detected by a "." in the first path segment, following Docker's
 convention).
 
 Params:
-  containerImage (dict|string): The container-level image config. Either an object
-                 with repository/tag keys, or a string like "repo:tag".
+  containerImage (dict): The container-level image config (image.repository, image.tag).
   globalImage    (dict): The global image config (.Values.global.mozcloud.image).
   workloadName   (string): Name of the workload (for error messages).
   containerName  (string): Name of the container (for error messages).
@@ -119,17 +118,10 @@ Returns:
   (string) A fully qualified image reference, e.g. "registry/repo:tag".
 */ -}}
 {{- define "mozcloud.image" -}}
+{{- $containerImage := default dict .containerImage }}
 {{- $globalImage := default dict .globalImage }}
 {{- $workloadName := .workloadName }}
 {{- $containerName := .containerName }}
-{{- /* Normalize containerImage: if string, split on ":" into repo/tag dict */ -}}
-{{- $containerImage := dict }}
-{{- if eq (kindOf .containerImage) "string" }}
-  {{- $parts := splitn ":" 2 .containerImage }}
-  {{- $containerImage = dict "repository" $parts._0 "tag" (default "" $parts._1) }}
-{{- else }}
-  {{- $containerImage = default dict .containerImage }}
-{{- end }}
 {{- $repo := default ($globalImage.repository) ($containerImage.repository) }}
 {{- if not $repo }}
   {{- fail (printf "Container image repository must be set for workload %q container %q. Set .Values.mozcloud.workloads.%s.containers.%s.image.repository or .Values.global.mozcloud.image.repository." $workloadName $containerName $workloadName $containerName) }}

--- a/mozcloud/application/templates/_helpers.tpl
+++ b/mozcloud/application/templates/_helpers.tpl
@@ -109,7 +109,8 @@ hostname (detected by a "." in the first path segment, following Docker's
 convention).
 
 Params:
-  containerImage (dict): The container-level image config (image.repository, image.tag).
+  containerImage (dict|string): The container-level image config. Either an object
+                 with repository/tag keys, or a string like "repo:tag".
   globalImage    (dict): The global image config (.Values.global.mozcloud.image).
   workloadName   (string): Name of the workload (for error messages).
   containerName  (string): Name of the container (for error messages).
@@ -118,10 +119,17 @@ Returns:
   (string) A fully qualified image reference, e.g. "registry/repo:tag".
 */ -}}
 {{- define "mozcloud.image" -}}
-{{- $containerImage := default dict .containerImage }}
 {{- $globalImage := default dict .globalImage }}
 {{- $workloadName := .workloadName }}
 {{- $containerName := .containerName }}
+{{- /* Normalize containerImage: if string, split on ":" into repo/tag dict */ -}}
+{{- $containerImage := dict }}
+{{- if eq (kindOf .containerImage) "string" }}
+  {{- $parts := splitn ":" 2 .containerImage }}
+  {{- $containerImage = dict "repository" $parts._0 "tag" (default "" $parts._1) }}
+{{- else }}
+  {{- $containerImage = default dict .containerImage }}
+{{- end }}
 {{- $repo := default ($globalImage.repository) ($containerImage.repository) }}
 {{- if not $repo }}
   {{- fail (printf "Container image repository must be set for workload %q container %q. Set .Values.mozcloud.workloads.%s.containers.%s.image.repository or .Values.global.mozcloud.image.repository." $workloadName $containerName $workloadName $containerName) }}

--- a/mozcloud/application/templates/workload/deployment.yaml
+++ b/mozcloud/application/templates/workload/deployment.yaml
@@ -104,7 +104,8 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-          image: {{ $workloadConfig.nginx.image }}
+          {{- $nginxImageParams := dict "containerImage" $workloadConfig.nginx.image "globalImage" $globals.image "workloadName" $workloadName "containerName" "nginx" }}
+          image: {{ include "mozcloud.image" $nginxImageParams }}
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/mozcloud/application/templates/workload/rollout.yaml
+++ b/mozcloud/application/templates/workload/rollout.yaml
@@ -110,7 +110,8 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-          image: {{ $workloadConfig.nginx.image }}
+          {{- $nginxImageParams := dict "containerImage" $workloadConfig.nginx.image "globalImage" $globals.image "workloadName" $workloadName "containerName" "nginx" }}
+          image: {{ include "mozcloud.image" $nginxImageParams }}
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
@@ -224,3 +224,151 @@ Configuration matches entire snapshot:
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: mozcloud-test
+  3: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service-nginx
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: web
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            checksum/configmap-nginx-config: c34d2b5ef0564bb36211561d58bb1eec27c44003f9989085eacad45320ab0485
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: web
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: web
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: web
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+              imagePullPolicy: Always
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /bin/bash
+                      - -c
+                      - /bin/sleep 25 && /usr/sbin/nginx -s quit
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__nginxheartbeat__
+                  port: http
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: nginx
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: http
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsGroup: 101
+                runAsUser: 101
+              volumeMounts:
+                - mountPath: /etc/nginx/nginx.conf
+                  name: nginx-conf
+                  readOnly: true
+                  subPath: nginx.conf
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-images/webapp:1.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: app
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test
+          volumes:
+            - configMap:
+                name: nginx-config
+              name: nginx-conf

--- a/mozcloud/application/tests/image-registry_test.yaml
+++ b/mozcloud/application/tests/image-registry_test.yaml
@@ -41,7 +41,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "app")].image
           value: "us-west1-docker.pkg.dev/moz-fx-fx-testing/fx-testing-prod/api-image:1.0.1"
-  - it: Parses nginx string image and does not prepend registry when it contains a domain
+  - it: Does not prepend registry to nginx when its repository already contains a domain
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service-nginx
@@ -49,12 +49,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "nginx")].image
           value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29"
-  - it: Prepends registry to nginx when using a short string image
+  - it: Prepends registry to nginx when using a short repository path
     set:
       workloads:
         test-service-nginx:
           nginx:
-            image: "nginxinc/nginx-unprivileged:1.29"
+            image:
+              repository: nginxinc/nginx-unprivileged
+              tag: "1.29"
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service-nginx

--- a/mozcloud/application/tests/image-registry_test.yaml
+++ b/mozcloud/application/tests/image-registry_test.yaml
@@ -41,6 +41,27 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "app")].image
           value: "us-west1-docker.pkg.dev/moz-fx-fx-testing/fx-testing-prod/api-image:1.0.1"
+  - it: Parses nginx string image and does not prepend registry when it contains a domain
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service-nginx
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "nginx")].image
+          value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29"
+  - it: Prepends registry to nginx when using a short string image
+    set:
+      workloads:
+        test-service-nginx:
+          nginx:
+            image: "nginxinc/nginx-unprivileged:1.29"
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service-nginx
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "nginx")].image
+          value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/nginxinc/nginx-unprivileged:1.29"
   - it: Works without registry set (backwards compatible)
     set:
       global:

--- a/mozcloud/application/tests/values/image-registry.yaml
+++ b/mozcloud/application/tests/values/image-registry.yaml
@@ -27,7 +27,9 @@ workloads:
     component: web
     nginx:
       enabled: true
-      image: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29"
+      image:
+        repository: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged
+        tag: "1.29"
       configMap: nginx-config
     containers:
       app:

--- a/mozcloud/application/tests/values/image-registry.yaml
+++ b/mozcloud/application/tests/values/image-registry.yaml
@@ -23,3 +23,29 @@ workloads:
         image:
           repository: us-west1-docker.pkg.dev/moz-fx-fx-testing/fx-testing-prod/api-image
           tag: "1.0.1"
+  test-service-nginx:
+    component: web
+    nginx:
+      enabled: true
+      configMap: nginx-config
+    containers:
+      app:
+        image:
+          repository: platform-images/webapp
+          tag: "1.0.0"
+    hosts:
+      test-service-nginx:
+        domains:
+          - test-nginx.dev.example.com
+        addresses:
+          - test-ip
+        tls:
+          certs:
+            - test-cert
+
+configMaps:
+  nginx-config:
+    data:
+      nginx.conf: |
+        events { worker_connections 1024; }
+        http { server { listen 8080; location / { proxy_pass http://localhost:8000; } } }

--- a/mozcloud/application/tests/values/image-registry.yaml
+++ b/mozcloud/application/tests/values/image-registry.yaml
@@ -27,6 +27,7 @@ workloads:
     component: web
     nginx:
       enabled: true
+      image: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29"
       configMap: nginx-config
     containers:
       app:

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1000,7 +1000,18 @@
                 "default": true
               },
               "image": {
-                "type": "string"
+                "oneOf": [
+                  { "type": "string" },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "registry": { "type": "string" },
+                      "repository": { "type": "string" },
+                      "tag": { "type": "string" }
+                    }
+                  }
+                ]
               },
               "configMap": {
                 "type": "string"

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1000,18 +1000,13 @@
                 "default": true
               },
               "image": {
-                "oneOf": [
-                  { "type": "string" },
-                  {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                      "registry": { "type": "string" },
-                      "repository": { "type": "string" },
-                      "tag": { "type": "string" }
-                    }
-                  }
-                ]
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "registry": { "type": "string" },
+                  "repository": { "type": "string" },
+                  "tag": { "type": "string" }
+                }
               },
               "configMap": {
                 "type": "string"

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1768,7 +1768,9 @@ workloads:
     #       memory: 128Mi
     nginx:
       enabled: true
-      image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+      image:
+        repository: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged
+        tag: "1.29"
 
     # Configure auto instrumentation for the OTEL Collector.
     #


### PR DESCRIPTION
we also use string for images 'repo/name:tag' this adds support for that as well.