### PR TITLE
feat: add support for existing managed certs

### DIFF
--- a/mozcloud-ingress/library/templates/_helpers.tpl
+++ b/mozcloud-ingress/library/templates/_helpers.tpl
@@ -248,6 +248,13 @@ ManagedCertificate template helpers
         {{- $managed_certs = append $managed_certs $managed_cert -}}
       {{- end -}}
     {{- end -}}
+    {{- if $tls.existingCerts -}}
+      {{- range $existingCert := $tls.existingCerts -}}
+        {{- $managed_cert = dict "name" $existingCert "domains" (list) "createCertificate" false "referenceOnly" true -}}
+        {{- $_ := set $managed_cert "ingressName" $ingress_name -}}
+        {{- $managed_certs = append $managed_certs $managed_cert -}}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{ $managed_certs | toYaml }}

--- a/mozcloud-ingress/library/templates/_ingress.yaml
+++ b/mozcloud-ingress/library/templates/_ingress.yaml
@@ -23,7 +23,7 @@ metadata:
     {{- if gt (len $managed_certificates) 0 }}
     {{- $certs := list }}
     {{- range $managed_certificate := $managed_certificates }}
-    {{- if and (eq $managed_certificate.ingressName $ingress.name) $managed_certificate.createCertificate }}
+    {{- if and (eq $managed_certificate.ingressName $ingress.name) (or $managed_certificate.createCertificate $managed_certificate.referenceOnly) }}
     {{- $certs = append $certs $managed_certificate.name }}
     {{- end }}
     {{- end }}

--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -72,11 +72,16 @@ ingresses:
             {{- $type = "ManagedCertificate" }}
           {{- end }}
           type: {{ $type }}
-          {{- if and (hasKey $hostConfig.tls "create") ($hostConfig.tls.create) }}
-          createCertificates: true
-          {{- if eq $type "ManagedCertificate" }}
-          multipleHosts: false
+          {{- if hasKey $hostConfig.tls "create" }}
+          createCertificates: {{ $hostConfig.tls.create }}
           {{- end }}
+          {{- if and (eq $type "ManagedCertificate") (hasKey $hostConfig.tls "create") (not $hostConfig.tls.create) ($hostConfig.tls.certs) }}
+          existingCerts:
+            {{- range $cert := $hostConfig.tls.certs }}
+            - {{ $cert | quote }}
+            {{- end }}
+          {{- else if and (hasKey $hostConfig.tls "create") ($hostConfig.tls.create) (eq $type "ManagedCertificate") }}
+          multipleHosts: false
           {{- end }}
           {{- if eq $type "pre-shared" }}
           preSharedCerts: {{ join "," (uniq $hostConfig.tls.certs | sortAlpha) | quote }}

--- a/mozcloud/application/tests/__snapshot__/existing-managed-cert-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/existing-managed-cert-configuration_test.yaml.snap
@@ -1,0 +1,99 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: networking.gke.io/v1beta1
+    kind: FrontendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      redirectToHttps:
+        enabled: true
+        responseCodeName: MOVED_PERMANENTLY_DEFAULT
+      sslPolicy: mozilla-intermediate
+  2: |
+    apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      logging:
+        enable: true
+        sampleRate: 0.1
+  3: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: gce
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
+        networking.gke.io/managed-certificates: existing-mcrt-test-service
+        networking.gke.io/v1beta1.FrontendConfig: test-service
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      defaultBackend:
+        service:
+          name: test-service
+          port:
+            number: 8080
+  4: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/backend-config: '{"default": "test-service"}'
+        cloud.google.com/neg: '{"ingress": true}'
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP

--- a/mozcloud/application/tests/existing-managed-cert-configuration_test.yaml
+++ b/mozcloud/application/tests/existing-managed-cert-configuration_test.yaml
@@ -1,0 +1,38 @@
+---
+suite: "mozcloud: Existing managed certificate configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/existing-managed-cert-configuration.yaml
+templates:
+  - gateway/gateway.yaml
+  - gke/frontendconfig.yaml
+  - gke/ingress.yaml
+  - ingress/ingress.yaml
+tests:
+  - it: Ensure no failures occur
+    asserts:
+      - notFailedTemplate: {}
+  - it: Configuration matches entire snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: No ManagedCertificate resource is created
+    template: gke/ingress.yaml
+    asserts:
+      - notContains:
+          path: $[*].kind
+          content: ManagedCertificate
+          any: true
+  - it: Ingress annotation references the existing certificate
+    template: ingress/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "Ingress")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: metadata.annotations["networking.gke.io/managed-certificates"]
+          value: existing-mcrt-test-service

--- a/mozcloud/application/tests/values/existing-managed-cert-configuration.yaml
+++ b/mozcloud/application/tests/values/existing-managed-cert-configuration.yaml
@@ -1,0 +1,21 @@
+---
+workloads:
+  test-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      test-service:
+        domains:
+          - test-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        tls:
+          type: ManagedCertificate
+          create: false
+          certs:
+            - existing-mcrt-test-service

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1394,25 +1394,28 @@ workloads:
         #
         # This section is not required if host type is "internal".
         tls:
-          # A list of the certmap, pre-shared cert, or ManagedCertificate names
-          # to use on the Gateway or Ingress. Only the first entry is used if
-          # "type" is "certmap".
+          # A list of cert identifiers to use on the Gateway or Ingress. The
+          # meaning depends on the TLS type:
+          #
+          #   certmap: The first entry is the cert map name.
+          #   pre-shared: All entries are pre-shared certificate names.
+          #   ManagedCertificate: When "create" is false, these are the names
+          #     of existing ManagedCertificate resources to reference in the
+          #     Ingress annotation without creating new ones.
+          #   certManager: The first entry is used as the TLS secret name.
           #
           # Certificate maps and pre-shared certificates are created
           # outside of Kubernetes either by tenant Terraform modules (certmaps)
           # or manually (pre-shared).
-          #
-          # ManagedCertificate certificates will be automatically created by
-          # this chart if "create" is set to "true".
           certs: []
 
-          # If enabled, certificates will be created.
+          # Controls whether ManagedCertificate resources are created by this
+          # chart. Only applicable when "type" is "ManagedCertificate" and
+          # "api" is "ingress".
           #
-          # This is only applicable when the TLS type is "ManagedCertificate"
-          # and the type of API is "ingress".
-          #
-          # The default behavior is to create ManagedCertificate resources when
-          # using Ingress. This option is ignored for Gateway API resources.
+          # Set to "false" and provide existing cert names in "certs" to
+          # reference certificates managed outside this chart (e.g. during
+          # migration from a custom chart).
           create: true
 
           # Can be "certmap", "ManagedCertificate", "pre-shared", or


### PR DESCRIPTION
Allows specifying existing `ManagedCertificate` resources by name via `tls.certs` when `tls.create: false`, referencing them in the Ingress annotation without provisioning new certificates. This enables tenants migrating from custom charts to adopt the mozcloud chart without disrupting existing certificates.