### PR TITLE
feat: Allow specify tls certificate or leaving blank

### DIFF
--- a/mozcloud-ingress/library/templates/_ingress.yaml
+++ b/mozcloud-ingress/library/templates/_ingress.yaml
@@ -7,6 +7,7 @@
 {{- $managed_certificates := include "mozcloud-ingress-lib.config.managedCertificates" . | fromYamlArray }}
 {{- range $ingress := $ingresses.ingresses }}
 {{- $certManagerConfig := default dict (default dict (first $ingress.hosts).tls).certManager }}
+{{- $tlsSecretConfig := default dict (default dict (first $ingress.hosts).tls).secret }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -49,7 +50,13 @@ spec:
   {{- if and (ne $provider "gke") $ingressClass }}
     ingressClassName: {{ $ingressClass | quote }}
   {{- end }}
-  {{- if $certManagerConfig }}
+  {{- $tlsSecretName := "" }}
+  {{- if $certManagerConfig.secretName }}
+    {{- $tlsSecretName = $certManagerConfig.secretName }}
+  {{- else if $tlsSecretConfig.secretName }}
+    {{- $tlsSecretName = $tlsSecretConfig.secretName }}
+  {{- end }}
+  {{- if $tlsSecretName }}
     tls:
       - hosts:
           {{- range $host := $ingress.hosts }}
@@ -57,7 +64,7 @@ spec:
           - {{ $domain | quote }}
           {{- end }}
           {{- end }}
-        secretName: {{ $certManagerConfig.secretName | quote }}
+        secretName: {{ $tlsSecretName | quote }}
   {{- end }}
   {{- if and
     (eq $provider "gke")

--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -89,6 +89,13 @@ ingresses:
             issuerKind: {{ $certManagerIssuerKind | quote }}
             secretName: {{ required "tls.certs must have at least one entry when tls.type is certManager" (first (default (list) $hostConfig.tls.certs)) | quote }}
           {{- end }}
+          {{- if eq $type "secret" }}
+          {{- $secretName := first (default (list) $hostConfig.tls.certs) }}
+          {{- if $secretName }}
+          secret:
+            secretName: {{ $secretName | quote }}
+          {{- end }}
+          {{- end }}
     {{- if $hostConfig.addresses }}
     staticIpName: {{ $hostConfig.addresses | first }}
     {{- else }}

--- a/mozcloud/application/tests/__snapshot__/secret-default-cert-ingress-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/secret-default-cert-ingress-configuration_test.yaml.snap
@@ -1,0 +1,59 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: traefik
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      ingressClassName: traefik
+      rules:
+        - host: test-service.dev.test-domain.com
+          http:
+            paths:
+              - backend:
+                  service:
+                    name: test-service
+                    port:
+                      number: 8080
+                path: /
+                pathType: Prefix
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP

--- a/mozcloud/application/tests/__snapshot__/secret-ingress-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/secret-ingress-configuration_test.yaml.snap
@@ -1,0 +1,63 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: traefik
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      ingressClassName: traefik
+      rules:
+        - host: test-service.dev.test-domain.com
+          http:
+            paths:
+              - backend:
+                  service:
+                    name: test-service
+                    port:
+                      number: 8080
+                path: /
+                pathType: Prefix
+      tls:
+        - hosts:
+            - test-service.dev.test-domain.com
+          secretName: my-wildcard-tls
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP

--- a/mozcloud/application/tests/secret-default-cert-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/secret-default-cert-ingress-configuration_test.yaml
@@ -1,0 +1,46 @@
+---
+suite: "mozcloud: secret default cert ingress configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/secret-default-cert-ingress-configuration.yaml
+templates:
+  - ingress/ingress.yaml
+tests:
+  - it: Ensure no failures occur
+    asserts:
+      - notFailedTemplate: {}
+  - it: Configuration matches entire snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: Ingress does not have spec.tls (uses controller default cert)
+    template: ingress/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "Ingress")].metadata.name
+      value: test-service
+    asserts:
+      - isNull:
+          path: spec.tls
+  - it: Ingress does not have cert-manager annotations
+    template: ingress/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "Ingress")].metadata.name
+      value: test-service
+    asserts:
+      - isNull:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - isNull:
+          path: metadata.annotations["cert-manager.io/issuer"]
+  - it: Ingress uses traefik ingress class annotation
+    template: ingress/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "Ingress")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: metadata.annotations["kubernetes.io/ingress.class"]
+          value: traefik

--- a/mozcloud/application/tests/secret-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/secret-ingress-configuration_test.yaml
@@ -1,0 +1,50 @@
+---
+suite: "mozcloud: secret TLS ingress configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/secret-ingress-configuration.yaml
+templates:
+  - ingress/ingress.yaml
+tests:
+  - it: Ensure no failures occur
+    asserts:
+      - notFailedTemplate: {}
+  - it: Configuration matches entire snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: Ingress has spec.tls with correct secret and domain
+    template: ingress/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "Ingress")].metadata.name
+      value: test-service
+    asserts:
+      - contains:
+          path: spec.tls
+          content:
+            hosts:
+              - test-service.dev.test-domain.com
+            secretName: my-wildcard-tls
+  - it: Ingress does not have cert-manager annotations
+    template: ingress/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "Ingress")].metadata.name
+      value: test-service
+    asserts:
+      - isNull:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - isNull:
+          path: metadata.annotations["cert-manager.io/issuer"]
+  - it: Ingress uses traefik ingress class annotation
+    template: ingress/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "Ingress")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: metadata.annotations["kubernetes.io/ingress.class"]
+          value: traefik

--- a/mozcloud/application/tests/values/secret-default-cert-ingress-configuration.yaml
+++ b/mozcloud/application/tests/values/secret-default-cert-ingress-configuration.yaml
@@ -1,0 +1,24 @@
+---
+cloud:
+  provider: on-prem
+  ingress:
+    default: traefik
+
+workloads:
+  test-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      test-service:
+        type: external
+        api: ingress
+        domains:
+          - test-service.dev.test-domain.com
+        addresses:
+          - test-service-ip-v4
+        tls:
+          type: secret

--- a/mozcloud/application/tests/values/secret-ingress-configuration.yaml
+++ b/mozcloud/application/tests/values/secret-ingress-configuration.yaml
@@ -1,0 +1,26 @@
+---
+cloud:
+  provider: on-prem
+  ingress:
+    default: traefik
+
+workloads:
+  test-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      test-service:
+        type: external
+        api: ingress
+        domains:
+          - test-service.dev.test-domain.com
+        addresses:
+          - test-service-ip-v4
+        tls:
+          type: secret
+          certs:
+            - my-wildcard-tls

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1415,13 +1415,22 @@ workloads:
           # using Ingress. This option is ignored for Gateway API resources.
           create: true
 
-          # Can be "certmap", "ManagedCertificate", "pre-shared", or
-          # "certManager". What you use depends on the type of API used.
+          # Can be "certmap", "ManagedCertificate", "pre-shared",
+          # "certManager", or "secret". What you use depends on the type of
+          # API used.
           #
           # Options (based on API):
           #   Gateway: certmap
           #   Ingress (GKE): ManagedCertificate (preferred), pre-shared
           #   Ingress (non-GKE): certManager (e.g. Let's Encrypt via cert-manager)
+          #                      secret (pre-existing Kubernetes TLS secret)
+          #
+          # Use "secret" to reference a TLS secret that already exists in the
+          # namespace (e.g. a wildcard cert provisioned externally). This
+          # renders spec.tls with the given secretName but does not add any
+          # cert-manager annotations. The first entry in "certs" is used as
+          # the secretName. If "certs" is omitted, spec.tls is not rendered
+          # and the ingress controller's default certificate is used instead.
           #
           # As the default API is "gateway", the default TLS type is "certmap".
           type: certmap


### PR DESCRIPTION
Bring your own TLS certificate or do not define it to use the ingress default.