### PR TITLE
chore(moztel): Housekeeping for OTel collectors

### DIFF
--- a/mozcloud-opentelemetry/application/README.md
+++ b/mozcloud-opentelemetry/application/README.md
@@ -40,7 +40,10 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| collectors.daemonset.resources | object | `{}` |  |
+| collectors.daemonset.resources.limits.cpu | string | `"500m"` |  |
+| collectors.daemonset.resources.limits.memory | string | `"1Gi"` |  |
+| collectors.daemonset.resources.requests.cpu | string | `"250m"` |  |
+| collectors.daemonset.resources.requests.memory | string | `"512Mi"` |  |
 | collectors.daemonset.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | collectors.daemonset.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | collectors.daemonset.securityContext.privileged | bool | `false` |  |

--- a/mozcloud-opentelemetry/application/templates/daemonset-collector.yaml
+++ b/mozcloud-opentelemetry/application/templates/daemonset-collector.yaml
@@ -78,14 +78,6 @@ spec:
         spike_limit_percentage: 20
 
     exporters:
-      debug:
-        verbosity: detailed
-
-      otlp:
-        endpoint: {{ printf "%s:%s" .Values.collectors.gateway.endpoints.otlp.endpoint .Values.collectors.gateway.endpoints.otlp.port | quote }}
-        tls:
-          insecure: true
-
       loadbalancing/metrics-otlp:
         routing_key: streamID
         timeout: 10s
@@ -124,12 +116,9 @@ spec:
       health_check:
         endpoint: ${env:POD_IP}:13133
 
-      googleclientauth: {}
-
     service:
       extensions:
       - health_check
-      - googleclientauth
       pipelines:
         metrics:
           receivers:
@@ -137,8 +126,8 @@ spec:
           - statsd
           processors:
           - metricstarttime
-          - k8sattributes
           - memory_limiter
+          - k8sattributes
           - resourcedetection
           exporters:
           - loadbalancing/metrics-otlp
@@ -146,9 +135,9 @@ spec:
           receivers:
           - otlp
           processors:
-          - k8sattributes
-          - memory_limiter
           - filter
+          - memory_limiter
+          - k8sattributes
           - resourcedetection
           exporters:
           - loadbalancing/traces-otlp

--- a/mozcloud-opentelemetry/application/templates/gateway-collector.yaml
+++ b/mozcloud-opentelemetry/application/templates/gateway-collector.yaml
@@ -26,7 +26,7 @@ spec:
         fieldPath: status.podIP
 
   ports:
-  - name: otlp-collecotrs
+  - name: otlp-collectors
     port: {{ .Values.collectors.gateway.endpoints.otlp.collectorMetricsPort }}
     targetPort: {{ .Values.collectors.gateway.endpoints.otlp.collectorMetricsPort }}
 
@@ -116,11 +116,7 @@ spec:
         override: false
 
     exporters:
-      debug:
-        verbosity: detailed
-
-
-      otlphttp:
+      otlp_http:
         encoding: json
         endpoint: https://telemetry.googleapis.com
         auth:
@@ -153,7 +149,7 @@ spec:
           - transform/mozcloud
           - resource/gcp_project_id
           exporters:
-          - otlphttp
+          - otlp_http
         metrics/collectors:
           receivers:
           - otlp/collectors
@@ -163,7 +159,7 @@ spec:
           - resourcedetection
           - resource/gcp_project_id
           exporters:
-          - otlphttp
+          - otlp_http
         traces:
           receivers:
           - otlp
@@ -173,7 +169,7 @@ spec:
           - resource/gcp_project_id
           - tail_sampling
           exporters:
-          - otlphttp
+          - otlp_http
       telemetry:
         logs:
           encoding: json

--- a/mozcloud-opentelemetry/application/values.yaml
+++ b/mozcloud-opentelemetry/application/values.yaml
@@ -24,7 +24,13 @@ collectors:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
-    resources: {}
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
 
   gateway:
     endpoints:


### PR DESCRIPTION
- Daemonset pipeline reordering
  -  metrics: metricstarttime -> memory_limiter -> k8sattributes -> resourcedetection
  - traces: filter -> memory_limiter -> k8sattributes -> resourcedetection
- Daemonset resource defaults - 250m/512Mi requests, 500m/1Gi limits
- Removed googleclientauth from daemonset extensions
- Removed unused exporters - debug and otlp from daemonset, debug from gateway
- Fixed typo  otlp-collecotrs -> otlp-collectors
- Renamed otlphttp -> otlp_http across exporter definition and all 3 pipeline references
  - https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlphttpexporter/README.md?plain=1#L22-L23