### PR TITLE
chore: Add ephemeral-storage support to container resources

### DIFF
--- a/mozcloud/application/templates/_pod.yaml
+++ b/mozcloud/application/templates/_pod.yaml
@@ -1,28 +1,32 @@
 {{- /*
-Validates CPU and memory resource requests and calculates resource limits,
-defaulting to 2× the request value for any limit not explicitly provided.
+Validates CPU, memory, and optional ephemeral-storage resource requests and
+calculates resource limits. CPU and memory limits default to 2× the request
+value when not explicitly provided. Ephemeral-storage limits default to the
+request value (no doubling).
 
 CPU validation: accepts integer, float (whole CPUs), or millicpu notation
 (e.g. "250m"). Decimal millicpu values are rounded up using ceil to produce a
 valid integer millicpu string (e.g. "1.5m" → "2m").
 
-Memory validation: requires a positive number with one of the following unit
-suffixes: K, Ki, M, Mi, G, Gi.
+Memory and ephemeral-storage validation: requires a positive number with one
+of the following unit suffixes: K, Ki, M, Mi, G, Gi.
 
 Params:
   requests (dict): (required) Resource requests. Must include:
-    cpu (string):    (required) CPU request (e.g. "250m", "1", "0.5").
-    memory (string): (required) Memory request (e.g. "256Mi", "1Gi").
+    cpu (string):              (required) CPU request (e.g. "250m", "1", "0.5").
+    memory (string):           (required) Memory request (e.g. "256Mi", "1Gi").
+    ephemeral-storage (string): (optional) Ephemeral storage request (e.g. "1Gi").
   limits (dict):   (optional) Resource limits. If omitted or partially unset,
                    missing values are auto-calculated as 2× the
-                   corresponding request value.
-    cpu (string):    (optional) CPU limit. Auto-calculated if absent.
-    memory (string): (optional) Memory limit. Auto-calculated if absent.
+                   corresponding request value (except ephemeral-storage
+                   which defaults to 1×).
+    cpu (string):              (optional) CPU limit. Auto-calculated if absent.
+    memory (string):           (optional) Memory limit. Auto-calculated if absent.
+    ephemeral-storage (string): (optional) Ephemeral storage limit. Defaults to request.
 
 Returns:
   (string) YAML-encoded Kubernetes resources object with "requests" and
-           "limits" sub-keys, each containing validated "cpu" and "memory"
-           values.
+           "limits" sub-keys.
 
 Example:
   Input:
@@ -96,30 +100,19 @@ CPU resources can only be integers/floats for an entire CPU or millicpu (m)
   {{- $_ := set $resources.limits "cpu" $limit -}}
 {{- end -}}
 {{- /* Validate memory requests and limits */ -}}
-{{- $requestSuffix = "" -}}
-{{- /* Only allow the following unit types: K, Ki, M, Mi, G, Gi */ -}}
-{{- $memorySuffixes := list "K" "Ki" "M" "Mi" "G" "Gi" -}}
+{{- $unitPattern := "(K|Ki|M|Mi|G|Gi)$" -}}
 {{- $request = $requests.memory | toString -}}
-{{- range $memorySuffix := $memorySuffixes -}}
-  {{- if hasSuffix $memorySuffix $request -}}
-    {{- $requestSuffix = $memorySuffix }}
-    {{- $request = trimSuffix $requestSuffix $request -}}
-  {{- end -}}
-{{- end -}}
+{{- $requestSuffix = regexFind $unitPattern $request -}}
+{{- $request = trimSuffix $requestSuffix $request -}}
 {{- if or (not $requestSuffix) (le (float64 $request) 0.0) -}}
-  {{- fail (printf "Memory requests must be positive and use one of the following unit types: %s" (join ", " $memorySuffixes)) -}}
+  {{- fail "Memory requests must be positive and use one of the following unit types: K, Ki, M, Mi, G, Gi" -}}
 {{- end -}}
 {{- if $limits.memory -}}
-  {{- $limitSuffix := "" -}}
   {{- $limit := $limits.memory | toString -}}
-  {{- range $memorySuffix := $memorySuffixes -}}
-    {{- if hasSuffix $memorySuffix $limit -}}
-      {{- $limitSuffix = $memorySuffix }}
-      {{- $limit = trimSuffix $limitSuffix $limit -}}
-    {{- end -}}
-  {{- end -}}
+  {{- $limitSuffix := regexFind $unitPattern $limit -}}
+  {{- $limit = trimSuffix $limitSuffix $limit -}}
   {{- if or (not $limitSuffix) (le (float64 $limit) 0.0) -}}
-    {{- fail (printf "Memory limits must be positive and use one of the following unit types: %s" (join ", " $memorySuffixes)) -}}
+    {{- fail "Memory limits must be positive and use one of the following unit types: K, Ki, M, Mi, G, Gi" -}}
   {{- end -}}
 {{- end -}}
 {{- /* Configure memory limits, if not set */ -}}
@@ -132,6 +125,28 @@ CPU resources can only be integers/floats for an entire CPU or millicpu (m)
     {{- $limit = printf "%.3f%s" (mulf 2 (float64 $request)) $requestSuffix -}}
   {{- end -}}
   {{- $_ := set $resources.limits "memory" $limit -}}
+{{- end -}}
+{{- /* Validate and configure ephemeral-storage requests and limits */ -}}
+{{- if not (index $requests "ephemeral-storage") -}}
+  {{- $_ := unset $resources.requests "ephemeral-storage" -}}
+{{- end -}}
+{{- if index $requests "ephemeral-storage" -}}
+  {{- $esRequest := index $requests "ephemeral-storage" | toString -}}
+  {{- $esRequestSuffix := regexFind $unitPattern $esRequest -}}
+  {{- $esRequest = trimSuffix $esRequestSuffix $esRequest -}}
+  {{- if or (not $esRequestSuffix) (le (float64 $esRequest) 0.0) -}}
+    {{- fail "Ephemeral-storage requests must be positive and use one of the following unit types: K, Ki, M, Mi, G, Gi" -}}
+  {{- end -}}
+  {{- if index $limits "ephemeral-storage" -}}
+    {{- $esLimit := index $limits "ephemeral-storage" | toString -}}
+    {{- $esLimitSuffix := regexFind $unitPattern $esLimit -}}
+    {{- $esLimit = trimSuffix $esLimitSuffix $esLimit -}}
+    {{- if or (not $esLimitSuffix) (le (float64 $esLimit) 0.0) -}}
+      {{- fail "Ephemeral-storage limits must be positive and use one of the following unit types: K, Ki, M, Mi, G, Gi" -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $_ := set $resources.limits "ephemeral-storage" (index $requests "ephemeral-storage") -}}
+  {{- end -}}
 {{- end -}}
 {{- /* Return resources */ -}}
 {{- $resources | toYaml }}

--- a/mozcloud/application/templates/task/_jobTemplate.yaml
+++ b/mozcloud/application/templates/task/_jobTemplate.yaml
@@ -131,15 +131,14 @@ template:
 
         This function can be found in templates/_pod.yaml
         */}}
-        {{- $params = dict "requests" (dict "cpu" $containerConfig.resources.cpu "memory" $containerConfig.resources.memory) }}
-        {{- $resources := include "pod.container.resources" $params | fromYaml }}
         resources:
-          requests:
-            cpu: {{ $resources.requests.cpu | quote }}
-            memory: {{ $resources.requests.memory | quote }}
-          limits:
-            cpu: {{ $resources.limits.cpu | quote }}
-            memory: {{ $resources.limits.memory | quote }}
+          {{- $resourceParams := dict "requests" (dict 
+           "cpu" $containerConfig.resources.cpu
+           "memory" $containerConfig.resources.memory 
+           "ephemeral-storage" (index $containerConfig.resources "ephemeral-storage"))
+          -}}
+          {{- include "pod.container.resources" $resourceParams | nindent 10 }}
+
         {{- /*
         The container security context helper function can be found in templates/_pod.yaml
         */}}

--- a/mozcloud/application/templates/workload/_helpers.tpl
+++ b/mozcloud/application/templates/workload/_helpers.tpl
@@ -233,7 +233,11 @@ Returns:
   {{- end }}
   {{- end }}
   resources:
-    {{- $resourceParams := dict "requests" (dict "cpu" $containerConfig.resources.cpu "memory" $containerConfig.resources.memory) }}
+    {{- $resourceParams := dict "requests" (dict 
+      "cpu" $containerConfig.resources.cpu
+      "memory" $containerConfig.resources.memory 
+      "ephemeral-storage" (index $containerConfig.resources "ephemeral-storage"))
+    -}}
     {{- include "pod.container.resources" $resourceParams | nindent 4 }}
   {{- /* Sidecars run as init containers need restartPolicy: Always configured */ -}}
   {{- if and (eq $type "initContainer") (dig "sidecar" false $containerConfig) }}

--- a/mozcloud/application/tests/__snapshot__/ephemeral-storage-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/ephemeral-storage-configuration_test.yaml.snap
@@ -1,0 +1,95 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: web
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: web
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: web
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: web
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-image:1.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: app
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  ephemeral-storage: 1Gi
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  ephemeral-storage: 1Gi
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test

--- a/mozcloud/application/tests/ephemeral-storage-configuration_test.yaml
+++ b/mozcloud/application/tests/ephemeral-storage-configuration_test.yaml
@@ -1,0 +1,35 @@
+---
+suite: "mozcloud: Ephemeral storage configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/ephemeral-storage-configuration.yaml
+templates:
+  - workload/deployment.yaml
+tests:
+  - it: Ensure no failures occur
+    asserts:
+      - notFailedTemplate: {}
+  - it: Configuration matches entire snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: Container resources include ephemeral-storage request
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="app")].resources.requests.ephemeral-storage
+          value: "1Gi"
+  - it: Container resources include ephemeral-storage limit equal to request
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="app")].resources.limits.ephemeral-storage
+          value: "1Gi"

--- a/mozcloud/application/tests/values/ephemeral-storage-configuration.yaml
+++ b/mozcloud/application/tests/values/ephemeral-storage-configuration.yaml
@@ -1,0 +1,13 @@
+---
+workloads:
+  test-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: "1.0.0"
+        resources:
+          cpu: 100m
+          memory: 128Mi
+          ephemeral-storage: 1Gi

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1234,6 +1234,11 @@
               "description": "K, Ki, M, Mi, G, or Gi (recommend binary units)",
               "pattern": "^\\d+(K|Ki|M|Mi|G|Gi)$",
               "default": "128Mi"
+            },
+            "ephemeral-storage": {
+              "type": "string",
+              "description": "Ephemeral storage request using K, Ki, M, Mi, G, or Gi units",
+              "pattern": "^\\d+(K|Ki|M|Mi|G|Gi)$"
             }
           }
         },

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1137,6 +1137,13 @@ workloads:
           # The default value is 128Mi.
           memory: 128Mi
 
+          # Ephemeral storage can optionally be specified using K, Ki, M, Mi,
+          # G, or Gi suffixes. Unlike CPU and memory, limits are not
+          # auto-calculated — the limit is set equal to the request.
+          #
+          # Example:
+          #   ephemeral-storage: 1Gi
+
         # Optionally override some securityContext settings for the container.
         # This section should not be configured unless the user knows what they
         # are doing. Most tenants will not need to configure any of this.
@@ -1632,6 +1639,13 @@ workloads:
           #
           # The default value is 128Mi.
           memory: 128Mi
+
+          # Ephemeral storage can optionally be specified using K, Ki, M, Mi,
+          # G, or Gi suffixes. Unlike CPU and memory, limits are not
+          # auto-calculated — the limit is set equal to the request.
+          #
+          # Example:
+          #   ephemeral-storage: 1Gi
 
         # Optionally override some securityContext settings for the container.
         # This section should not be configured unless the user knows what they


### PR DESCRIPTION
## Summary
- Add optional `ephemeral-storage` resource support for workload containers, init containers, and task containers (jobs/cronjobs)
- Limit defaults to equal the request value (no 2x auto-doubling) since unexpected disk eviction is harder to recover from than CPU throttling
- Refactored unit suffix validation in `pod.container.resources` to use `regexFind` instead of loop-based matching

## Example
```yaml
workloads:
  my-app:
    containers:
      app:
        resources:
          cpu: 100m
          memory: 128Mi
          ephemeral-storage: 1Gi
```

Closes [MZCLD-2713](https://mozilla-hub.atlassian.net/browse/MZCLD-2713)