### PR TITLE
feat(mozcloud): add concurrencyPolicy support to CronJobs, allow custom parallel values for `make unit-tests`

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -64,9 +64,9 @@ jobs:
           if [ "${EVENT_NAME}" == "pull_request" ]; then
             affected=$(uv run --directory ./scripts chartkit affected --base "origin/${BASE_REF}")
             if [ -n "$affected" ]; then
-              uv run --directory ./scripts chartkit unittest $affected
+              uv run --directory ./scripts chartkit unittest --parallel 16 $affected
             fi
           else
-            make unit-tests
+            make unit-tests PARALLEL=16
           fi
         shell: bash

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -64,9 +64,9 @@ jobs:
           if [ "${EVENT_NAME}" == "pull_request" ]; then
             affected=$(uv run --directory ./scripts chartkit affected --base "origin/${BASE_REF}")
             if [ -n "$affected" ]; then
-              uv run --directory ./scripts chartkit unittest --parallel 16 $affected
+              uv run --directory ./scripts chartkit unittest $affected
             fi
           else
-            make unit-tests PARALLEL=16
+            make unit-tests
           fi
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ else
 	UPDATE_SNAPSHOTS_ARG =
 endif
 
+PARALLEL ?=
+PARALLEL_ARG := $(if $(PARALLEL),--parallel $(PARALLEL),)
+
 %:
 	@:
 
@@ -67,7 +70,7 @@ unit-tests: ## Run unit tests for all charts (set UPDATE_SNAPSHOTS=1 to update s
 		$(MAKE) update-dependencies; \
 	fi
 	@echo "$(UNIT_TEST_MESSAGE)"
-	@$(CHART_KIT) unittest $(UPDATE_SNAPSHOTS_ARG)
+	@$(CHART_KIT) unittest $(UPDATE_SNAPSHOTS_ARG) $(PARALLEL_ARG)
 
 unit-tests-affected: ## Run unit tests for staged charts and their dependents
 	@affected=$$($(CHART_KIT) affected); \

--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -82,6 +82,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | tasks.common.job.security | object | `{}` |  |
 | tasks.common.job.serviceAccount | string | `""` |  |
 | tasks.common.job.type | string | `"preDeployment"` |  |
+| tasks.cronJobs.default.concurrencyPolicy | string | `"Allow"` |  |
 | tasks.cronJobs.default.jobConfig | object | `{}` |  |
 | tasks.cronJobs.default.jobHistory.failed | int | `1` |  |
 | tasks.cronJobs.default.jobHistory.successful | int | `1` |  |

--- a/mozcloud/application/templates/task/cronjob.yaml
+++ b/mozcloud/application/templates/task/cronjob.yaml
@@ -25,6 +25,9 @@ metadata:
     {{- $annotations | toYaml | nindent 4 }}
   {{- end }}
 spec:
+  {{- if $config.concurrencyPolicy }}
+  concurrencyPolicy: {{ $config.concurrencyPolicy }}
+  {{- end }}
   {{- if ($config.jobHistory).successful }}
   successfulJobsHistoryLimit: {{ $config.jobHistory.successful }}
   {{- end }}

--- a/mozcloud/application/tests/__snapshot__/basic-cronjob-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/basic-cronjob-configuration_test.yaml.snap
@@ -16,6 +16,7 @@ Configuration matches entire snapshot:
         realm: nonprod
       name: test-cronjob
     spec:
+      concurrencyPolicy: Allow
       failedJobsHistoryLimit: 1
       jobTemplate:
         spec:

--- a/mozcloud/application/tests/__snapshot__/external-secrets_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/external-secrets_test.yaml.snap
@@ -82,6 +82,7 @@ Configuration matches entire snapshot:
         realm: nonprod
       name: test-cronjob
     spec:
+      concurrencyPolicy: Allow
       failedJobsHistoryLimit: 1
       jobTemplate:
         spec:

--- a/mozcloud/application/tests/basic-cronjob-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-cronjob-configuration_test.yaml
@@ -32,6 +32,9 @@ tests:
           path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
       - notExists:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Allow
       - matchRegex:
           path: spec.schedule
           pattern: ^(0 \* \* \* \*|@hourly)$

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1331,6 +1331,10 @@
     "cronJob": {
       "type": "object",
       "properties": {
+        "concurrencyPolicy": {
+          "type": "string",
+          "enum": ["Allow", "Forbid", "Replace"]
+        },
         "jobHistory": {
           "type": "object",
           "additionalProperties": false,

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -303,6 +303,7 @@ tasks:
     #
     # Some options are commented out as they are omitted by default.
     cronJob:
+      #concurrencyPolicy:
       jobHistory: {}
       schedule: ''
       #suspend:
@@ -333,6 +334,14 @@ tasks:
     # This is the name of your cron job. Use any name other than "default",
     # which is reserved for setting default values shared across all cron jobs.
     default:
+      # Controls how Kubernetes handles overlapping executions of the same cron
+      # job. Valid values are:
+      #
+      #   Allow:   (default) allows concurrent runs
+      #   Forbid:  skips the new run if a previous run is still active
+      #   Replace: cancels the running job and replaces it with a new one
+      concurrencyPolicy: Allow
+
       # Configures the total number of jobs keep after cron jobs run.
       jobHistory:
         successful: 1

--- a/scripts/chartkit/cli.py
+++ b/scripts/chartkit/cli.py
@@ -172,6 +172,7 @@ def affected(graph: ChartGraph, base: Optional[str]):
     "--parallel",
     "-p",
     default=None,
+    type=int,
     help="Number of parallel workers (default: CPU count).",
 )
 @click.option(


### PR DESCRIPTION
Two changes:

1. Adds `concurrencyPolicy` support to CronJob resources. The default is `Always`.
2. Updates Makefile and chartkit to allow customization of parallel runs of unit tests in `make` command