### PR TITLE
chore: Improve unit test times by collapsing similar test blocks

### DIFF
--- a/.claude/skills/chart-standards/SKILL.md
+++ b/.claude/skills/chart-standards/SKILL.md
@@ -112,6 +112,6 @@ Before running unit tests after modifying a library chart, always run `make upda
 - Ensure `make unit-tests` results in all tests passing before finishing a change.
 
 ### Unit test structure
-Every test suite must open with these two cases, in this order, before any feature-specific assertions:
-1. `Ensure no failures occur` — asserts `notFailedTemplate: {}`
-2. `Configuration matches entire snapshot` — asserts `matchSnapshot: {}`
+Every test suite must open with a single `Configuration matches entire snapshot` case whose `asserts` contains both `notFailedTemplate: {}` and `matchSnapshot: {}`, in that order, before any feature-specific assertions.
+
+helm-unittest re-renders the full chart for every `it:` block, so keep the total number of `it:` blocks in a suite small. Group feature-specific assertions under a single `it:` when they share a theme, and use per-assert `template` and `documentSelector` to target different documents within a group. Only split into a new `it:` when the test needs a different `set` / `values` override, or when splitting genuinely clarifies intent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,11 +100,9 @@ templates:
   - workload/deployment.yaml         # Limit rendering to only the templates under test
   - workload/hpa.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
   - it: Deployment has correct replica settings
     template: workload/deployment.yaml
@@ -120,8 +118,8 @@ tests:
 Conventions to follow:
 
 - **Pin `chart.version` to `1.0.0`.** The labels library embeds the chart version in resource labels, so leaving it unpinned causes every snapshot to change on every chart bump, adding noise to PR diffs that is unrelated to the change being reviewed.
-- **Always include `notFailedTemplate` as the first test in every suite.** This catches render errors before any other assertions run.
-- **Always include `matchSnapshot`.** See [Snapshots](#snapshots) below.
+- **Always include `notFailedTemplate` and `matchSnapshot` in the first `it:` block.** `notFailedTemplate` catches render errors; `matchSnapshot` is the primary regression safety net (see [Snapshots](#snapshots) below). Keep them in the same `it:` so the chart is only rendered once for both.
+- **Prefer fewer `it:` blocks with more assertions.** helm-unittest re-renders the full chart for every `it:` block, which is the dominant cost of the suite. Group assertions under a single `it:` when they share a semantic theme, and use per-assert `template` and `documentSelector` when you need to target different documents within the same group. Split into a new `it:` only when the test requires a different `set` / `values` override, or when splitting genuinely clarifies intent.
 - **Scope your `templates` list to only the templates relevant to the scenario.** Rendering every template in every suite adds noise and slows tests down.
 
 ### Values organization

--- a/mozcloud-gateway/application/tests/basic-configuration_test.yaml
+++ b/mozcloud-gateway/application/tests/basic-configuration_test.yaml
@@ -12,40 +12,51 @@ values:
   - values/globals.yaml
   - values/basic-configuration.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: GCP backend policy is configured correctly
-    template: backendpolicy.yaml
-    documentSelector:
-      path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
-      value: test-service
+
+  - it: Gateway, GCPGatewayPolicy, Service, GCPBackendPolicy, and HealthCheckPolicy are configured correctly
     asserts:
+      # GCP backend policy is configured correctly
       - isSubset:
           path: spec.default
           content:
             logging:
               enabled: true
               sampleRate: 100000
+        template: backendpolicy.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: test-service
       - equal:
           path: spec.targetRef.name
           value: test-service
+        template: backendpolicy.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: test-service
       - notExists:
           path: spec.default.securityPolicy
-  - it: External gateway is configured correctly
-    template: gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: test-gateway
-    asserts:
+        template: backendpolicy.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: test-service
+      # External gateway is configured correctly
       - equal:
           path: metadata.annotations["networking.gke.io/certmap"]
           value: mozcloud-test-nonprod-dev
+        template: gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: test-gateway
       - isNotNullOrEmpty:
           path: spec.addresses
+        template: gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: test-gateway
       - contains:
           path: spec.listeners
           count: 1
@@ -56,6 +67,10 @@ tests:
             name: http
             port: 80
             protocol: HTTP
+        template: gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: test-gateway
       - contains:
           path: spec.listeners
           count: 1
@@ -66,42 +81,87 @@ tests:
             name: https
             port: 443
             protocol: HTTPS
+        template: gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: test-gateway
       - matchRegex:
           path: spec.gatewayClassName
           pattern: ^gke-l7-global-external-managed(-mc)?$
-  - it: Gateway policy is configured correctly
-    template: gatewaypolicy.yaml
-    documentSelector:
-      path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
-      value: test-gateway
-    asserts:
+        template: gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: test-gateway
+      # Gateway policy is configured correctly
       - equal:
           path: spec.default.sslPolicy
           value: mozilla-intermediate
+        template: gatewaypolicy.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
+          value: test-gateway
       - isSubset:
           path: spec.targetRef
           content:
             group: gateway.networking.k8s.io
             kind: Gateway
             name: test-gateway
-  - it: Healthcheck policy is configured correctly
-    template: healthcheckpolicy.yaml
-    documentSelector:
-      path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
-      value: test-service
-    asserts:
+        template: gatewaypolicy.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
+          value: test-gateway
+      # Healthcheck policy is configured correctly
       - equal:
           path: spec.default.config.httpHealthCheck.requestPath
           value: /__lbheartbeat__
+        template: healthcheckpolicy.yaml
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: test-service
       - equal:
           path: spec.targetRef.name
           value: test-service
-  - it: HTTPS HTTPRoute is configured correctly
+        template: healthcheckpolicy.yaml
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: test-service
+      # Service is configured correctly
+      - contains:
+          path: spec.ports
+          count: 1
+          content:
+            name: http
+            port: 8080
+            protocol: TCP
+            targetPort: http
+        template: service.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      - exists:
+          path: spec.selector
+        template: service.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      - isNotNullOrEmpty:
+          path: spec.selector
+        template: service.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        template: service.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+
+  - it: HTTPS and HTTP-to-HTTPS redirect HTTPRoutes are configured correctly
     template: httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: test-httproute
     asserts:
+      # HTTPS HTTPRoute is configured correctly
       - contains:
           path: spec.parentRefs
           count: 1
@@ -110,6 +170,9 @@ tests:
             kind: Gateway
             name: test-gateway
             sectionName: https
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute
       - notContains:
           path: spec.parentRefs
           content:
@@ -117,11 +180,20 @@ tests:
             kind: Gateway
             name: test-gateway
             sectionName: http
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute
       - lengthEqual:
           path: spec.rules
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute
       - exists:
           path: spec.rules[0].backendRefs
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute
       - contains:
           path: spec.rules[0].backendRefs
           count: 1
@@ -131,14 +203,15 @@ tests:
             name: test-service
             port: 8080
             weight: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute
       - notExists:
           path: spec.rules[0].filters[0].requestRedirect
-  - it: HTTP-to-HTTPS redirect HTTPRoute is configured correctly
-    template: httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: test-httproute-http-redirect
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute
+      # HTTP-to-HTTPS redirect HTTPRoute is configured correctly
       - contains:
           path: spec.parentRefs
           count: 1
@@ -147,6 +220,9 @@ tests:
             kind: Gateway
             name: test-gateway
             sectionName: http
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute-http-redirect
       - notContains:
           path: spec.parentRefs
           content:
@@ -154,11 +230,20 @@ tests:
             kind: Gateway
             name: test-gateway
             sectionName: https
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute-http-redirect
       - lengthEqual:
           path: spec.rules
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute-http-redirect
       - notExists:
           path: spec.rules[0].backendRefs
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute-http-redirect
       - contains:
           path: spec.rules[0].filters
           count: 1
@@ -167,6 +252,9 @@ tests:
               scheme: https
               statusCode: 302
             type: RequestRedirect
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute-http-redirect
       - contains:
           path: spec.rules[0].matches
           count: 1
@@ -174,24 +262,6 @@ tests:
             path:
               type: PathPrefix
               value: /
-  - it: Service is configured correctly
-    template: service.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
-      - contains:
-          path: spec.ports
-          count: 1
-          content:
-            name: http
-            port: 8080
-            protocol: TCP
-            targetPort: http
-      - exists:
-          path: spec.selector
-      - isNotNullOrEmpty:
-          path: spec.selector
-      - equal:
-          path: spec.type
-          value: ClusterIP
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-httproute-http-redirect

--- a/mozcloud-ingress/application/tests/basic-configuration_test.yaml
+++ b/mozcloud-ingress/application/tests/basic-configuration_test.yaml
@@ -12,32 +12,31 @@ values:
   - values/globals.yaml
   - values/basic-configuration.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Backend is configured correctly
-    template: backendconfig.yaml
-    documentSelector:
-      path: $[?(@.kind == "BackendConfig")].metadata.name
-      value: test-ingress
+
+  - it: BackendConfig, FrontendConfig, Ingress, ManagedCertificate, and Service are configured correctly
     asserts:
+      # Backend is configured correctly
       - isSubset:
           path: spec
           content:
             logging:
               enable: true
               sampleRate: 0.1
+        template: backendconfig.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-ingress
       - notExists:
           path: spec.securityPolicy
-  - it: Frontend is configured correctly
-    template: frontendconfig.yaml
-    documentSelector:
-      path: $[?(@.kind == "FrontendConfig")].metadata.name
-      value: test-ingress
-    asserts:
+        template: backendconfig.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-ingress
+      # Frontend is configured correctly
       - isSubset:
           path: spec
           content:
@@ -45,12 +44,11 @@ tests:
               enabled: true
               responseCodeName: MOVED_PERMANENTLY_DEFAULT
             sslPolicy: mozilla-intermediate
-  - it: Ingress is configured correctly
-    template: ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-ingress
-    asserts:
+        template: frontendconfig.yaml
+        documentSelector:
+          path: $[?(@.kind == "FrontendConfig")].metadata.name
+          value: test-ingress
+      # Ingress is configured correctly
       - isSubset:
           path: metadata.annotations
           content:
@@ -58,6 +56,10 @@ tests:
             kubernetes.io/ingress.global-static-ip-name: mozcloud-test-dev-ip-v4
             networking.gke.io/managed-certificates: mcrt-test-ingress-0
             networking.gke.io/v1beta1.FrontendConfig: test-ingress
+        template: ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-ingress
       - isSubset:
           path: spec
           content:
@@ -66,24 +68,26 @@ tests:
                 name: test-ingress
                 port:
                   number: 8080
-  - it: Managed certificate is configured correctly
-    template: managedcertificate.yaml
-    documentSelector:
-      path: $[?(@.kind == "ManagedCertificate")].metadata.name
-      value: mcrt-test-ingress-0
-    asserts:
+        template: ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-ingress
+      # Managed certificate is configured correctly
       - lengthEqual:
           path: spec.domains
           count: 1
+        template: managedcertificate.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: mcrt-test-ingress-0
       - contains:
           path: spec.domains
           content: "test-service.dev.test-domain.com"
-  - it: Service is configured correctly
-    template: service.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-ingress
-    asserts:
+        template: managedcertificate.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: mcrt-test-ingress-0
+      # Service is configured correctly
       - contains:
           path: spec.ports
           count: 1
@@ -92,10 +96,26 @@ tests:
             port: 8080
             protocol: TCP
             targetPort: http
+        template: service.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-ingress
       - exists:
           path: spec.selector
+        template: service.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-ingress
       - isNotNullOrEmpty:
           path: spec.selector
+        template: service.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-ingress
       - equal:
           path: spec.type
           value: ClusterIP
+        template: service.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-ingress

--- a/mozcloud-ingress/application/tests/cert-names-configuration_test.yaml
+++ b/mozcloud-ingress/application/tests/cert-names-configuration_test.yaml
@@ -12,36 +12,34 @@ templates:
   - managedcertificate.yaml
   - ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: A ManagedCertificate is created for the first user-specified name
-    template: managedcertificate.yaml
-    documentSelector:
-      path: $[?(@.kind == "ManagedCertificate")].metadata.name
-      value: cert-a
+
+  - it: ManagedCertificates are created per user-specified name and Ingress references all of them
     asserts:
+      # A ManagedCertificate is created for the first user-specified name
       - contains:
           path: spec.domains
           content: "test-service.dev.test-domain.com"
-  - it: A ManagedCertificate is created for the second user-specified name
-    template: managedcertificate.yaml
-    documentSelector:
-      path: $[?(@.kind == "ManagedCertificate")].metadata.name
-      value: cert-b
-    asserts:
+        template: managedcertificate.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: cert-a
+      # A ManagedCertificate is created for the second user-specified name
       - contains:
           path: spec.domains
           content: "test-service.dev.test-domain.com"
-  - it: Ingress annotation references all cert names
-    template: ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-ingress
-    asserts:
+        template: managedcertificate.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: cert-b
+      # Ingress annotation references all cert names
       - equal:
           path: metadata.annotations["networking.gke.io/managed-certificates"]
           value: cert-a,cert-b
+        template: ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-ingress

--- a/mozcloud-ingress/application/tests/disable-managed-cert-configuration_test.yaml
+++ b/mozcloud-ingress/application/tests/disable-managed-cert-configuration_test.yaml
@@ -12,23 +12,22 @@ templates:
   - managedcertificate.yaml
   - ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: No ManagedCertificate resources are created
-    template: managedcertificate.yaml
+
+  - it: No ManagedCertificate is created and Ingress references the pre-existing cert name
     asserts:
+      # No ManagedCertificate resources are created
       - hasDocuments:
           count: 0
-  - it: Ingress annotation references the pre-existing cert name
-    template: ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-ingress
-    asserts:
+        template: managedcertificate.yaml
+      # Ingress annotation references the pre-existing cert name
       - equal:
           path: metadata.annotations["networking.gke.io/managed-certificates"]
           value: existing-cert
+        template: ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-ingress

--- a/mozcloud-ingress/application/tests/multi-cert-no-create-configuration_test.yaml
+++ b/mozcloud-ingress/application/tests/multi-cert-no-create-configuration_test.yaml
@@ -12,20 +12,18 @@ templates:
   - managedcertificate.yaml
   - ingress.yaml
 tests:
-  - it: Ensure no failures occur
+  - it: Templates render without failures, no ManagedCertificate is created, and Ingress references all pre-existing cert names
     asserts:
       - notFailedTemplate: {}
-  - it: No ManagedCertificate resources are created
-    template: managedcertificate.yaml
-    asserts:
+      # No ManagedCertificate resources are created
       - hasDocuments:
           count: 0
-  - it: Ingress annotation references all pre-existing cert names
-    template: ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-ingress
-    asserts:
+        template: managedcertificate.yaml
+      # Ingress annotation references all pre-existing cert names
       - equal:
           path: metadata.annotations["networking.gke.io/managed-certificates"]
           value: cert-a,cert-b
+        template: ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-ingress

--- a/mozcloud/application/tests/basic-configmap-interpolate_test.yaml
+++ b/mozcloud/application/tests/basic-configmap-interpolate_test.yaml
@@ -17,67 +17,39 @@ tests:
   - it: Configuration matches entire snapshot
     asserts:
       - matchSnapshot: {}
-  # Test that explicitly listed keys are transformed
-  - it: URLBASE is transformed when empty and explicitly listed
+
+  - it: ConfigMap keys transform (or preserve) correctly based on urlTransformKeys
     template: configmap/configmap.yaml
     documentSelector:
       path: $[?(@.kind == "ConfigMap")].metadata.name
       value: app-config
     asserts:
+      # Test that explicitly listed keys are transformed
+      # URLBASE is transformed when empty and explicitly listed
       - equal:
           path: data.URLBASE
           value: "https://test.preview.mozilla.cloud"
-
-  - it: ATTACHMENT_BASE is transformed when empty and explicitly listed
-    template: configmap/configmap.yaml
-    documentSelector:
-      path: $[?(@.kind == "ConfigMap")].metadata.name
-      value: app-config
-    asserts:
+      # ATTACHMENT_BASE is transformed when empty and explicitly listed
       - equal:
           path: data.ATTACHMENT_BASE
           value: "https://test.preview.mozilla.cloud/attachments"
-
-  # Test that non-listed keys are NOT transformed
-  - it: URL_BASE is not transformed when not in urlTransformKeys list
-    template: configmap/configmap.yaml
-    documentSelector:
-      path: $[?(@.kind == "ConfigMap")].metadata.name
-      value: app-config
-    asserts:
+      # Test that non-listed keys are NOT transformed
+      # URL_BASE is not transformed when not in urlTransformKeys list
       - equal:
           path: data.URL_BASE
           value: ""
-
-  # Test that non-empty values are preserved
-  - it: Non-empty values are not overwritten
-    template: configmap/configmap.yaml
-    documentSelector:
-      path: $[?(@.kind == "ConfigMap")].metadata.name
-      value: app-config
-    asserts:
+      # Test that non-empty values are preserved
+      # Non-empty values are not overwritten
       - equal:
           path: data.OTHER_VAR
           value: "keep-this"
-
-  # Test that values defined in the same file can be referenced
-  - it: HOSTNAME evaluates to yaml value defined in same file
-    template: configmap/configmap.yaml
-    documentSelector:
-      path: $[?(@.kind == "ConfigMap")].metadata.name
-      value: app-config
-    asserts:
+      # Test that values defined in the same file can be referenced
+      # HOSTNAME evaluates to yaml value defined in same file
       - equal:
           path: data.HOSTNAME
           value: "mozilla.cloud"
-
-  # Test that default values can be set
-  - it: DEFAULT is set to 'default'
-    template: configmap/configmap.yaml
-    documentSelector:
-      path: $[?(@.kind == "ConfigMap")].metadata.name
-      value: app-config
-    asserts:
+      # Test that default values can be set
+      # DEFAULT is set to 'default'
       - equal:
           path: data.DEFAULT
           value: "default"

--- a/mozcloud/application/tests/basic-cronjob-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-cronjob-configuration_test.yaml
@@ -14,59 +14,100 @@ values:
 templates:
   - task/cronjob.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
       - matchSnapshot: {}
-  - it: Cron job is configured correctly
+
+  - it: CronJob renders without failures and is configured correctly
     template: task/cronjob.yaml
-    documentSelector:
-      path: $[?(@.kind == "CronJob")].metadata.name
-      value: test-cronjob
     asserts:
+      - notFailedTemplate: {}
       - notExists:
           path: metadata.annotations["argocd.argoproj.io/hook"]
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - notExists:
           path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - notExists:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.concurrencyPolicy
           value: Allow
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - matchRegex:
           path: spec.schedule
           pattern: ^(0 \* \* \* \*|@hourly)$
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.successfulJobsHistoryLimit
           value: 1
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.failedJobsHistoryLimit
           value: 1
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.jobTemplate.spec.backoffLimit
           value: 6
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.jobTemplate.spec.parallelism
           value: 1
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - lengthEqual:
           path: spec.jobTemplate.spec.template.spec.containers
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
           value: test-repo/test-image:latest
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].command
           value: ["sh", "-c"]
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].args
           value: ["echo", "foo", "bar"]
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].name
           value: job
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - exists:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - isSubset:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources
           content:
@@ -76,8 +117,14 @@ tests:
             requests:
               cpu: 100m
               memory: 128Mi
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - exists:
           path: spec.jobTemplate.spec.template.spec.containers[0].securityContext
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - isSubset:
           path: spec.jobTemplate.spec.template.spec.containers[0].securityContext
           content:
@@ -87,11 +134,20 @@ tests:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - equal:
           path: spec.jobTemplate.spec.template.spec.restartPolicy
           value: Never
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - exists:
           path: spec.jobTemplate.spec.template.spec.securityContext
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob
       - isSubset:
           path: spec.jobTemplate.spec.template.spec.securityContext
           content:
@@ -100,3 +156,6 @@ tests:
             runAsUser: 10001
             seccompProfile:
               type: RuntimeDefault
+        documentSelector:
+          path: $[?(@.kind == "CronJob")].metadata.name
+          value: test-cronjob

--- a/mozcloud/application/tests/basic-gateway-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-gateway-configuration_test.yaml
@@ -18,40 +18,51 @@ templates:
   - gke/backend.yaml
   - gke/gateway.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: GCP backend policy is configured correctly
-    template: gke/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
-      value: test-service
+
+  - it: Gateway, GCPGatewayPolicy, backend Service, GCPBackendPolicy, and HealthCheckPolicy are configured correctly
     asserts:
+      # GCP backend policy is configured correctly
       - isSubset:
           path: spec.default
           content:
             logging:
               enabled: true
               sampleRate: 500000
+        template: gke/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: test-service
       - equal:
           path: spec.targetRef.name
           value: test-service
+        template: gke/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: test-service
       - notExists:
           path: spec.default.securityPolicy
-  - it: External gateway is configured correctly
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test
-    asserts:
+        template: gke/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: test-service
+      # External gateway is configured correctly
       - equal:
           path: metadata.annotations["networking.gke.io/certmap"]
           value: test-service-nonprod-dev
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - isNotNullOrEmpty:
           path: spec.addresses
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - contains:
           path: spec.listeners
           count: 1
@@ -62,6 +73,10 @@ tests:
             name: http
             port: 80
             protocol: HTTP
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - contains:
           path: spec.listeners
           count: 1
@@ -72,42 +87,87 @@ tests:
             name: https
             port: 443
             protocol: HTTPS
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - matchRegex:
           path: spec.gatewayClassName
           pattern: ^gke-l7-global-external-managed(-mc)?$
-  - it: Gateway policy is configured correctly
-    template: gke/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
-      value: mozcloud-test
-    asserts:
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
+      # Gateway policy is configured correctly
       - equal:
           path: spec.default.sslPolicy
           value: mozilla-intermediate
+        template: gke/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
+          value: mozcloud-test
       - isSubset:
           path: spec.targetRef
           content:
             group: gateway.networking.k8s.io
             kind: Gateway
             name: mozcloud-test
-  - it: Healthcheck policy is configured correctly
-    template: gke/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
-      value: test-service
-    asserts:
+        template: gke/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
+          value: mozcloud-test
+      # Healthcheck policy is configured correctly
       - equal:
           path: spec.default.config.httpHealthCheck.requestPath
           value: /__lbheartbeat__
+        template: gke/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: test-service
       - equal:
           path: spec.targetRef.name
           value: test-service
-  - it: HTTPS HTTPRoute is configured correctly
+        template: gke/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: test-service
+      # Service is configured correctly
+      - contains:
+          path: spec.ports
+          count: 1
+          content:
+            name: http
+            port: 8080
+            protocol: TCP
+            targetPort: http
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      - exists:
+          path: spec.selector
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      - isNotNullOrEmpty:
+          path: spec.selector
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+
+  - it: HTTPS and HTTP-to-HTTPS redirect HTTPRoutes are configured correctly
     template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: test-service
     asserts:
+      # HTTPS HTTPRoute is configured correctly
       - contains:
           path: spec.parentRefs
           count: 1
@@ -116,6 +176,9 @@ tests:
             kind: Gateway
             name: mozcloud-test
             sectionName: https
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service
       - notContains:
           path: spec.parentRefs
           content:
@@ -123,11 +186,20 @@ tests:
             kind: Gateway
             name: mozcloud-test
             sectionName: http
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service
       - lengthEqual:
           path: spec.rules
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service
       - exists:
           path: spec.rules[0].backendRefs
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service
       - contains:
           path: spec.rules[0].backendRefs
           count: 1
@@ -137,14 +209,15 @@ tests:
             name: test-service
             port: 8080
             weight: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service
       - notExists:
           path: spec.rules[0].filters[0].requestRedirect
-  - it: HTTP-to-HTTPS redirect HTTPRoute is configured correctly
-    template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: test-service-http-redirect
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service
+      # HTTP-to-HTTPS redirect HTTPRoute is configured correctly
       - contains:
           path: spec.parentRefs
           count: 1
@@ -153,6 +226,9 @@ tests:
             kind: Gateway
             name: mozcloud-test
             sectionName: http
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service-http-redirect
       - notContains:
           path: spec.parentRefs
           content:
@@ -160,11 +236,20 @@ tests:
             kind: Gateway
             name: mozcloud-test
             sectionName: https
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service-http-redirect
       - lengthEqual:
           path: spec.rules
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service-http-redirect
       - notExists:
           path: spec.rules[0].backendRefs
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service-http-redirect
       - contains:
           path: spec.rules[0].filters
           count: 1
@@ -173,6 +258,9 @@ tests:
               scheme: https
               statusCode: 302
             type: RequestRedirect
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service-http-redirect
       - contains:
           path: spec.rules[0].matches
           count: 1
@@ -180,24 +268,6 @@ tests:
             path:
               type: PathPrefix
               value: /
-  - it: Service is configured correctly
-    template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
-      - contains:
-          path: spec.ports
-          count: 1
-          content:
-            name: http
-            port: 8080
-            protocol: TCP
-            targetPort: http
-      - exists:
-          path: spec.selector
-      - isNotNullOrEmpty:
-          path: spec.selector
-      - equal:
-          path: spec.type
-          value: ClusterIP
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service-http-redirect

--- a/mozcloud/application/tests/basic-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-ingress-configuration_test.yaml
@@ -17,30 +17,25 @@ templates:
   - gke/ingress.yaml
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Backend is configured correctly
-    template: gke/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "BackendConfig")].metadata.name
-      value: test-service
+
+  - it: BackendConfig, FrontendConfig, Ingress, ManagedCertificate, and Services are configured correctly
     asserts:
+      # Backend is configured correctly
       - isSubset:
           path: spec
           content:
             logging:
               enable: true
               sampleRate: 0.1
-  - it: Frontend is configured correctly
-    template: gke/frontendconfig.yaml
-    documentSelector:
-      path: $[?(@.kind == "FrontendConfig")].metadata.name
-      value: test-service
-    asserts:
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-service
+      # Frontend is configured correctly
       - isSubset:
           path: spec
           content:
@@ -48,12 +43,11 @@ tests:
               enabled: true
               responseCodeName: MOVED_PERMANENTLY_DEFAULT
             sslPolicy: mozilla-intermediate
-  - it: Ingress is configured correctly
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+        template: gke/frontendconfig.yaml
+        documentSelector:
+          path: $[?(@.kind == "FrontendConfig")].metadata.name
+          value: test-service
+      # Ingress is configured correctly
       - isSubset:
           path: metadata.annotations
           content:
@@ -61,6 +55,10 @@ tests:
             kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
             networking.gke.io/managed-certificates: mcrt-test-service-dev-test-domain-com
             networking.gke.io/v1beta1.FrontendConfig: test-service
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service
       - isSubset:
           path: spec
           content:
@@ -69,24 +67,26 @@ tests:
                 name: test-service
                 port:
                   number: 8080
-  - it: Managed certificate is configured correctly
-    template: gke/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "ManagedCertificate")].metadata.name
-      value: mcrt-test-service-dev-test-domain-com
-    asserts:
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service
+      # Managed certificate is configured correctly
       - lengthEqual:
           path: spec.domains
           count: 1
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: mcrt-test-service-dev-test-domain-com
       - contains:
           path: spec.domains
           content: "test-service.dev.test-domain.com"
-  - it: Service is configured correctly
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: mcrt-test-service-dev-test-domain-com
+      # Service is configured correctly
       - contains:
           path: spec.ports
           count: 1
@@ -95,19 +95,30 @@ tests:
             port: 8080
             protocol: TCP
             targetPort: http
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
       - exists:
           path: spec.selector
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
       - isNotNullOrEmpty:
           path: spec.selector
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
       - equal:
           path: spec.type
           value: ClusterIP
-  - it: Service for nginx-disabled workload routes to explicit targetPort
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: nginx-disabled-service
-    asserts:
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      # Service for nginx-disabled workload routes to explicit targetPort
       - contains:
           path: spec.ports
           count: 1
@@ -116,3 +127,7 @@ tests:
             port: 8080
             protocol: TCP
             targetPort: web-server
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: nginx-disabled-service

--- a/mozcloud/application/tests/basic-job-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-job-configuration_test.yaml
@@ -20,50 +20,80 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Pre-deployment job is configured correctly
+
+  - it: Pre- and post-deployment Jobs are configured correctly
     template: task/job.yaml
-    documentSelector:
-      path: $[?(@.kind == "Job")].metadata.name
-      value: test-predeployment-job
     asserts:
+      # Pre-deployment job is configured correctly
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook"]
           value: Sync
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
           value: BeforeHookCreation,HookSucceeded
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "-1"
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - equal:
           path: spec.backoffLimit
           value: 6
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - equal:
           path: spec.parallelism
           value: 1
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - lengthEqual:
           path: spec.template.spec.containers
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - equal:
           path: spec.template.spec.containers[0].image
           value: test-repo/test-predeployment-job-image:2.0.0
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - equal:
           path: spec.template.spec.containers[0].command
           value: ["sh", "-c"]
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - equal:
           path: spec.template.spec.containers[0].args
           value: ["echo", "running", "before", "deployment"]
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - equal:
           path: spec.template.spec.containers[0].name
           value: job
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - exists:
           path: spec.template.spec.containers[0].resources
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - isSubset:
           path: spec.template.spec.containers[0].resources
           content:
@@ -73,8 +103,14 @@ tests:
             requests:
               cpu: 100m
               memory: 128Mi
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - exists:
           path: spec.template.spec.containers[0].securityContext
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - isSubset:
           path: spec.template.spec.containers[0].securityContext
           content:
@@ -84,11 +120,20 @@ tests:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - equal:
           path: spec.template.spec.restartPolicy
           value: Never
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - exists:
           path: spec.template.spec.securityContext
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
       - isSubset:
           path: spec.template.spec.securityContext
           content:
@@ -97,44 +142,75 @@ tests:
             runAsUser: 10001
             seccompProfile:
               type: RuntimeDefault
-  - it: Post-deployment job is configured correctly
-    template: task/job.yaml
-    documentSelector:
-      path: $[?(@.kind == "Job")].metadata.name
-      value: test-postdeployment-job
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-predeployment-job
+      # Post-deployment job is configured correctly
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook"]
           value: Sync
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
           value: BeforeHookCreation,HookSucceeded
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "1"
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - equal:
           path: spec.backoffLimit
           value: 6
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - equal:
           path: spec.parallelism
           value: 1
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - lengthEqual:
           path: spec.template.spec.containers
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - equal:
           path: spec.template.spec.containers[0].image
           value: test-repo/test-postdeployment-job-image:3.0.0
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - equal:
           path: spec.template.spec.containers[0].command
           value: ["sh", "-c"]
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - equal:
           path: spec.template.spec.containers[0].args
           value: ["echo", "running", "after", "deployment"]
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - equal:
           path: spec.template.spec.containers[0].name
           value: job
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - exists:
           path: spec.template.spec.containers[0].resources
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - isSubset:
           path: spec.template.spec.containers[0].resources
           content:
@@ -144,8 +220,14 @@ tests:
             requests:
               cpu: 100m
               memory: 128Mi
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - exists:
           path: spec.template.spec.containers[0].securityContext
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - isSubset:
           path: spec.template.spec.containers[0].securityContext
           content:
@@ -155,11 +237,20 @@ tests:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - equal:
           path: spec.template.spec.restartPolicy
           value: Never
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - exists:
           path: spec.template.spec.securityContext
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job
       - isSubset:
           path: spec.template.spec.securityContext
           content:
@@ -168,3 +259,6 @@ tests:
             runAsUser: 10001
             seccompProfile:
               type: RuntimeDefault
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-postdeployment-job

--- a/mozcloud/application/tests/basic-workload-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-workload-configuration_test.yaml
@@ -19,13 +19,12 @@ templates:
   - workload/deployment.yaml
   - workload/hpa.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Config map is configured correctly
+
+  - it: ConfigMap is configured correctly
     template: configmap/configmap.yaml
     documentSelector:
       path: $[?(@.kind == "ConfigMap")].metadata.name
@@ -39,7 +38,8 @@ tests:
           content:
             FOO: bar
             baz: "1"
-  - it: External secret is configured correctly
+
+  - it: ExternalSecret is configured correctly
     template: externalsecret/externalsecret.yaml
     documentSelector:
       path: $[?(@.kind == "ExternalSecret")].metadata.name
@@ -68,7 +68,8 @@ tests:
       - equal:
           path: spec.target.name
           value: test-chart-secrets
-  - it: Service account is configured correctly
+
+  - it: ServiceAccount is configured correctly
     template: serviceaccount/serviceaccount.yaml
     documentSelector:
       path: $[?(@.kind == "ServiceAccount")].metadata.name
@@ -82,12 +83,14 @@ tests:
       - equal:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
           value: gke-dev@moz-fx-mozcloud-test-nonprod.iam.gserviceaccount.com
-  - it: Deployment (containers excluded) is configured correctly
+
+  - it: Deployment pod spec and both containers are configured correctly
     template: workload/deployment.yaml
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service
     asserts:
+      # Deployment (containers excluded) is configured correctly
       - exists:
           path: spec.selector.matchLabels
       - isNotNullOrEmpty:
@@ -139,12 +142,7 @@ tests:
             secret:
               secretName: test-service-secret
             name: test-service-secret
-  - it: Deployment (app container) is configured correctly
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Deployment (app container) is configured correctly
       - contains:
           path: spec.template.spec.containers[1].envFrom
           content:
@@ -207,12 +205,7 @@ tests:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
-  - it: Deployment (nginx container) is configured correctly
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Deployment (nginx container) is configured correctly
       - equal:
           path: spec.template.spec.containers[0].image
           value: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
@@ -290,7 +283,8 @@ tests:
             name: nginx-conf
             readOnly: true
             subPath: nginx.conf
-  - it: NGINX config map is configured correctly
+
+  - it: NGINX sidecar ConfigMap is rendered with nginx.conf data
     template: workload/deployment.yaml
     documentSelector:
       path: $[?(@.kind == "ConfigMap")].metadata.name
@@ -298,6 +292,7 @@ tests:
     asserts:
       - isNotNullOrEmpty:
           path: data["nginx.conf"]
+
   - it: HPA is configured correctly
     template: workload/hpa.yaml
     documentSelector:
@@ -325,11 +320,13 @@ tests:
             apiVersion: apps/v1
             kind: Deployment
             name: test-service
+
   - it: PodMonitoring is not rendered when telegraf is disabled by default
     template: gke/podmonitoring.yaml
     asserts:
       - hasDocuments:
           count: 0
+
   - it: Schema rejects emptyDir with medium Memory but no sizeLimit
     template: workload/deployment.yaml
     set:

--- a/mozcloud/application/tests/cert-manager-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/cert-manager-ingress-configuration_test.yaml
@@ -11,39 +11,29 @@ values:
 templates:
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Ingress has cert-manager cluster-issuer annotation from cloud default
+
+  - it: Ingress uses cert-manager cluster-issuer, secret TLS, and traefik class
     template: ingress/ingress.yaml
     documentSelector:
       path: $[?(@.kind == "Ingress")].metadata.name
       value: test-service
     asserts:
+      # Ingress has cert-manager cluster-issuer annotation from cloud default
       - equal:
           path: metadata.annotations["cert-manager.io/cluster-issuer"]
           value: letsencrypt-prod
-  - it: Ingress has spec.tls with correct secret and domain
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+      # Ingress has spec.tls with correct secret and domain
       - contains:
           path: spec.tls
           content:
             hosts:
               - test-service.dev.test-domain.com
             secretName: test-service-tls
-  - it: Ingress uses traefik ingress class annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+      # Ingress uses traefik ingress class annotation
       - equal:
           path: metadata.annotations["kubernetes.io/ingress.class"]
           value: traefik

--- a/mozcloud/application/tests/cert-manager-ingress-per-host-override-configuration_test.yaml
+++ b/mozcloud/application/tests/cert-manager-ingress-per-host-override-configuration_test.yaml
@@ -11,20 +11,22 @@ values:
 templates:
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
       - matchSnapshot: {}
-  - it: Ingress uses per-host issuer annotation (namespace-scoped Issuer)
+
+  - it: Ingress renders without failures and uses per-host issuer annotation (namespace-scoped Issuer)
     template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
     asserts:
+      - notFailedTemplate: {}
       - equal:
           path: metadata.annotations["cert-manager.io/issuer"]
           value: letsencrypt-staging
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service
       - isNull:
           path: metadata.annotations["cert-manager.io/cluster-issuer"]
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/chart-disabled_test.yaml
+++ b/mozcloud/application/tests/chart-disabled_test.yaml
@@ -16,23 +16,22 @@ tests:
   - it: Schema validation passes without global.mozcloud required fields
     asserts:
       - notFailedTemplate: {}
-  - it: No deployments are rendered
-    template: workload/deployment.yaml
+
+  - it: No Deployments, ExternalSecrets, ServiceAccounts, or Jobs are rendered when chart is disabled
     asserts:
+      # No deployments are rendered
       - hasDocuments:
           count: 0
-  - it: No external secrets are rendered
-    template: externalsecret/externalsecret.yaml
-    asserts:
+        template: workload/deployment.yaml
+      # No external secrets are rendered
       - hasDocuments:
           count: 0
-  - it: No service accounts are rendered
-    template: serviceaccount/serviceaccount.yaml
-    asserts:
+        template: externalsecret/externalsecret.yaml
+      # No service accounts are rendered
       - hasDocuments:
           count: 0
-  - it: No jobs are rendered
-    template: task/job.yaml
-    asserts:
+        template: serviceaccount/serviceaccount.yaml
+      # No jobs are rendered
       - hasDocuments:
           count: 0
+        template: task/job.yaml

--- a/mozcloud/application/tests/configmap-checksum_test.yaml
+++ b/mozcloud/application/tests/configmap-checksum_test.yaml
@@ -87,35 +87,25 @@ tests:
   - it: Ensure no failures occur
     asserts:
       - notFailedTemplate: {}
-  - it: Deployment pod template has checksum annotation for nginx configMap
+
+  - it: Nginx and container configMap checksums are present and well-formed
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-deployment
     asserts:
+      # Deployment pod template has checksum annotation for nginx configMap
       - exists:
           path: spec.template.metadata.annotations["checksum/configmap-my-nginx-configmap"]
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/configmap-my-nginx-configmap"]
           pattern: ^[a-f0-9]{64}$
-  - it: Deployment pod template has checksum annotation for regular container configMap
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-deployment
-    asserts:
+      # Deployment pod template has checksum annotation for regular container configMap
       - exists:
           path: spec.template.metadata.annotations["checksum/configmap-test-config-volume"]
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/configmap-test-config-volume"]
           pattern: ^[a-f0-9]{64}$
-  - it: Both nginx and container configMap checksums are present
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-deployment
-    asserts:
-      - exists:
-          path: spec.template.metadata.annotations["checksum/configmap-my-nginx-configmap"]
-      - exists:
-          path: spec.template.metadata.annotations["checksum/configmap-test-config-volume"]
+
   - it: Nginx configMap checksum changes when nginx config data changes
     set:
       configMaps:

--- a/mozcloud/application/tests/configmap-tpl_test.yaml
+++ b/mozcloud/application/tests/configmap-tpl_test.yaml
@@ -14,34 +14,33 @@ tests:
   - it: Ensure no failures occur
     asserts:
       - notFailedTemplate: {}
-  - it: Resolves template expressions to their values
-    asserts:
-      - equal:
-          path: data.RESOLVED_VALUE
-          value: "mozcloud-test"
-  - it: Renders empty string for null template expressions
-    asserts:
-      - equal:
-          path: data.NULL_VALUE
-          value: ""
-  - it: Preserves static values without template expressions
-    asserts:
-      - equal:
-          path: data.STATIC_KEY
-          value: "no-template-here"
-  - it: Resolves template expressions embedded in a larger string
-    asserts:
-      - equal:
-          path: data.MIXED_VALUE
-          value: "prefix-dev-suffix"
-  - it: Resolves piped template expressions
-    asserts:
-      - equal:
-          path: data.MULTI_VAL
-          value: "1,2"
   - it: Snapshot of full rendered ConfigMap
     asserts:
       - matchSnapshot: {}
+
+  - it: Template expressions resolve correctly across static, null, mixed, and piped values
+    asserts:
+      # Resolves template expressions to their values
+      - equal:
+          path: data.RESOLVED_VALUE
+          value: "mozcloud-test"
+      # Renders empty string for null template expressions
+      - equal:
+          path: data.NULL_VALUE
+          value: ""
+      # Preserves static values without template expressions
+      - equal:
+          path: data.STATIC_KEY
+          value: "no-template-here"
+      # Resolves template expressions embedded in a larger string
+      - equal:
+          path: data.MIXED_VALUE
+          value: "prefix-dev-suffix"
+      # Resolves piped template expressions
+      - equal:
+          path: data.MULTI_VAL
+          value: "1,2"
+
   - it: Fails when a blocked function is used
     set:
       configMaps:

--- a/mozcloud/application/tests/container-enabled_test.yaml
+++ b/mozcloud/application/tests/container-enabled_test.yaml
@@ -11,49 +11,37 @@ values:
 templates:
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Only enabled containers are rendered
+
+  - it: Only enabled containers and init containers are rendered
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service
     asserts:
+      # Only enabled containers are rendered
       - lengthEqual:
           path: spec.template.spec.containers
           count: 1
       - equal:
           path: spec.template.spec.containers[0].name
           value: app
-  - it: Only enabled init containers are rendered
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Only enabled init containers are rendered
       - lengthEqual:
           path: spec.template.spec.initContainers
           count: 1
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: init-enabled
-  - it: Disabled containers are excluded from output
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Disabled containers are excluded from output
       - notContains:
           path: spec.template.spec.containers
           content:
             name: disabled-container
           any: true
-  - it: Disabled init containers are excluded from output
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Disabled init containers are excluded from output
       - notContains:
           path: spec.template.spec.initContainers
           content:

--- a/mozcloud/application/tests/custom-managed-cert-names-configuration_test.yaml
+++ b/mozcloud/application/tests/custom-managed-cert-names-configuration_test.yaml
@@ -14,27 +14,26 @@ templates:
   - gke/ingress.yaml
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: ManagedCertificate resource uses the user-specified name
-    template: gke/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "ManagedCertificate")].metadata.name
-      value: my-custom-cert
+
+  - it: ManagedCertificate uses the user-specified name and Ingress references it
     asserts:
+      # ManagedCertificate resource uses the user-specified name
       - contains:
           path: spec.domains
           content: "test-service.dev.test-domain.com"
-  - it: Ingress annotation references the user-specified cert name
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: my-custom-cert
+      # Ingress annotation references the user-specified cert name
       - equal:
           path: metadata.annotations["networking.gke.io/managed-certificates"]
           value: my-custom-cert
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/disable-managed-cert-configuration_test.yaml
+++ b/mozcloud/application/tests/disable-managed-cert-configuration_test.yaml
@@ -14,25 +14,24 @@ templates:
   - gke/ingress.yaml
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: No ManagedCertificate resource is created
-    template: gke/ingress.yaml
+
+  - it: No ManagedCertificate is created and Ingress references the pre-existing cert name
     asserts:
+      # No ManagedCertificate resource is created
       - notContains:
           path: $[*].kind
           content: ManagedCertificate
           any: true
-  - it: Ingress annotation references the pre-existing cert name
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+        template: gke/ingress.yaml
+      # Ingress annotation references the pre-existing cert name
       - equal:
           path: metadata.annotations["networking.gke.io/managed-certificates"]
           value: existing-cert
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/env-from-fields-configuration_test.yaml
+++ b/mozcloud/application/tests/env-from-fields-configuration_test.yaml
@@ -11,18 +11,17 @@ values:
 templates:
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
       - matchSnapshot: {}
-  - it: Deployment contains envFromFields as fieldRef env vars
+
+  - it: Deployment renders without failures and contains envFromFields as fieldRef env vars
     template: workload/deployment.yaml
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service
     asserts:
+      - notFailedTemplate: {}
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -44,4 +43,3 @@ tests:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-

--- a/mozcloud/application/tests/ephemeral-storage-configuration_test.yaml
+++ b/mozcloud/application/tests/ephemeral-storage-configuration_test.yaml
@@ -11,25 +11,21 @@ values:
 templates:
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Container resources include ephemeral-storage request
+
+  - it: Container resources include ephemeral-storage request and matching limit
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service
     asserts:
+      # Container resources include ephemeral-storage request
       - equal:
           path: spec.template.spec.containers[?(@.name=="app")].resources.requests.ephemeral-storage
           value: "1Gi"
-  - it: Container resources include ephemeral-storage limit equal to request
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Container resources include ephemeral-storage limit equal to request
       - equal:
           path: spec.template.spec.containers[?(@.name=="app")].resources.limits.ephemeral-storage
           value: "1Gi"

--- a/mozcloud/application/tests/external-secrets-default-disabled_test.yaml
+++ b/mozcloud/application/tests/external-secrets-default-disabled_test.yaml
@@ -12,35 +12,35 @@ templates:
   - externalsecret/externalsecret.yaml
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Only the custom external secret is created
-    template: externalsecret/externalsecret.yaml
+
+  - it: Only the custom ExternalSecret is rendered and default secret is not injected
     asserts:
+      # Only the custom external secret is created
       - hasDocuments:
           count: 1
-  - it: Custom external secret is created correctly
-    template: externalsecret/externalsecret.yaml
-    documentIndex: 0
-    asserts:
+        template: externalsecret/externalsecret.yaml
+      # Custom external secret is created correctly
       - equal:
           path: metadata.name
           value: test-k8s-secret
+        template: externalsecret/externalsecret.yaml
+        documentIndex: 0
       - equal:
           path: spec.dataFrom[0].extract.key
           value: dev-gke-test-custom-secrets
-  - it: Default secret is not injected into app container
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+        template: externalsecret/externalsecret.yaml
+        documentIndex: 0
+      # Default secret is not injected into app container
       - notContains:
           path: spec.template.spec.containers[?(@.name=="app")].envFrom
           content:
             secretRef:
               name: test-chart-secrets
+        template: workload/deployment.yaml
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/external-secrets_test.yaml
+++ b/mozcloud/application/tests/external-secrets_test.yaml
@@ -17,13 +17,12 @@ templates:
   - task/job.yaml
   - task/cronjob.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Default external secret configured correctly
+
+  - it: Default ExternalSecret is configured correctly
     template: externalsecret/externalsecret.yaml
     documentSelector:
       path: $[?(@.kind == "ExternalSecret")].metadata.name
@@ -38,7 +37,8 @@ tests:
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "-11"
-  - it: Custom external secret configured correctly
+
+  - it: Custom ExternalSecret is configured correctly
     template: externalsecret/externalsecret.yaml
     documentSelector:
       path: $[?(@.kind == "ExternalSecret")].metadata.name
@@ -53,24 +53,21 @@ tests:
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "-11"
-  - it: Default secret in app container
+
+  - it: Deployment containers and init container mount the correct secrets (with dedup)
     template: workload/deployment.yaml
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service
     asserts:
+      # Default secret in app container
       - equal:
           path: spec.template.spec.containers[?(@.name=="app")].envFrom[0].secretRef.name
           value: test-chart-secrets
       - lengthEqual:
           path: spec.template.spec.containers[?(@.name=="app")].envFrom
           count: 1
-  - it: Default and chart-managed secrets in custom container
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Default and chart-managed secrets in custom container
       - equal:
           path: spec.template.spec.containers[?(@.name=="custom")].envFrom[0].secretRef.name
           value: test-chart-secrets
@@ -80,12 +77,7 @@ tests:
       - lengthEqual:
           path: spec.template.spec.containers[?(@.name=="custom")].envFrom
           count: 2
-  - it: Default and externally-managed secrets in external container
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Default and externally-managed secrets in external container
       - equal:
           path: spec.template.spec.containers[?(@.name=="external")].envFrom[0].secretRef.name
           value: test-chart-secrets
@@ -95,24 +87,14 @@ tests:
       - lengthEqual:
           path: spec.template.spec.containers[?(@.name=="external")].envFrom
           count: 2
-  - it: Default secret appears exactly once in envFrom when also listed in secrets
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Default secret appears exactly once in envFrom when also listed in secrets
       - equal:
           path: spec.template.spec.containers[?(@.name=="dedup")].envFrom[0].secretRef.name
           value: test-chart-secrets
       - lengthEqual:
           path: spec.template.spec.containers[?(@.name=="dedup")].envFrom
           count: 1
-  - it: Init container mounts default, chart-managed, and externally-managed secrets
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Init container mounts default, chart-managed, and externally-managed secrets
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="init")].envFrom[0].secretRef.name
           value: test-chart-secrets
@@ -125,6 +107,7 @@ tests:
       - lengthEqual:
           path: spec.template.spec.initContainers[?(@.name=="init")].envFrom
           count: 3
+
   - it: Job container mounts chart-managed and externally-managed secrets
     template: task/job.yaml
     documentSelector:
@@ -140,6 +123,7 @@ tests:
       - lengthEqual:
           path: spec.template.spec.containers[?(@.name=="job")].envFrom
           count: 2
+
   - it: CronJob container mounts chart-managed and externally-managed secrets
     template: task/cronjob.yaml
     documentSelector:

--- a/mozcloud/application/tests/hpa-configuration_test.yaml
+++ b/mozcloud/application/tests/hpa-configuration_test.yaml
@@ -11,25 +11,21 @@ values:
 templates:
   - workload/hpa.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: HPA has sync-wave annotation set to 1
+
+  - it: HPA has sync-wave annotation and targets the correct Deployment
     documentSelector:
       path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
       value: test-service
     asserts:
+      # HPA has sync-wave annotation set to 1
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "1"
-  - it: HPA targets the correct deployment
-    documentSelector:
-      path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
-      value: test-service
-    asserts:
+      # HPA targets the correct deployment
       - equal:
           path: spec.scaleTargetRef.kind
           value: Deployment

--- a/mozcloud/application/tests/httproute-rules_test.yaml
+++ b/mozcloud/application/tests/httproute-rules_test.yaml
@@ -14,17 +14,14 @@ values:
 templates:
   - gateway/httproute.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Header-only HTTPRoute is configured with correct rules
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: header-only
+
+  - it: Header-only, path-only, and headers-and-path HTTPRoutes render correct rules
     asserts:
+      # Header-only HTTPRoute is configured with correct rules
       - contains:
           path: spec.rules[0].backendRefs
           content:
@@ -33,17 +30,19 @@ tests:
             name: test-service
             port: 8080
             weight: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: header-only
       - contains:
           path: spec.rules[0].matches
           content:
             headers:
               - name: foo
                 value: bar
-  - it: Path-only HTTPRoute is configured with correct rules
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: path-only
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: header-only
+      # Path-only HTTPRoute is configured with correct rules
       - contains:
           path: spec.rules[0].backendRefs
           content:
@@ -52,17 +51,19 @@ tests:
             name: test-service
             port: 8080
             weight: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: path-only
       - contains:
           path: spec.rules[0].matches
           content:
             path:
               type: PathPrefix
               value: /foo
-  - it: Headers and path HTTPRoute is configured with correct rules
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: headers-and-path
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: path-only
+      # Headers and path HTTPRoute is configured with correct rules
       - contains:
           path: spec.rules[0].backendRefs
           content:
@@ -71,6 +72,9 @@ tests:
             name: test-service
             port: 8080
             weight: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: headers-and-path
       - contains:
           path: spec.rules[0].matches
           content:
@@ -82,3 +86,6 @@ tests:
             path:
               type: PathPrefix
               value: /foo
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: headers-and-path

--- a/mozcloud/application/tests/image-pull-policy-configuration_test.yaml
+++ b/mozcloud/application/tests/image-pull-policy-configuration_test.yaml
@@ -21,32 +21,21 @@ tests:
     asserts:
       - notFailedTemplate: {}
 
-  - it: App container uses configured imagePullPolicy
+  - it: Deployment app, init, and nginx sidecar containers use their configured imagePullPolicy
     template: workload/deployment.yaml
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service
     asserts:
+      # App container uses configured imagePullPolicy
       - equal:
           path: spec.template.spec.containers[?(@.name=="app")].imagePullPolicy
           value: IfNotPresent
-
-  - it: Init container uses configured imagePullPolicy
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Init container uses configured imagePullPolicy
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="init")].imagePullPolicy
           value: IfNotPresent
-
-  - it: Nginx sidecar always uses imagePullPolicy Always
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Nginx sidecar always uses imagePullPolicy Always
       - equal:
           path: spec.template.spec.containers[?(@.name=="nginx")].imagePullPolicy
           value: Always

--- a/mozcloud/application/tests/image-registry_test.yaml
+++ b/mozcloud/application/tests/image-registry_test.yaml
@@ -11,44 +11,42 @@ values:
 templates:
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Prepends global registry to short repository paths
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
+
+  - it: Registry prefix handling for default workload images
     asserts:
+      # Prepends global registry to short repository paths
       - equal:
           path: spec.template.spec.containers[?(@.name == "app")].image
           value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-images/myapp:1.0.0"
-  - it: Does not double-prefix when repository already contains the registry
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
+      # Does not double-prefix when repository already contains the registry
       - equal:
           path: spec.template.spec.containers[?(@.name == "sidecar")].image
           value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/other-images/sidecar:2.0.0"
-  - it: Does not double-prefix when repository already contains a different registry
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service-2
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
+      # Does not double-prefix when repository already contains a different registry
       - equal:
           path: spec.template.spec.containers[?(@.name == "app")].image
           value: "us-west1-docker.pkg.dev/moz-fx-fx-testing/fx-testing-prod/api-image:1.0.1"
-  - it: Does not prepend registry to nginx when its repository already contains a domain
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service-nginx
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service-2
+      # Does not prepend registry to nginx when its repository already contains a domain
       - equal:
           path: spec.template.spec.containers[?(@.name == "nginx")].image
           value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29"
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service-nginx
+
   - it: Prepends registry to nginx when using a short repository path
     set:
       workloads:

--- a/mozcloud/application/tests/ingress-backend-options-configuration_test.yaml
+++ b/mozcloud/application/tests/ingress-backend-options-configuration_test.yaml
@@ -17,47 +17,32 @@ templates:
   - gke/ingress.yaml
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: timeoutSec is rendered at the BackendConfig spec root level
+
+  - it: BackendConfig spec renders timeoutSec, logSampleRate, and securityPolicy correctly
     template: gke/ingress.yaml
     documentSelector:
       path: $[?(@.kind == "BackendConfig")].metadata.name
       value: test-service
     asserts:
+      # timeoutSec is rendered at the BackendConfig spec root level
       - equal:
           path: spec.timeoutSec
           value: 600
-  - it: timeoutSec is not nested under logging
-    template: gke/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "BackendConfig")].metadata.name
-      value: test-service
-    asserts:
+      # timeoutSec is not nested under logging
       - notExists:
           path: spec.logging.timeoutSec
-  - it: logSampleRate is rendered as a ratio in BackendConfig logging spec
-    template: gke/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "BackendConfig")].metadata.name
-      value: test-service
-    asserts:
+      # logSampleRate is rendered as a ratio in BackendConfig logging spec
       - isSubset:
           path: spec
           content:
             logging:
               enable: true
               sampleRate: 0.1
-  - it: securityPolicy is rendered as an object in BackendConfig spec
-    template: gke/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "BackendConfig")].metadata.name
-      value: test-service
-    asserts:
+      # securityPolicy is rendered as an object in BackendConfig spec
       - equal:
           path: spec.securityPolicy
           value:

--- a/mozcloud/application/tests/ingress-multi-domain-configuration_test.yaml
+++ b/mozcloud/application/tests/ingress-multi-domain-configuration_test.yaml
@@ -12,55 +12,56 @@ templates:
   - gke/ingress.yaml
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Ingress uses rules instead of defaultBackend for multiple domains
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
+
+  - it: Ingress uses rules per domain and a shared BackendConfig across all domains
     asserts:
+      # Ingress uses rules instead of defaultBackend for multiple domains
       - exists:
           path: spec.rules
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service
       - notExists:
           path: spec.defaultBackend
-  - it: Ingress has one rule per domain
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service
+      # Ingress has one rule per domain
       - lengthEqual:
           path: spec.rules
           count: 2
-  - it: First domain has its own ingress rule
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service
+      # First domain has its own ingress rule
       - equal:
           path: spec.rules[0].host
           value: test-service.dev.test-domain.com
-  - it: Second domain has its own ingress rule
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service
+      # Second domain has its own ingress rule
       - equal:
           path: spec.rules[1].host
           value: www.test-service.dev.test-domain.com
-  - it: A single BackendConfig is shared across all domains
-    template: gke/ingress.yaml
-    asserts:
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service
+      # A single BackendConfig is shared across all domains
       - hasDocuments:
           count: 3
+        template: gke/ingress.yaml
       - equal:
           path: kind
           value: BackendConfig
         documentIndex: 0
+        template: gke/ingress.yaml

--- a/mozcloud/application/tests/internal-and-external-gateway-configuration_test.yaml
+++ b/mozcloud/application/tests/internal-and-external-gateway-configuration_test.yaml
@@ -13,41 +13,51 @@ templates:
   - gateway/httproute.yaml
   - gke/gateway.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Creates two gateways (internal and external)
+
+  - it: Internal and external Gateways are configured correctly
     template: gateway/gateway.yaml
     asserts:
+      # Creates two gateways (internal and external)
       - hasDocuments:
           count: 2
-  - it: External gateway is configured correctly
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test-external
-    asserts:
+      # External gateway is configured correctly
       - equal:
           path: metadata.name
+          value: mozcloud-test-external
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
           value: mozcloud-test-external
       - equal:
           path: metadata.annotations["networking.gke.io/certmap"]
           value: test-service-nonprod-dev
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-external
       - equal:
           path: spec.gatewayClassName
           value: gke-l7-global-external-managed
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-external
       - contains:
           path: spec.addresses
           count: 1
           content:
             type: NamedAddress
             value: mozcloud-dev-external-ip-v4
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-external
       - lengthEqual:
           path: spec.listeners
           count: 2
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-external
       - contains:
           path: spec.listeners
           count: 1
@@ -58,6 +68,9 @@ tests:
             name: http
             port: 80
             protocol: HTTP
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-external
       - contains:
           path: spec.listeners
           count: 1
@@ -68,27 +81,37 @@ tests:
             name: https
             port: 443
             protocol: HTTPS
-  - it: Internal gateway is configured correctly
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test-internal
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-external
+      # Internal gateway is configured correctly
       - equal:
           path: metadata.name
+          value: mozcloud-test-internal
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
           value: mozcloud-test-internal
       - equal:
           path: spec.gatewayClassName
           value: gke-l7-global-external-managed
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-internal
       - contains:
           path: spec.addresses
           count: 1
           content:
             type: NamedAddress
             value: mozcloud-dev-internal-ip-v4
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-internal
       - lengthEqual:
           path: spec.listeners
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-internal
       - contains:
           path: spec.listeners
           count: 1
@@ -99,23 +122,32 @@ tests:
             name: http
             port: 80
             protocol: HTTP
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-internal
       - notExists:
           path: metadata.annotations["networking.gke.io/certmap"]
-  - it: External gateway policy is configured correctly
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test-internal
+
+  - it: Only external GCPGatewayPolicy is rendered (internal has no HTTPS listener)
     template: gke/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
-      value: mozcloud-test-external
     asserts:
+      # External gateway policy is configured correctly
       - equal:
           path: spec.default.sslPolicy
           value: mozilla-intermediate
+        documentSelector:
+          path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
+          value: mozcloud-test-external
       - equal:
           path: spec.targetRef.name
           value: mozcloud-test-external
-  - it: Only external gateway policy exists (internal has no HTTPS listener)
-    template: gke/gateway.yaml
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
+          value: mozcloud-test-external
+      # Only external gateway policy exists (internal has no HTTPS listener)
       - documentIndex: 0
         equal:
           path: kind
@@ -124,16 +156,18 @@ tests:
         equal:
           path: metadata.name
           value: mozcloud-test-external
-  - it: External HTTPRoute references external gateway
+
+  - it: HTTPRoutes reference their respective internal and external gateways
     template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: external-host
     asserts:
+      # External HTTPRoute references external gateway
       - contains:
           path: spec.hostnames
           count: 1
           content: external.test-domain.com
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: external-host
       - contains:
           path: spec.parentRefs
           count: 1
@@ -142,12 +176,10 @@ tests:
             kind: Gateway
             name: mozcloud-test-external
             sectionName: https
-  - it: External HTTPRoute has HTTP redirect
-    template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: external-host-http-redirect
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: external-host
+      # External HTTPRoute has HTTP redirect
       - contains:
           path: spec.parentRefs
           count: 1
@@ -156,16 +188,17 @@ tests:
             kind: Gateway
             name: mozcloud-test-external
             sectionName: http
-  - it: Internal HTTPRoute references internal gateway
-    template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: internal-host
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: external-host-http-redirect
+      # Internal HTTPRoute references internal gateway
       - contains:
           path: spec.hostnames
           count: 1
           content: internal.test-domain.local
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: internal-host
       - contains:
           path: spec.parentRefs
           count: 1
@@ -174,6 +207,12 @@ tests:
             kind: Gateway
             name: mozcloud-test-internal
             sectionName: http
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: internal-host
       - lengthEqual:
           path: spec.parentRefs
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: internal-host

--- a/mozcloud/application/tests/job-numeric-fields_test.yaml
+++ b/mozcloud/application/tests/job-numeric-fields_test.yaml
@@ -14,36 +14,31 @@ tests:
   - it: Ensure no failures occur
     asserts:
       - notFailedTemplate: {}
-  - it: backoffLimit 0 is rendered
-    documentSelector:
-      path: $[?(@.kind == "Job")].metadata.name
-      value: test-zero-backoff-job
-    asserts:
-      - equal:
-          path: spec.backoffLimit
-          value: 0
-  - it: ttlSecondsAfterFinished 0 is rendered
-    documentSelector:
-      path: $[?(@.kind == "Job")].metadata.name
-      value: test-zero-backoff-job
-    asserts:
-      - equal:
-          path: spec.ttlSecondsAfterFinished
-          value: 0
-  - it: parallelism is rendered as integer
-    documentSelector:
-      path: $[?(@.kind == "Job")].metadata.name
-      value: test-zero-backoff-job
-    asserts:
-      - equal:
-          path: spec.parallelism
-          value: 3
   - it: Configuration matches entire snapshot
     documentSelector:
       path: $[?(@.kind == "Job")].metadata.name
       value: test-zero-backoff-job
     asserts:
       - matchSnapshot: {}
+
+  - it: Job numeric fields (backoffLimit, ttlSecondsAfterFinished, parallelism) render correctly
+    documentSelector:
+      path: $[?(@.kind == "Job")].metadata.name
+      value: test-zero-backoff-job
+    asserts:
+      # backoffLimit 0 is rendered
+      - equal:
+          path: spec.backoffLimit
+          value: 0
+      # ttlSecondsAfterFinished 0 is rendered
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 0
+      # parallelism is rendered as integer
+      - equal:
+          path: spec.parallelism
+          value: 3
+
   - it: Schema rejects non-integer backoffLimit
     set:
       tasks.jobs.test-zero-backoff-job.backoffLimit: 0.5

--- a/mozcloud/application/tests/mixed-gateway-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/mixed-gateway-ingress-configuration_test.yaml
@@ -18,39 +18,30 @@ templates:
   - gke/ingress.yaml
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
-
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
 
-  # Gateway template tests - should only create resources for gateway-service
-  - it: Gateway template creates resources for gateway workload
-    template: gateway/gateway.yaml
+  - it: Gateway resources are only created for the gateway workload
     asserts:
+      # Gateway template tests - should only create resources for gateway-service
       - hasDocuments:
           count: 1
-
-  - it: Gateway is configured for gateway-service
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test
-    asserts:
+        template: gateway/gateway.yaml
       - isNotNullOrEmpty:
           path: spec.addresses
-
-  - it: Gateway Service is created for gateway-service
-    template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: gateway-service
-    asserts:
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - equal:
           path: spec.type
           value: ClusterIP
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: gateway-service
       - contains:
           path: spec.ports
           count: 1
@@ -59,13 +50,10 @@ tests:
             port: 8080
             protocol: TCP
             targetPort: http
-
-  - it: Gateway HTTPRoute references gateway-service
-    template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: gateway-service
-    asserts:
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: gateway-service
       - contains:
           path: spec.rules[0].backendRefs
           content:
@@ -74,26 +62,20 @@ tests:
             name: gateway-service
             port: 8080
             weight: 1
+        template: gateway/httproute.yaml
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: gateway-service
 
-  # Ingress template tests - should only create resources for ingress-service
-  - it: Frontend template creates resources for ingress workload
-    template: gke/frontendconfig.yaml
+  - it: Ingress resources are only created for the ingress workload
     asserts:
+      # Ingress template tests - should only create resources for ingress-service
       - hasDocuments:
           count: 1
-
-  - it: Ingress template creates resources for ingress workload
-    template: ingress/ingress.yaml
-    asserts:
+        template: gke/frontendconfig.yaml
       - hasDocuments:
           count: 2
-
-  - it: Ingress is configured for ingress-service
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: ingress-service
-    asserts:
+        template: ingress/ingress.yaml
       - isSubset:
           path: spec
           content:
@@ -102,16 +84,17 @@ tests:
                 name: ingress-service
                 port:
                   number: 8080
-
-  - it: Ingress Service is created for ingress-service
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: ingress-service
-    asserts:
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: ingress-service
       - equal:
           path: spec.type
           value: ClusterIP
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: ingress-service
       - contains:
           path: spec.ports
           count: 1
@@ -120,30 +103,28 @@ tests:
             port: 8080
             protocol: TCP
             targetPort: http
-
-  - it: Ingress ManagedCertificate is created
-    template: gke/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "ManagedCertificate")].metadata.name
-      value: mcrt-ingress-service-dev-test-domain-com
-    asserts:
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: ingress-service
       - contains:
           path: spec.domains
           content: "ingress-service.dev.test-domain.com"
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: mcrt-ingress-service-dev-test-domain-com
 
-  # Cross-validation tests - ensure no resource leakage between templates
-  - it: Gateway backend template does NOT create resources for ingress-service
-    template: gateway/backend.yaml
+  - it: No resource leakage between gateway and ingress templates
     asserts:
+      # Cross-validation tests - ensure no resource leakage between templates
       - notContains:
           path: $[*].metadata.name
           content: ingress-service
           any: true
-
-  - it: Ingress template does NOT create resources for gateway-service
-    template: ingress/ingress.yaml
-    asserts:
+        template: gateway/backend.yaml
       - notContains:
           path: $[*].metadata.name
           content: gateway-service
           any: true
+        template: ingress/ingress.yaml

--- a/mozcloud/application/tests/multi-cert-names-configuration_test.yaml
+++ b/mozcloud/application/tests/multi-cert-names-configuration_test.yaml
@@ -14,36 +14,34 @@ templates:
   - gke/ingress.yaml
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: A ManagedCertificate is created for the first user-specified name
-    template: gke/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "ManagedCertificate")].metadata.name
-      value: cert-a
+
+  - it: ManagedCertificates are created per user-specified name and Ingress references all of them
     asserts:
+      # A ManagedCertificate is created for the first user-specified name
       - contains:
           path: spec.domains
           content: "test-service.dev.test-domain.com"
-  - it: A ManagedCertificate is created for the second user-specified name
-    template: gke/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "ManagedCertificate")].metadata.name
-      value: cert-b
-    asserts:
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: cert-a
+      # A ManagedCertificate is created for the second user-specified name
       - contains:
           path: spec.domains
           content: "test-service.dev.test-domain.com"
-  - it: Ingress annotation references all cert names
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: cert-b
+      # Ingress annotation references all cert names
       - equal:
           path: metadata.annotations["networking.gke.io/managed-certificates"]
           value: cert-a,cert-b
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/multi-cert-no-create-configuration_test.yaml
+++ b/mozcloud/application/tests/multi-cert-no-create-configuration_test.yaml
@@ -17,19 +17,20 @@ tests:
   - it: Ensure no failures occur
     asserts:
       - notFailedTemplate: {}
-  - it: No ManagedCertificate resources are created
-    template: gke/ingress.yaml
+
+  - it: No ManagedCertificate resources are created and Ingress references all pre-existing cert names
     asserts:
+      # No ManagedCertificate resources are created
       - notContains:
           path: $[*].kind
           content: ManagedCertificate
           any: true
-  - it: Ingress annotation references all pre-existing cert names
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+        template: gke/ingress.yaml
+      # Ingress annotation references all pre-existing cert names
       - equal:
           path: metadata.annotations["networking.gke.io/managed-certificates"]
           value: cert-a,cert-b
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-additional-region_test.yaml
+++ b/mozcloud/application/tests/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-additional-region_test.yaml
@@ -15,24 +15,23 @@ values:
 templates:
   - gateway/backend.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Resource count matches expectations
+
+  - it: Additional region renders Service and ServiceExport correctly
     asserts:
+      # Resource count matches expectations
       - hasDocuments:
           count: 2
-  - it: Service is configured correctly
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: mozcloud-test-europe-west1
-    asserts:
+      # Service is configured correctly
       - lengthEqual:
           path: spec.ports
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: mozcloud-test-europe-west1
       - contains:
           path: spec.ports
           count: 1
@@ -41,16 +40,21 @@ tests:
             port: 8080
             protocol: TCP
             targetPort: http
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: mozcloud-test-europe-west1
       - equal:
           path: spec.selector
           value:
             app.kubernetes.io/component: web
             app.kubernetes.io/name: mozcloud-test
             env_code: dev
-  - it: ServiceExport exists
-    documentSelector:
-      path: $[?(@.kind == "ServiceExport")].metadata.name
-      value: mozcloud-test-europe-west1
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: mozcloud-test-europe-west1
+      # ServiceExport exists
       - isAPIVersion:
           of: net.gke.io/v1
+        documentSelector:
+          path: $[?(@.kind == "ServiceExport")].metadata.name
+          value: mozcloud-test-europe-west1

--- a/mozcloud/application/tests/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-primary-region_test.yaml
+++ b/mozcloud/application/tests/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-primary-region_test.yaml
@@ -19,21 +19,20 @@ templates:
   - gke/backend.yaml
   - gke/gateway.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Service is configured correctly
+
+  - it: Backend Service and ServiceExport are configured for multi-cluster primary region
     template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: mozcloud-test-us-west1
     asserts:
       - lengthEqual:
           path: spec.ports
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: mozcloud-test-us-west1
       - contains:
           path: spec.ports
           count: 1
@@ -42,25 +41,26 @@ tests:
             port: 8080
             protocol: TCP
             targetPort: http
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: mozcloud-test-us-west1
       - equal:
           path: spec.selector
           value:
             app.kubernetes.io/component: web
             app.kubernetes.io/name: mozcloud-test
             env_code: dev
-  - it: ServiceExport exists
-    template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "ServiceExport")].metadata.name
-      value: mozcloud-test-us-west1
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: mozcloud-test-us-west1
       - isAPIVersion:
           of: net.gke.io/v1
-  - it: HealthCheckPolicy is configured correctly (primary region)
+        documentSelector:
+          path: $[?(@.kind == "ServiceExport")].metadata.name
+          value: mozcloud-test-us-west1
+
+  - it: HealthCheckPolicy and GCPBackendPolicy target correct ServiceImports in both regions
     template: gke/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
-      value: mozcloud-test-us-west1
     asserts:
       - equal:
           path: spec.default.config
@@ -68,74 +68,84 @@ tests:
             httpHealthCheck:
               requestPath: /readiness/
             type: HTTP
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: mozcloud-test-us-west1
       - equal:
           path: spec.targetRef
           value:
             group: net.gke.io
             kind: ServiceImport
             name: mozcloud-test-us-west1
-  - it: HealthCheckPolicy is configured correctly (additional region)
-    template: gke/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
-      value: mozcloud-test-europe-west1
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: mozcloud-test-us-west1
       - equal:
           path: spec.default.config
           value:
             httpHealthCheck:
               requestPath: /readiness/
             type: HTTP
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: mozcloud-test-europe-west1
       - equal:
           path: spec.targetRef
           value:
             group: net.gke.io
             kind: ServiceImport
             name: mozcloud-test-europe-west1
-  - it: GCPBackendPolicy is configured correctly (primary region)
-    template: gke/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
-      value: mozcloud-test-us-west1
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: mozcloud-test-europe-west1
       - equal:
           path: spec.targetRef
           value:
             group: net.gke.io
             kind: ServiceImport
             name: mozcloud-test-us-west1
-  - it: GCPBackendPolicy is configured correctly (additional region)
-    template: gke/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
-      value: mozcloud-test-europe-west1
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: mozcloud-test-us-west1
       - equal:
           path: spec.targetRef
           value:
             group: net.gke.io
             kind: ServiceImport
             name: mozcloud-test-europe-west1
-  - it: HTTPRoute is configured correctly (http-redirect)
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: mozcloud-test-europe-west1
+
+  - it: HTTPRoutes are configured for http-redirect and weighted traffic split
     template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: mozcloud-test-http-redirect
     asserts:
       - lengthEqual:
           path: spec.hostnames
           count: 2
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test-http-redirect
       - contains:
           path: spec.hostnames
           count: 1
           content: dev.mozcloud-test.nonprod.webservices.mozgcp.net
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test-http-redirect
       - contains:
           path: spec.hostnames
           count: 1
           content: mozcloud-test.allizom.org
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test-http-redirect
       - lengthEqual:
           path: spec.rules
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test-http-redirect
       - contains:
           path: spec.rules
           count: 1
@@ -149,29 +159,41 @@ tests:
               - path:
                   type: PathPrefix
                   value: /
-  - it: HTTPRoute is configured correctly
-    template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: mozcloud-test
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test-http-redirect
       - lengthEqual:
           path: spec.hostnames
           count: 2
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test
       - contains:
           path: spec.hostnames
           count: 1
           content: dev.mozcloud-test.nonprod.webservices.mozgcp.net
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test
       - contains:
           path: spec.hostnames
           count: 1
           content: mozcloud-test.allizom.org
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test
       - lengthEqual:
           path: spec.rules
           count: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test
       - lengthEqual:
           path: spec.rules[0].backendRefs
           count: 2
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test
       - contains:
           path: spec.rules[0].backendRefs
           count: 1
@@ -181,6 +203,9 @@ tests:
             name: mozcloud-test-us-west1
             port: 8080
             weight: 100
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test
       - contains:
           path: spec.rules[0].backendRefs
           count: 1
@@ -190,11 +215,11 @@ tests:
             name: mozcloud-test-europe-west1
             port: 8080
             weight: 0
-  - it: GCPGatewayPolicy is configured correctly
-    template: gke/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
-      value: mozcloud-test
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: mozcloud-test
+
+  - it: Gateway and GCPGatewayPolicy are configured correctly
     asserts:
       - equal:
           path: spec.targetRef
@@ -202,27 +227,41 @@ tests:
             group: gateway.networking.k8s.io
             kind: Gateway
             name: mozcloud-test
-  - it: Gateway is configured correctly
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test
-    asserts:
+        template: gke/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPGatewayPolicy")].metadata.name
+          value: mozcloud-test
       - equal:
           path: spec.gatewayClassName
           value: gke-l7-global-external-managed-mc
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - lengthEqual:
           path: spec.addresses
           count: 1
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - contains:
           path: spec.addresses
           count: 1
           content:
             type: NamedAddress
             value: mozcloud-test-dev-ip-v4
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - lengthEqual:
           path: spec.listeners
           count: 2
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - contains:
           path: spec.listeners
           count: 1
@@ -233,6 +272,10 @@ tests:
             name: http
             port: 80
             protocol: HTTP
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test
       - contains:
           path: spec.listeners
           count: 1
@@ -243,3 +286,7 @@ tests:
             name: https
             port: 443
             protocol: HTTPS
+        template: gateway/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "Gateway")].metadata.name
+          value: mozcloud-test

--- a/mozcloud/application/tests/multi-containers_test.yaml
+++ b/mozcloud/application/tests/multi-containers_test.yaml
@@ -14,83 +14,51 @@ values:
 templates:
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Container count is correct
+
+  - it: Deployment has the expected containers and init containers with correct images and sidecar config
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service
     asserts:
+      # Container count is correct
       - lengthEqual:
           path: spec.template.spec.containers
           count: 2
-  - it: Init container count is correct
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Init container count is correct
       - lengthEqual:
           path: spec.template.spec.initContainers
           count: 2
-  - it: First container has correct image
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # First container has correct image
       - equal:
           path: spec.template.spec.containers[?(@.name=="container-1")].image
           value: "test-repo/image1:1.0.0"
-  - it: Second container has correct image
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Second container has correct image
       - equal:
           path: spec.template.spec.containers[?(@.name=="container-2")].image
           value: "test-repo/image2:2.0.0"
-  - it: First init container has correct image
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # First init container has correct image
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="init-container-1")].image
           value: "test-repo/image3:3.0.0"
-  - it: Second container has correct image
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Second init container has correct image
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="init-container-2")].image
           value: "test-repo/image4:4.0.0"
-  - it: Init container with sidecar mode enabled correctly identified
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Init container with sidecar mode enabled correctly identified
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="init-container-1")].restartPolicy
           value: "Always"
-  - it: Init container env vars are rendered
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Init container env vars are rendered
       - contains:
           path: spec.template.spec.initContainers[?(@.name=="init-container-1")].env
           content:
             name: INIT_KEY
             value: init-value
-  - it: Init container security context is rendered
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Init container security context is rendered
       - equal:
           path: spec.template.spec.initContainers[?(@.name=="init-container-1")].securityContext.runAsUser
           value: 1000

--- a/mozcloud/application/tests/onprem-gateway-configuration_test.yaml
+++ b/mozcloud/application/tests/onprem-gateway-configuration_test.yaml
@@ -13,82 +13,62 @@ templates:
   - gateway/gateway.yaml
   - gateway/httproute.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
-
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
 
-  # GKE CRDs must not be emitted
-  - it: No GCPBackendPolicy is rendered
-    template: gateway/backend.yaml
+  - it: GKE-specific CRDs and annotations are not emitted
     asserts:
+      # GKE CRDs must not be emitted
       - notContains:
           path: $[*].kind
           content: GCPBackendPolicy
         documentIndex: 0
-
-  - it: No HealthCheckPolicy is rendered
-    template: gateway/backend.yaml
-    asserts:
+        template: gateway/backend.yaml
       - notContains:
           path: $[*].kind
           content: HealthCheckPolicy
         documentIndex: 0
-
-  - it: No GCPGatewayPolicy is rendered
-    template: gateway/gateway.yaml
-    asserts:
+        template: gateway/backend.yaml
       - hasDocuments:
           count: 1
-
-  - it: Only a Service is rendered in backend template
-    template: gateway/backend.yaml
-    asserts:
+        template: gateway/gateway.yaml
       - hasDocuments:
           count: 1
+        template: gateway/backend.yaml
       - equal:
           path: kind
           value: Service
         documentIndex: 0
+        template: gateway/backend.yaml
+      - isNull:
+          path: metadata.annotations["cloud.google.com/neg"]
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      - isNull:
+          path: metadata.annotations["cloud.google.com/backend-config"]
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
 
-  # Gateway resource assertions
-  - it: Gateway uses user-specified gatewayClass
+  - it: Gateway uses user-specified gatewayClass and Kubernetes secret TLS (no GKE specifics)
     template: gateway/gateway.yaml
     documentSelector:
       path: $[?(@.kind == "Gateway")].metadata.name
       value: mozcloud-test
     asserts:
+      # Gateway resource assertions
       - equal:
           path: spec.gatewayClassName
           value: nginx
-
-  - it: Gateway has no static IP addresses (no NamedAddress)
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test
-    asserts:
       - isNull:
           path: spec.addresses
-
-  - it: Gateway has no GKE certmap annotation
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test
-    asserts:
       - isNull:
           path: metadata.annotations["networking.gke.io/certmap"]
-
-  - it: Gateway TLS uses Kubernetes secret certificateRefs
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test
-    asserts:
       - contains:
           path: spec.listeners
           content:
@@ -103,37 +83,12 @@ tests:
               certificateRefs:
                 - name: test-service-tls
 
-  - it: Service has no GKE NEG annotation
-    template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
-      - isNull:
-          path: metadata.annotations["cloud.google.com/neg"]
-
-  - it: Service has no GKE backend-config annotation
-    template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
-      - isNull:
-          path: metadata.annotations["cloud.google.com/backend-config"]
-
-  # HTTPRoutes should still render normally
-  - it: HTTPRoutes are still rendered
+  - it: HTTPRoutes render and reference the Gateway correctly
     template: gateway/httproute.yaml
     asserts:
+      # HTTPRoutes should still render normally
       - hasDocuments:
           count: 2
-
-  - it: HTTPS HTTPRoute references the Gateway correctly
-    template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: test-service
-    asserts:
       - contains:
           path: spec.parentRefs
           count: 1
@@ -142,3 +97,6 @@ tests:
             kind: Gateway
             name: mozcloud-test
             sectionName: https
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/onprem-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/onprem-ingress-configuration_test.yaml
@@ -12,95 +12,55 @@ templates:
   - ingress/frontendconfig.yaml
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
-
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
 
-  # GKE CRDs must not be emitted
-  - it: No FrontendConfig is rendered
-    template: ingress/frontendconfig.yaml
+  - it: GKE-specific resources are not rendered
     asserts:
+      # GKE CRDs must not be emitted
       - hasDocuments:
           count: 0
-
-  - it: No BackendConfig is rendered
-    template: ingress/ingress.yaml
-    asserts:
+        template: ingress/frontendconfig.yaml
       - notContains:
           path: $[*].kind
           content: BackendConfig
         documentIndex: 0
-
-  - it: No ManagedCertificate is rendered
-    template: ingress/ingress.yaml
-    asserts:
+        template: ingress/ingress.yaml
       - notContains:
           path: $[*].kind
           content: ManagedCertificate
         documentIndex: 0
-
-  - it: Only Ingress and Service are rendered
-    template: ingress/ingress.yaml
-    asserts:
+        template: ingress/ingress.yaml
       - hasDocuments:
           count: 2
+        template: ingress/ingress.yaml
 
-  # Ingress has no GKE-specific annotations
-  - it: Ingress has no GCE ingress class annotation
+  - it: Ingress omits GKE-specific annotations
     template: ingress/ingress.yaml
     documentSelector:
       path: $[?(@.kind == "Ingress")].metadata.name
       value: test-service
     asserts:
+      # Ingress has no GKE-specific annotations
       - isNull:
           path: metadata.annotations["kubernetes.io/ingress.class"]
-
-  - it: Ingress has no static IP annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
       - isNull:
           path: metadata.annotations["kubernetes.io/ingress.global-static-ip-name"]
-
-  - it: Ingress has no managed-certificates annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
       - isNull:
           path: metadata.annotations["networking.gke.io/managed-certificates"]
-
-  - it: Ingress has no FrontendConfig annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
       - isNull:
           path: metadata.annotations["networking.gke.io/v1beta1.FrontendConfig"]
 
-  # Service has no GKE-specific annotations
-  - it: Service has no GKE NEG annotation
+  - it: Service omits GKE-specific annotations
     template: ingress/ingress.yaml
     documentSelector:
       path: $[?(@.kind == "Service")].metadata.name
       value: test-service
     asserts:
+      # Service has no GKE-specific annotations
       - isNull:
           path: metadata.annotations["cloud.google.com/neg"]
-
-  - it: Service has no GKE backend-config annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
       - isNull:
           path: metadata.annotations["cloud.google.com/backend-config"]

--- a/mozcloud/application/tests/onprem-service-accounts_test.yaml
+++ b/mozcloud/application/tests/onprem-service-accounts_test.yaml
@@ -11,37 +11,29 @@ values:
 templates:
   - serviceaccount/serviceaccount.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
-
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
 
-  - it: Default service account has no GKE WorkloadIdentity annotation
+  - it: ServiceAccounts have no GKE-specific annotations in on-prem mode
     template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: $[?(@.kind == "ServiceAccount")].metadata.name
-      value: mozcloud-test
     asserts:
+      # Default service account has no GKE WorkloadIdentity annotation
       - isNull:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
-
-  - it: Custom service account has no GKE WorkloadIdentity annotation
-    template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: $[?(@.kind == "ServiceAccount")].metadata.name
-      value: test-k8s-service-account
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: mozcloud-test
+      # Custom service account has no GKE WorkloadIdentity annotation
       - isNull:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
-
-  - it: Custom service account has no GKE backend-config annotation
-    template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: $[?(@.kind == "ServiceAccount")].metadata.name
-      value: test-k8s-service-account
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: test-k8s-service-account
+      # Custom service account has no GKE backend-config annotation
       - isNull:
           path: metadata.annotations["cloud.google.com/backend-config"]
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: test-k8s-service-account

--- a/mozcloud/application/tests/otel-configurations_test.yaml
+++ b/mozcloud/application/tests/otel-configurations_test.yaml
@@ -14,17 +14,14 @@ values:
 templates:
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: OTEL settings absent if disabled
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: otel-disabled
+
+  - it: OTEL annotations and env vars are conditional on otel and auto-instrumentation settings
     asserts:
+      # OTEL settings absent if disabled
       - isNotSubset:
           path: spec.template.metadata.annotations
           content:
@@ -34,6 +31,9 @@ tests:
             resource.opentelemetry.io/component_code: web
             resource.opentelemetry.io/env_code: dev
             resource.opentelemetry.io/realm: nonprod
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: otel-disabled
       - isNotSubset:
           path: spec.template.spec.containers[?(@.name=="app")].env
           content:
@@ -42,11 +42,10 @@ tests:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-  - it: OTEL settings configured correctly when auto instrumentation is disabled
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: otel-auto-instrumentation-disabled
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: otel-disabled
+      # OTEL settings configured correctly when auto instrumentation is disabled
       - isSubset:
           path: spec.template.metadata.annotations
           content:
@@ -54,11 +53,17 @@ tests:
             resource.opentelemetry.io/component_code: web
             resource.opentelemetry.io/env_code: dev
             resource.opentelemetry.io/realm: nonprod
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: otel-auto-instrumentation-disabled
       - isNotSubset:
           path: spec.template.metadata.annotations
           content:
             instrumentation.opentelemetry.io/inject-python: "mozcloud-opentelemetry/mozcloud-opentelemetry-instrumentation"
             instrumentation.opentelemetry.io/python-container-names: app
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: otel-auto-instrumentation-disabled
       - contains:
           path: spec.template.spec.containers[?(@.name=="app")].env
           content:
@@ -67,6 +72,9 @@ tests:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: otel-auto-instrumentation-disabled
       - notContains:
           path: spec.template.spec.containers[?(@.name=="sidecar")].env
           content:
@@ -75,11 +83,10 @@ tests:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-  - it: OTEL settings configured correctly when auto instrumentation is enabled
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: otel-auto-instrumentation-enabled
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: otel-auto-instrumentation-disabled
+      # OTEL settings configured correctly when auto instrumentation is enabled
       - isSubset:
           path: spec.template.metadata.annotations
           content:
@@ -89,6 +96,9 @@ tests:
             resource.opentelemetry.io/component_code: web
             resource.opentelemetry.io/env_code: dev
             resource.opentelemetry.io/realm: nonprod
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: otel-auto-instrumentation-enabled
       - notContains:
           path: spec.template.spec.containers[?(@.name=="app")].env
           content:
@@ -97,6 +107,9 @@ tests:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: otel-auto-instrumentation-enabled
       - notContains:
           path: spec.template.spec.containers[?(@.name=="sidecar")].env
           content:
@@ -105,3 +118,6 @@ tests:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: otel-auto-instrumentation-enabled

--- a/mozcloud/application/tests/pdb-configuration_test.yaml
+++ b/mozcloud/application/tests/pdb-configuration_test.yaml
@@ -11,47 +11,49 @@ values:
 templates:
   - workload/pdb.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Only one PDB is rendered across all three workloads
+
+  - it: Single PDB is rendered with correct kind, name, budgets, selector, and no PDB for disabled workloads
     asserts:
+      # Only one PDB is rendered across all three workloads
       - hasDocuments:
           count: 1
-  - it: PDB is created with correct kind and name
-    documentSelector:
-      path: $[?(@.kind == "PodDisruptionBudget")].metadata.name
-      value: test-service
-    asserts:
+      # PDB is created with correct kind and name
       - equal:
           path: apiVersion
           value: policy/v1
+        documentSelector:
+          path: $[?(@.kind == "PodDisruptionBudget")].metadata.name
+          value: test-service
       - equal:
           path: kind
           value: PodDisruptionBudget
-  - it: PDB sets minAvailable and maxUnavailable correctly
-    documentSelector:
-      path: $[?(@.kind == "PodDisruptionBudget")].metadata.name
-      value: test-service
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "PodDisruptionBudget")].metadata.name
+          value: test-service
+      # PDB sets minAvailable and maxUnavailable correctly
       - equal:
           path: spec.minAvailable
           value: 1
+        documentSelector:
+          path: $[?(@.kind == "PodDisruptionBudget")].metadata.name
+          value: test-service
       - equal:
           path: spec.maxUnavailable
           value: 30%
-  - it: PDB selector matches workload labels
-    documentSelector:
-      path: $[?(@.kind == "PodDisruptionBudget")].metadata.name
-      value: test-service
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "PodDisruptionBudget")].metadata.name
+          value: test-service
+      # PDB selector matches workload labels
       - isNotNullOrEmpty:
           path: spec.selector.matchLabels
-  - it: No PDB is rendered for workload with empty-pdb or disabled-pdb
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "PodDisruptionBudget")].metadata.name
+          value: test-service
+      # No PDB is rendered for workload with empty-pdb or disabled-pdb
       - notContains:
           path: "[*].metadata.name"
           content: test-service-empty-pdb

--- a/mozcloud/application/tests/preview-all-resources_test.yaml
+++ b/mozcloud/application/tests/preview-all-resources_test.yaml
@@ -27,195 +27,133 @@ tests:
   - it: Configuration matches entire snapshot
     asserts:
       - matchSnapshot: {}
-  # Test ConfigMap is prefixed
-  - it: Top-level ConfigMap is prefixed with PR number
-    template: configmap/configmap.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-app-config
+
+  - it: Top-level and default resources are prefixed with PR number
     asserts:
+      # Test ConfigMap is prefixed
       - equal:
           path: metadata.name
           value: pr789-app-config
-
-  # Test ServiceAccount is prefixed
-  - it: Top-level ServiceAccount is prefixed with PR number
-    template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-app-service-account
-    asserts:
+        template: configmap/configmap.yaml
+        documentSelector:
+          path: metadata.name
+          value: pr789-app-config
+      # Test ServiceAccount is prefixed
       - equal:
           path: metadata.name
           value: pr789-app-service-account
-
-  # Test default ServiceAccount is prefixed
-  - it: Default ServiceAccount is prefixed with PR number
-    template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-mozcloud-test
-    asserts:
+        template: serviceaccount/serviceaccount.yaml
+        documentSelector:
+          path: metadata.name
+          value: pr789-app-service-account
+      # Test default ServiceAccount is prefixed
       - equal:
           path: metadata.name
           value: pr789-mozcloud-test
-
-  # Test ExternalSecret is prefixed
-  - it: Top-level ExternalSecret is prefixed with PR number
-    template: externalsecret/externalsecret.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-app-external-secret
-    asserts:
+        template: serviceaccount/serviceaccount.yaml
+        documentSelector:
+          path: metadata.name
+          value: pr789-mozcloud-test
+      # Test ExternalSecret is prefixed
       - equal:
           path: metadata.name
           value: pr789-app-external-secret
-
-  # Test default ExternalSecret is prefixed
-  - it: Default ExternalSecret is prefixed with PR number
-    template: externalsecret/externalsecret.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-test-chart-secrets
-    asserts:
+        template: externalsecret/externalsecret.yaml
+        documentSelector:
+          path: metadata.name
+          value: pr789-app-external-secret
+      # Test default ExternalSecret is prefixed
       - equal:
           path: metadata.name
           value: pr789-test-chart-secrets
+        template: externalsecret/externalsecret.yaml
+        documentSelector:
+          path: metadata.name
+          value: pr789-test-chart-secrets
 
-  # Test Job is prefixed
-  - it: Job is prefixed with PR number
+  - it: Job is prefixed and its references resolve to prefixed resources
     template: task/job.yaml
     asserts:
+      # Test Job is prefixed
       - equal:
           path: metadata.name
           value: pr789-background-processor
-
-  # Test that configMapRef is prefixed in job containers
-  - it: Job container configMapRef should reference prefixed ConfigMap
-    template: task/job.yaml
-    asserts:
+      # Test that configMapRef is prefixed in job containers
       - equal:
           path: spec.template.spec.containers[?(@.name=="processor")].envFrom[0].configMapRef.name
           value: pr789-app-config
-
-  # Test that externalSecret secretRef is prefixed in job containers
-  - it: Job container secretRef should reference prefixed ExternalSecret
-    template: task/job.yaml
-    asserts:
+      # Test that externalSecret secretRef is prefixed in job containers
       - equal:
           path: spec.template.spec.containers[?(@.name=="processor")].envFrom[1].secretRef.name
           value: pr789-app-external-secret
-
-  # Test that serviceAccount reference is prefixed in job spec
-  - it: Job serviceAccountName should reference prefixed ServiceAccount
-    template: task/job.yaml
-    asserts:
+      # Test that serviceAccount reference is prefixed in job spec
       - equal:
           path: spec.template.spec.serviceAccountName
           value: pr789-app-service-account
 
-  # Test Deployment (workload) is prefixed
-  - it: Deployment is prefixed with PR number
+  - it: Deployment is prefixed and its references resolve to prefixed resources
     template: workload/deployment.yaml
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: pr789-api-service
     asserts:
+      # Test Deployment (workload) is prefixed
       - equal:
           path: metadata.name
           value: pr789-api-service
-
-  # Test Service is prefixed
-  - it: Service is prefixed with PR number
-    template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: pr789-api-service
-    asserts:
-      - equal:
-          path: metadata.name
-          value: pr789-api-service
-
-  # Test HTTPRoute is created with correct preview hostname
-  - it: HTTPRoute has correct preview hostname
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-api-host
-    asserts:
-      - contains:
-          path: spec.hostnames
-          content: "pr789-test.preview.mozilla.cloud"
-
-  # Test HTTPRoute routes to prefixed service
-  - it: HTTPRoute routes to prefixed service
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-api-host
-    asserts:
-      - equal:
-          path: spec.rules[0].backendRefs[0].name
-          value: pr789-api-service
-
-  # Test endpoint check job is created and prefixed
-  - it: Endpoint check job is prefixed with PR number
-    template: preview/endpointCheck.yaml
-    asserts:
-      - isKind:
-          of: Job
-      - equal:
-          path: metadata.name
-          value: pr789-mozcloud-test-endpoint-check
-
-  # Test endpoint check validates preview hostname
-  - it: Endpoint check validates preview hostname
-    template: preview/endpointCheck.yaml
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].args[2]
-          pattern: "pr789-test.preview.mozilla.cloud"
-
-  # Test that default secret reference is prefixed in workload containers
-  - it: Workload container secretRef should reference prefixed secret
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: pr789-api-service
-    asserts:
+      # Test that default secret reference is prefixed in workload containers
       - equal:
           path: spec.template.spec.containers[?(@.name=="app")].envFrom[1].secretRef.name
           value: pr789-test-chart-secrets
-
-  # Test that configMapRef is prefixed in workload containers
-  - it: Workload container configMapRef should reference prefixed ConfigMap
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: pr789-api-service
-    asserts:
+      # Test that configMapRef is prefixed in workload containers
       - equal:
           path: spec.template.spec.containers[?(@.name=="app")].envFrom[0].configMapRef.name
           value: pr789-app-config
-
-  # Test that user-defined externalSecret secretRef is prefixed in workload containers
-  - it: Workload container user-defined secretRef should reference prefixed ExternalSecret
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: pr789-api-service
-    asserts:
+      # Test that user-defined externalSecret secretRef is prefixed in workload containers
       - equal:
           path: spec.template.spec.containers[?(@.name=="app")].envFrom[2].secretRef.name
           value: pr789-app-external-secret
-
-  # Test that serviceAccount reference is prefixed in workload spec
-  - it: Workload serviceAccountName should reference prefixed ServiceAccount
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: pr789-api-service
-    asserts:
+      # Test that serviceAccount reference is prefixed in workload spec
       - equal:
           path: spec.template.spec.serviceAccountName
           value: pr789-mozcloud-test
+
+  - it: Service, HTTPRoute, and endpoint check target prefixed preview resources
+    asserts:
+      # Test Service is prefixed
+      - equal:
+          path: metadata.name
+          value: pr789-api-service
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: pr789-api-service
+      # Test HTTPRoute is created with correct preview hostname
+      - contains:
+          path: spec.hostnames
+          content: "pr789-test.preview.mozilla.cloud"
+        template: preview/httpRoute.yaml
+        documentSelector:
+          path: metadata.name
+          value: pr789-api-host
+      # Test HTTPRoute routes to prefixed service
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: pr789-api-service
+        template: preview/httpRoute.yaml
+        documentSelector:
+          path: metadata.name
+          value: pr789-api-host
+      # Test endpoint check job is created and prefixed
+      - isKind:
+          of: Job
+        template: preview/endpointCheck.yaml
+      - equal:
+          path: metadata.name
+          value: pr789-mozcloud-test-endpoint-check
+        template: preview/endpointCheck.yaml
+      # Test endpoint check validates preview hostname
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "pr789-test.preview.mozilla.cloud"
+        template: preview/endpointCheck.yaml

--- a/mozcloud/application/tests/preview-configmap-transform_test.yaml
+++ b/mozcloud/application/tests/preview-configmap-transform_test.yaml
@@ -18,53 +18,43 @@ tests:
   - it: Configuration matches entire snapshot
     asserts:
       - matchSnapshot: {}
-  # Test that explicitly listed keys are transformed
-  - it: URLBASE is transformed when empty and explicitly listed
+
+  - it: Preview ConfigMap is prefixed and transforms or preserves data keys correctly
     template: configmap/configmap.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-app-config
     asserts:
+      # Test that ConfigMap is prefixed in preview mode
+      # ConfigMap name is prefixed with PR number
+      - equal:
+          path: metadata.name
+          value: pr789-app-config
+      # Test that explicitly listed keys are transformed
+      # URLBASE is transformed when empty and explicitly listed
       - equal:
           path: data.URLBASE
           value: "https://pr789-test.preview.mozilla.cloud"
-
-  - it: ATTACHMENT_BASE is transformed when empty and explicitly listed
-    template: configmap/configmap.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-app-config
-    asserts:
+        documentSelector:
+          path: metadata.name
+          value: pr789-app-config
+      # ATTACHMENT_BASE is transformed when empty and explicitly listed
       - equal:
           path: data.ATTACHMENT_BASE
           value: "https://pr789-test.preview.mozilla.cloud"
-
-  # Test that non-listed keys are NOT transformed
-  - it: URL_BASE is not transformed when not in urlTransformKeys list
-    template: configmap/configmap.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-app-config
-    asserts:
+        documentSelector:
+          path: metadata.name
+          value: pr789-app-config
+      # Test that non-listed keys are NOT transformed
+      # URL_BASE is not transformed when not in urlTransformKeys list
       - equal:
           path: data.URL_BASE
           value: ""
-
-  # Test that non-empty values are preserved
-  - it: Non-empty values are not overwritten
-    template: configmap/configmap.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr789-app-config
-    asserts:
+        documentSelector:
+          path: metadata.name
+          value: pr789-app-config
+      # Test that non-empty values are preserved
+      # Non-empty values are not overwritten
       - equal:
           path: data.OTHER_VAR
           value: "keep-this"
-
-  # Test that ConfigMap is prefixed in preview mode
-  - it: ConfigMap name is prefixed with PR number
-    template: configmap/configmap.yaml
-    asserts:
-      - equal:
+        documentSelector:
           path: metadata.name
           value: pr789-app-config

--- a/mozcloud/application/tests/preview-multiple-workloads_test.yaml
+++ b/mozcloud/application/tests/preview-multiple-workloads_test.yaml
@@ -21,216 +21,140 @@ tests:
   - it: Configuration matches entire snapshot
     asserts:
       - matchSnapshot: {}
-  # Test that all three workload deployments are created with correct prefixes
-  - it: API deployment is prefixed with PR number
+
+  - it: All workload Deployments are prefixed with PR number
     template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: pr456-api-service
     asserts:
+      # Test that all three workload deployments are created with correct prefixes
       - equal:
           path: metadata.name
           value: pr456-api-service
-
-  - it: Web deployment is prefixed with PR number
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: pr456-web-service
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: pr456-api-service
       - equal:
           path: metadata.name
           value: pr456-web-service
-
-  - it: Admin deployment is prefixed with PR number
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: pr456-admin-service
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: pr456-web-service
       - equal:
           path: metadata.name
           value: pr456-admin-service
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: pr456-admin-service
 
-  # Test API HTTPRoute configuration
-  - it: API HTTPRoute has correct preview hostname
+  - it: API HTTPRoute is correctly configured for its preview hostname and shared gateway
     template: preview/httpRoute.yaml
     documentSelector:
       path: metadata.name
       value: pr456-api-host
     asserts:
+      # Test API HTTPRoute configuration
       - contains:
           path: spec.hostnames
           content: "api-pr456-test.preview.mozilla.cloud"
-
-  - it: API HTTPRoute uses shared preview gateway
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-api-host
-    asserts:
       - isSubset:
           path: spec.parentRefs[0]
           content:
             name: sandbox-high-preview-gateway
             namespace: preview-shared-infrastructure
-
-  - it: API HTTPRoute routes to prefixed service
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-api-host
-    asserts:
       - equal:
           path: spec.rules[0].backendRefs[0].name
           value: pr456-api-service
-
-  - it: API HTTPRoute has correct component label
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-api-host
-    asserts:
       - equal:
           path: metadata.labels.component_code
           value: api
 
-  # Test Web HTTPRoute configuration
-  - it: Web HTTPRoute has correct preview hostname
+  - it: Web HTTPRoute is correctly configured for its preview hostname and shared gateway
     template: preview/httpRoute.yaml
     documentSelector:
       path: metadata.name
       value: pr456-web-host
     asserts:
+      # Test Web HTTPRoute configuration
       - contains:
           path: spec.hostnames
           content: "web-pr456-test.preview.mozilla.cloud"
-
-  - it: Web HTTPRoute uses shared preview gateway
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-web-host
-    asserts:
       - isSubset:
           path: spec.parentRefs[0]
           content:
             name: sandbox-high-preview-gateway
             namespace: preview-shared-infrastructure
-
-  - it: Web HTTPRoute routes to prefixed service
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-web-host
-    asserts:
       - equal:
           path: spec.rules[0].backendRefs[0].name
           value: pr456-web-service
-
-  - it: Web HTTPRoute has correct component label
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-web-host
-    asserts:
       - equal:
           path: metadata.labels.component_code
           value: web
 
-  # Test Admin HTTPRoute configuration
-  - it: Admin HTTPRoute has correct preview hostname
+  - it: Admin HTTPRoute is correctly configured for its preview hostname and shared gateway
     template: preview/httpRoute.yaml
     documentSelector:
       path: metadata.name
       value: pr456-admin-host
     asserts:
+      # Test Admin HTTPRoute configuration
       - contains:
           path: spec.hostnames
           content: "admin-pr456-test.preview.mozilla.cloud"
-
-  - it: Admin HTTPRoute uses shared preview gateway
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-admin-host
-    asserts:
       - isSubset:
           path: spec.parentRefs[0]
           content:
             name: sandbox-high-preview-gateway
             namespace: preview-shared-infrastructure
-
-  - it: Admin HTTPRoute routes to prefixed service
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-admin-host
-    asserts:
       - equal:
           path: spec.rules[0].backendRefs[0].name
           value: pr456-admin-service
-
-  - it: Admin HTTPRoute has correct component label
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-admin-host
-    asserts:
       - equal:
           path: metadata.labels.component_code
           value: admin
 
-  # Test HTTP redirect routes are also created
-  - it: API HTTP to HTTPS redirect route is created
+  - it: HTTP-to-HTTPS redirect routes are created for each workload
     template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-api-host-http-redirect
     asserts:
+      # Test HTTP redirect routes are also created
       - contains:
           path: spec.hostnames
           content: "api-pr456-test.preview.mozilla.cloud"
+        documentSelector:
+          path: metadata.name
+          value: pr456-api-host-http-redirect
       - equal:
           path: spec.rules[0].filters[0].type
           value: RequestRedirect
+        documentSelector:
+          path: metadata.name
+          value: pr456-api-host-http-redirect
       - equal:
           path: spec.rules[0].filters[0].requestRedirect.scheme
           value: https
-
-  - it: Web HTTP to HTTPS redirect route is created
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-web-host-http-redirect
-    asserts:
+        documentSelector:
+          path: metadata.name
+          value: pr456-api-host-http-redirect
       - contains:
           path: spec.hostnames
           content: "web-pr456-test.preview.mozilla.cloud"
-
-  - it: Admin HTTP to HTTPS redirect route is created
-    template: preview/httpRoute.yaml
-    documentSelector:
-      path: metadata.name
-      value: pr456-admin-host-http-redirect
-    asserts:
+        documentSelector:
+          path: metadata.name
+          value: pr456-web-host-http-redirect
       - contains:
           path: spec.hostnames
           content: "admin-pr456-test.preview.mozilla.cloud"
+        documentSelector:
+          path: metadata.name
+          value: pr456-admin-host-http-redirect
 
-  # Test endpoint check validates all hostnames
-  - it: Endpoint check job is created
+  - it: Endpoint check job validates all preview hostnames
     template: preview/endpointCheck.yaml
     asserts:
+      # Test endpoint check validates all hostnames
       - isKind:
           of: Job
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook"]
           value: PostSync
-
-  - it: Endpoint check validates all three hostnames
-    template: preview/endpointCheck.yaml
-    asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[2]
           pattern: "admin-pr456-test.preview.mozilla.cloud"
@@ -240,10 +164,6 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[2]
           pattern: "web-pr456-test.preview.mozilla.cloud"
-
-  - it: Endpoint check reports correct count
-    template: preview/endpointCheck.yaml
-    asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[2]
           pattern: "Checking 3 endpoint"

--- a/mozcloud/application/tests/pvc-configuration_test.yaml
+++ b/mozcloud/application/tests/pvc-configuration_test.yaml
@@ -15,76 +15,114 @@ templates:
   - pvc/pvc.yaml
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: ReadWriteOnce PVC is configured correctly
-    template: pvc/pvc.yaml
-    documentSelector:
-      path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
-      value: pvc-rwo
+
+  - it: PVCs and Deployment volume mounts are configured correctly
     asserts:
+      # ReadWriteOnce PVC is configured correctly
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "-11"
+        template: pvc/pvc.yaml
+        documentSelector:
+          path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
+          value: pvc-rwo
       - equal:
           path: metadata.labels.component_code
           value: pvc
+        template: pvc/pvc.yaml
+        documentSelector:
+          path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
+          value: pvc-rwo
       - equal:
           path: spec.accessModes
           value: ["ReadWriteOnce"]
+        template: pvc/pvc.yaml
+        documentSelector:
+          path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
+          value: pvc-rwo
       - equal:
           path: spec.resources.requests.storage
           value: 10Gi
+        template: pvc/pvc.yaml
+        documentSelector:
+          path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
+          value: pvc-rwo
       - equal:
           path: spec.storageClassName
           value: standard
-  - it: ReadWriteMany PVC is configured correctly
-    template: pvc/pvc.yaml
-    documentSelector:
-      path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
-      value: pvc-rwm
-    asserts:
+        template: pvc/pvc.yaml
+        documentSelector:
+          path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
+          value: pvc-rwo
+      # ReadWriteMany PVC is configured correctly
       - equal:
           path: metadata.labels.component_code
           value: pvc
+        template: pvc/pvc.yaml
+        documentSelector:
+          path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
+          value: pvc-rwm
       - equal:
           path: spec.accessModes
           value: ["ReadWriteOnce", "ReadWriteMany"]
+        template: pvc/pvc.yaml
+        documentSelector:
+          path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
+          value: pvc-rwm
       - equal:
           path: spec.resources.requests.storage
           value: 50Gi
+        template: pvc/pvc.yaml
+        documentSelector:
+          path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
+          value: pvc-rwm
       - equal:
           path: spec.storageClassName
           value: mozilla-enterprise-rwx
-  - it: Container is configured to use PVCs as volumes
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+        template: pvc/pvc.yaml
+        documentSelector:
+          path: $[?(@.kind == "PersistentVolumeClaim")].metadata.name
+          value: pvc-rwm
+      # Container is configured to use PVCs as volumes
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /data/pvc-rwo
             name: pvc-rwo
+        template: workload/deployment.yaml
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /data/pvc-rwm
             name: pvc-rwm
+        template: workload/deployment.yaml
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
       - contains:
           path: spec.template.spec.volumes
           content:
             name: pvc-rwo
             persistentVolumeClaim:
               claimName: pvc-rwo
+        template: workload/deployment.yaml
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
       - contains:
           path: spec.template.spec.volumes
           content:
             name: pvc-rwm
             persistentVolumeClaim:
               claimName: pvc-rwm
+        template: workload/deployment.yaml
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/rollout-configuration_test.yaml
+++ b/mozcloud/application/tests/rollout-configuration_test.yaml
@@ -12,64 +12,82 @@ templates:
   - workload/rollout.yaml
   - workload/hpa.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Renders a Rollout instead of a Deployment
-    template: workload/rollout.yaml
-    documentSelector:
-      path: $[?(@.kind == "Rollout")].metadata.name
-      value: test-service
+
+  - it: Renders a Rollout with canary strategy and HPA targeting the Rollout
     asserts:
+      # Renders a Rollout instead of a Deployment
       - equal:
           path: apiVersion
           value: argoproj.io/v1alpha1
+        template: workload/rollout.yaml
+        documentSelector:
+          path: $[?(@.kind == "Rollout")].metadata.name
+          value: test-service
       - equal:
           path: kind
           value: Rollout
-  - it: Rollout has canary strategy with correct steps
-    template: workload/rollout.yaml
-    documentSelector:
-      path: $[?(@.kind == "Rollout")].metadata.name
-      value: test-service
-    asserts:
+        template: workload/rollout.yaml
+        documentSelector:
+          path: $[?(@.kind == "Rollout")].metadata.name
+          value: test-service
+      # Rollout has canary strategy with correct steps
       - isNotEmpty:
           path: spec.strategy.canary.steps
+        template: workload/rollout.yaml
+        documentSelector:
+          path: $[?(@.kind == "Rollout")].metadata.name
+          value: test-service
       - contains:
           path: spec.strategy.canary.steps
           content:
             setWeight: 20
+        template: workload/rollout.yaml
+        documentSelector:
+          path: $[?(@.kind == "Rollout")].metadata.name
+          value: test-service
       - contains:
           path: spec.strategy.canary.steps
           content:
             pause:
               duration: 30s
-  - it: Rollout does not have a Deployment-style strategy type
-    template: workload/rollout.yaml
-    documentSelector:
-      path: $[?(@.kind == "Rollout")].metadata.name
-      value: test-service
-    asserts:
+        template: workload/rollout.yaml
+        documentSelector:
+          path: $[?(@.kind == "Rollout")].metadata.name
+          value: test-service
+      # Rollout does not have a Deployment-style strategy type
       - notExists:
           path: spec.strategy.type
-  - it: HPA targets the Rollout instead of a Deployment
-    template: workload/hpa.yaml
-    documentSelector:
-      path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
-      value: test-service
-    asserts:
+        template: workload/rollout.yaml
+        documentSelector:
+          path: $[?(@.kind == "Rollout")].metadata.name
+          value: test-service
+      # HPA targets the Rollout instead of a Deployment
       - equal:
           path: spec.scaleTargetRef.apiVersion
           value: argoproj.io/v1alpha1
+        template: workload/hpa.yaml
+        documentSelector:
+          path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+          value: test-service
       - equal:
           path: spec.scaleTargetRef.kind
           value: Rollout
+        template: workload/hpa.yaml
+        documentSelector:
+          path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+          value: test-service
       - equal:
           path: spec.scaleTargetRef.name
           value: test-service
+        template: workload/hpa.yaml
+        documentSelector:
+          path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+          value: test-service
+
   - it: Schema rejects canary as a plain string strategy
     template: workload/rollout.yaml
     set:

--- a/mozcloud/application/tests/secret-default-cert-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/secret-default-cert-ingress-configuration_test.yaml
@@ -11,36 +11,26 @@ values:
 templates:
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Ingress does not have spec.tls (uses controller default cert)
+
+  - it: Ingress uses controller default cert (no TLS), traefik class, and no cert-manager annotations
     template: ingress/ingress.yaml
     documentSelector:
       path: $[?(@.kind == "Ingress")].metadata.name
       value: test-service
     asserts:
+      # Ingress does not have spec.tls (uses controller default cert)
       - isNull:
           path: spec.tls
-  - it: Ingress does not have cert-manager annotations
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+      # Ingress does not have cert-manager annotations
       - isNull:
           path: metadata.annotations["cert-manager.io/cluster-issuer"]
       - isNull:
           path: metadata.annotations["cert-manager.io/issuer"]
-  - it: Ingress uses traefik ingress class annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+      # Ingress uses traefik ingress class annotation
       - equal:
           path: metadata.annotations["kubernetes.io/ingress.class"]
           value: traefik

--- a/mozcloud/application/tests/secret-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/secret-ingress-configuration_test.yaml
@@ -11,40 +11,30 @@ values:
 templates:
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Ingress has spec.tls with correct secret and domain
+
+  - it: Ingress has secret TLS, traefik class, and no cert-manager annotations
     template: ingress/ingress.yaml
     documentSelector:
       path: $[?(@.kind == "Ingress")].metadata.name
       value: test-service
     asserts:
+      # Ingress has spec.tls with correct secret and domain
       - contains:
           path: spec.tls
           content:
             hosts:
               - test-service.dev.test-domain.com
             secretName: my-wildcard-tls
-  - it: Ingress does not have cert-manager annotations
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+      # Ingress does not have cert-manager annotations
       - isNull:
           path: metadata.annotations["cert-manager.io/cluster-issuer"]
       - isNull:
           path: metadata.annotations["cert-manager.io/issuer"]
-  - it: Ingress uses traefik ingress class annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
+      # Ingress uses traefik ingress class annotation
       - equal:
           path: metadata.annotations["kubernetes.io/ingress.class"]
           value: traefik

--- a/mozcloud/application/tests/security-context_test.yaml
+++ b/mozcloud/application/tests/security-context_test.yaml
@@ -14,18 +14,18 @@ values:
 templates:
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Deployment pod security context set correctly
+
+  - it: Deployment pod and container security contexts are set correctly
     template: workload/deployment.yaml
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service
     asserts:
+      # Deployment pod security context set correctly
       - isSubset:
           path: spec.template.spec.securityContext
           content:
@@ -36,12 +36,7 @@ tests:
             fsGroupChangePolicy: OnRootMismatch
             seccompProfile:
               type: RuntimeDefault
-  - it: Deployment container security context set correctly
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
-    asserts:
+      # Deployment container security context set correctly
       - isSubset:
           path: spec.template.spec.containers[0].securityContext
           content:

--- a/mozcloud/application/tests/service-account-image-pull-secrets_test.yaml
+++ b/mozcloud/application/tests/service-account-image-pull-secrets_test.yaml
@@ -11,33 +11,34 @@ values:
 templates:
   - serviceaccount/serviceaccount.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Default service account has imagePullSecrets
+
+  - it: Default and custom ServiceAccounts have their configured imagePullSecrets
     template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: $[?(@.kind == "ServiceAccount")].metadata.name
-      value: mozcloud-test
     asserts:
+      # Default service account has imagePullSecrets
       - contains:
           path: imagePullSecrets
           content:
             name: default-registry-secret
-  - it: Custom service account has multiple imagePullSecrets
-    template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: $[?(@.kind == "ServiceAccount")].metadata.name
-      value: custom-sa
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: mozcloud-test
+      # Custom service account has multiple imagePullSecrets
       - contains:
           path: imagePullSecrets
           content:
             name: custom-registry-secret-1
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: custom-sa
       - contains:
           path: imagePullSecrets
           content:
             name: custom-registry-secret-2
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: custom-sa

--- a/mozcloud/application/tests/service-accounts-default-disabled_test.yaml
+++ b/mozcloud/application/tests/service-accounts-default-disabled_test.yaml
@@ -14,18 +14,19 @@ tests:
   - it: Ensure no failures occur
     asserts:
       - notFailedTemplate: {}
-  - it: Only the custom service account is created
+
+  - it: Only the custom ServiceAccount is rendered and configured correctly
     template: serviceaccount/serviceaccount.yaml
     asserts:
+      # Only the custom service account is created
       - hasDocuments:
           count: 1
-  - it: Custom service account is created correctly
-    template: serviceaccount/serviceaccount.yaml
-    documentIndex: 0
-    asserts:
+      # Custom service account is created correctly
       - equal:
           path: metadata.name
           value: test-k8s-service-account-my-project
+        documentIndex: 0
       - equal:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
           value: test-service-nonprod-dev@moz-fx-mozcloud-test-nonprod.iam.gserviceaccount.com
+        documentIndex: 0

--- a/mozcloud/application/tests/service-accounts_test.yaml
+++ b/mozcloud/application/tests/service-accounts_test.yaml
@@ -15,72 +15,75 @@ templates:
   - serviceaccount/serviceaccount.yaml
   - workload/deployment.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Default service account configured correctly
+
+  - it: Default and custom ServiceAccounts are configured correctly
     template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: $[?(@.kind == "ServiceAccount")].metadata.name
-      value: mozcloud-test
     asserts:
+      # Default service account configured correctly
       - equal:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
           value: gke-dev@moz-fx-mozcloud-test-nonprod.iam.gserviceaccount.com
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: mozcloud-test
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "-11"
-  - it: Custom service account (same project) configured correctly
-    template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: $[?(@.kind == "ServiceAccount")].metadata.name
-      value: test-k8s-service-account-my-project
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: mozcloud-test
+      # Custom service account (same project) configured correctly
       - equal:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
           value: test-service-nonprod-dev@moz-fx-mozcloud-test-nonprod.iam.gserviceaccount.com
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: test-k8s-service-account-my-project
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "-11"
-  - it: Custom service account (different project) configured correctly
-    template: serviceaccount/serviceaccount.yaml
-    documentSelector:
-      path: $[?(@.kind == "ServiceAccount")].metadata.name
-      value: test-k8s-service-account-different-project
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: test-k8s-service-account-my-project
+      # Custom service account (different project) configured correctly
       - equal:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
           value: different-service-nonprod-dev@moz-fx-different-project-nonprod.iam.gserviceaccount.com
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: test-k8s-service-account-different-project
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "-11"
-  - it: Default deployment uses default service account
+        documentSelector:
+          path: $[?(@.kind == "ServiceAccount")].metadata.name
+          value: test-k8s-service-account-different-project
+
+  - it: Deployments reference their respective default or custom ServiceAccounts
     template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: web
     asserts:
+      # Default deployment uses default service account
       - equal:
           path: spec.template.spec.serviceAccountName
           value: mozcloud-test
-  - it: First custom deployment uses custom service account from same project
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: custom-my-project
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: web
+      # First custom deployment uses custom service account from same project
       - equal:
           path: spec.template.spec.serviceAccountName
           value: test-k8s-service-account-my-project
-  - it: Second custom deployment uses custom service account from different project
-    template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: custom-different-project
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: custom-my-project
+      # Second custom deployment uses custom service account from different project
       - equal:
           path: spec.template.spec.serviceAccountName
           value: test-k8s-service-account-different-project
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: custom-different-project

--- a/mozcloud/application/tests/shared-gateway-configuration_test.yaml
+++ b/mozcloud/application/tests/shared-gateway-configuration_test.yaml
@@ -15,27 +15,33 @@ templates:
   - gke/backend.yaml
   - gke/gateway.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: Does not create a Gateway resource when using shared gateway
-    template: gateway/gateway.yaml
+
+  - it: No Gateway or GCPGatewayPolicy is created when using the shared gateway
     asserts:
+      # Does not create a Gateway resource when using shared gateway
       - isNull:
           path: $[?(@.kind == "Gateway")]
-  - it: Creates HTTPRoute that references the shared gateway
+        template: gateway/gateway.yaml
+      # Does not create GCPGatewayPolicy when using shared gateway
+      - isNull:
+          path: $[?(@.kind == "GCPGatewayPolicy")]
+        template: gke/gateway.yaml
+
+  - it: HTTPRoutes reference the shared gateway for HTTPS and HTTP redirect
     template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: shared-gateway-host
     asserts:
+      # Creates HTTPRoute that references the shared gateway
       - contains:
           path: spec.hostnames
           count: 1
           content: shared.test-domain.com
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: shared-gateway-host
       - contains:
           path: spec.parentRefs
           count: 1
@@ -45,12 +51,10 @@ tests:
             name: sandbox-high-preview-gateway
             namespace: preview-shared-infrastructure
             sectionName: https
-  - it: Creates HTTP redirect HTTPRoute that references the shared gateway
-    template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: shared-gateway-host-http-redirect
-    asserts:
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: shared-gateway-host
+      # Creates HTTP redirect HTTPRoute that references the shared gateway
       - contains:
           path: spec.parentRefs
           count: 1
@@ -60,35 +64,33 @@ tests:
             name: sandbox-high-preview-gateway
             namespace: preview-shared-infrastructure
             sectionName: http
-  - it: Does not create GCPGatewayPolicy when using shared gateway
-    template: gke/gateway.yaml
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: shared-gateway-host-http-redirect
+
+  - it: Backend Service, GCPBackendPolicy, and HealthCheckPolicy are created for the workload
     asserts:
-      - isNull:
-          path: $[?(@.kind == "GCPGatewayPolicy")]
-  - it: Creates backend Service for the workload
-    template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
+      # Creates backend Service for the workload
       - equal:
           path: spec.type
           value: ClusterIP
-  - it: Creates GCPBackendPolicy for the backend service
-    template: gke/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
-      value: test-service
-    asserts:
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      # Creates GCPBackendPolicy for the backend service
       - equal:
           path: spec.targetRef.name
           value: test-service
-  - it: Creates HealthCheckPolicy for the backend service
-    template: gke/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
-      value: test-service
-    asserts:
+        template: gke/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: test-service
+      # Creates HealthCheckPolicy for the backend service
       - equal:
           path: spec.targetRef.name
+          value: test-service
+        template: gke/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
           value: test-service

--- a/mozcloud/application/tests/telegraf-podmonitoring_test.yaml
+++ b/mozcloud/application/tests/telegraf-podmonitoring_test.yaml
@@ -11,34 +11,32 @@ values:
 templates:
   - gke/podmonitoring.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
-  - it: PodMonitoring is rendered when telegraf.enabled is true
+
+  - it: PodMonitoring is rendered with correct name, kind, and telegraf selector when enabled
     asserts:
+      # PodMonitoring is rendered when telegraf.enabled is true
       - hasDocuments:
           count: 1
-  - it: PodMonitoring resource has correct name
-    documentIndex: 0
-    asserts:
+      # PodMonitoring resource has correct name
       - equal:
           path: metadata.name
           value: mozcloud-test-telegraf
-  - it: PodMonitoring resource has correct kind
-    documentIndex: 0
-    asserts:
+        documentIndex: 0
+      # PodMonitoring resource has correct kind
       - equal:
           path: kind
           value: PodMonitoring
-  - it: PodMonitoring scrapes telegraf selector
-    documentIndex: 0
-    asserts:
+        documentIndex: 0
+      # PodMonitoring scrapes telegraf selector
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: telegraf
+        documentIndex: 0
+
   - it: PodMonitoring is not rendered when telegraf.enabled is false
     set:
       telegraf.enabled: false

--- a/mozcloud/application/tests/traefik-gateway-configuration_test.yaml
+++ b/mozcloud/application/tests/traefik-gateway-configuration_test.yaml
@@ -13,82 +13,62 @@ templates:
   - gateway/gateway.yaml
   - gateway/httproute.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
-
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
 
-  # GKE CRDs must not be emitted
-  - it: No GCPBackendPolicy is rendered
-    template: gateway/backend.yaml
+  - it: GKE-specific CRDs and annotations are not emitted
     asserts:
+      # GKE CRDs must not be emitted
       - notContains:
           path: $[*].kind
           content: GCPBackendPolicy
         documentIndex: 0
-
-  - it: No HealthCheckPolicy is rendered
-    template: gateway/backend.yaml
-    asserts:
+        template: gateway/backend.yaml
       - notContains:
           path: $[*].kind
           content: HealthCheckPolicy
         documentIndex: 0
-
-  - it: No GCPGatewayPolicy is rendered
-    template: gateway/gateway.yaml
-    asserts:
+        template: gateway/backend.yaml
       - hasDocuments:
           count: 1
-
-  - it: Only a Service is rendered in backend template
-    template: gateway/backend.yaml
-    asserts:
+        template: gateway/gateway.yaml
       - hasDocuments:
           count: 1
+        template: gateway/backend.yaml
       - equal:
           path: kind
           value: Service
         documentIndex: 0
+        template: gateway/backend.yaml
+      - isNull:
+          path: metadata.annotations["cloud.google.com/neg"]
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
+      - isNull:
+          path: metadata.annotations["cloud.google.com/backend-config"]
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: test-service
 
-  # Gateway uses gatewayClass derived from cloud.ingress.default
-  - it: Gateway uses traefik gatewayClass from cloud.ingress.default
+  - it: Gateway uses traefik gatewayClass and Kubernetes secret TLS (no GKE specifics)
     template: gateway/gateway.yaml
     documentSelector:
       path: $[?(@.kind == "Gateway")].metadata.name
       value: mozcloud-test
     asserts:
+      # Gateway uses gatewayClass derived from cloud.ingress.default
       - equal:
           path: spec.gatewayClassName
           value: traefik
-
-  - it: Gateway has no static IP addresses (no NamedAddress)
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test
-    asserts:
       - isNull:
           path: spec.addresses
-
-  - it: Gateway has no GKE certmap annotation
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test
-    asserts:
       - isNull:
           path: metadata.annotations["networking.gke.io/certmap"]
-
-  - it: Gateway TLS uses Kubernetes secret certificateRefs
-    template: gateway/gateway.yaml
-    documentSelector:
-      path: $[?(@.kind == "Gateway")].metadata.name
-      value: mozcloud-test
-    asserts:
       - contains:
           path: spec.listeners
           content:
@@ -103,37 +83,12 @@ tests:
               certificateRefs:
                 - name: test-service-tls
 
-  - it: Service has no GKE NEG annotation
-    template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
-      - isNull:
-          path: metadata.annotations["cloud.google.com/neg"]
-
-  - it: Service has no GKE backend-config annotation
-    template: gateway/backend.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
-      - isNull:
-          path: metadata.annotations["cloud.google.com/backend-config"]
-
-  # HTTPRoutes should still render normally
-  - it: HTTPRoutes are still rendered
+  - it: HTTPRoutes render and reference the Gateway correctly
     template: gateway/httproute.yaml
     asserts:
+      # HTTPRoutes should still render normally
       - hasDocuments:
           count: 2
-
-  - it: HTTPS HTTPRoute references the Gateway correctly
-    template: gateway/httproute.yaml
-    documentSelector:
-      path: $[?(@.kind == "HTTPRoute")].metadata.name
-      value: test-service
-    asserts:
       - contains:
           path: spec.parentRefs
           count: 1
@@ -142,3 +97,6 @@ tests:
             kind: Gateway
             name: mozcloud-test
             sectionName: https
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/traefik-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/traefik-ingress-configuration_test.yaml
@@ -12,96 +12,56 @@ templates:
   - ingress/frontendconfig.yaml
   - ingress/ingress.yaml
 tests:
-  - it: Ensure no failures occur
-    asserts:
-      - notFailedTemplate: {}
-
   - it: Configuration matches entire snapshot
     asserts:
+      - notFailedTemplate: {}
       - matchSnapshot: {}
 
-  # GKE CRDs must not be emitted
-  - it: No FrontendConfig is rendered
-    template: ingress/frontendconfig.yaml
+  - it: GKE-specific resources are not rendered
     asserts:
+      # GKE CRDs must not be emitted
       - hasDocuments:
           count: 0
-
-  - it: No BackendConfig is rendered
-    template: ingress/ingress.yaml
-    asserts:
+        template: ingress/frontendconfig.yaml
       - notContains:
           path: $[*].kind
           content: BackendConfig
         documentIndex: 0
-
-  - it: No ManagedCertificate is rendered
-    template: ingress/ingress.yaml
-    asserts:
+        template: ingress/ingress.yaml
       - notContains:
           path: $[*].kind
           content: ManagedCertificate
         documentIndex: 0
-
-  - it: Only Ingress and Service are rendered
-    template: ingress/ingress.yaml
-    asserts:
+        template: ingress/ingress.yaml
       - hasDocuments:
           count: 2
+        template: ingress/ingress.yaml
 
-  # Ingress has traefik class annotation and no GKE-specific annotations
-  - it: Ingress has traefik ingress class annotation from cloud.ingress.default
+  - it: Ingress uses traefik class and omits GKE-specific annotations
     template: ingress/ingress.yaml
     documentSelector:
       path: $[?(@.kind == "Ingress")].metadata.name
       value: test-service
     asserts:
+      # Ingress has traefik class annotation and no GKE-specific annotations
       - equal:
           path: metadata.annotations["kubernetes.io/ingress.class"]
           value: traefik
-
-  - it: Ingress has no static IP annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
       - isNull:
           path: metadata.annotations["kubernetes.io/ingress.global-static-ip-name"]
-
-  - it: Ingress has no managed-certificates annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
       - isNull:
           path: metadata.annotations["networking.gke.io/managed-certificates"]
-
-  - it: Ingress has no FrontendConfig annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Ingress")].metadata.name
-      value: test-service
-    asserts:
       - isNull:
           path: metadata.annotations["networking.gke.io/v1beta1.FrontendConfig"]
 
-  # Service has no GKE-specific annotations
-  - it: Service has no GKE NEG annotation
+  - it: Service omits GKE-specific annotations
     template: ingress/ingress.yaml
     documentSelector:
       path: $[?(@.kind == "Service")].metadata.name
       value: test-service
     asserts:
+      # Service has no GKE-specific annotations
       - isNull:
           path: metadata.annotations["cloud.google.com/neg"]
-
-  - it: Service has no GKE backend-config annotation
-    template: ingress/ingress.yaml
-    documentSelector:
-      path: $[?(@.kind == "Service")].metadata.name
-      value: test-service
-    asserts:
       - isNull:
           path: metadata.annotations["cloud.google.com/backend-config"]

--- a/mozcloud/application/tests/workload-disabled_test.yaml
+++ b/mozcloud/application/tests/workload-disabled_test.yaml
@@ -13,18 +13,17 @@ templates:
   - workload/hpa.yaml
   - gke/podmonitoring.yaml
 tests:
-  - it: Deployment is not rendered for disabled workload
-    template: workload/deployment.yaml
+  - it: Deployment, HPA, and PodMonitoring are not rendered for disabled workload
     asserts:
+      # Deployment is not rendered for disabled workload
       - hasDocuments:
           count: 0
-  - it: HPA is not rendered for disabled workload
-    template: workload/hpa.yaml
-    asserts:
+        template: workload/deployment.yaml
+      # HPA is not rendered for disabled workload
       - hasDocuments:
           count: 0
-  - it: PodMonitoring is not rendered for disabled workload
-    template: gke/podmonitoring.yaml
-    asserts:
+        template: workload/hpa.yaml
+      # PodMonitoring is not rendered for disabled workload
       - hasDocuments:
           count: 0
+        template: gke/podmonitoring.yaml


### PR DESCRIPTION
Each test block (usually denoted by an `it:`) [re-renders the entire chart](https://github.com/helm-unittest/helm-unittest/blob/main/DOCUMENT.md#test-job:~:text=Your%20chart%20is%20rendered%20each%20time%20a%20test%20job%20run), which can be expensive. 

In this PR, we "collapse" similar blocks when possible and make more assertions on each block. This has a downside of making test failures a little less obvious to diagnose (i.e. an assertion error vs a helpful message in the `it:` block), but it speeds up the test suite from [~6m30s](https://github.com/mozilla/helm-charts/actions/runs/24536768986/job/71733512590) to [~3m](https://github.com/mozilla/helm-charts/actions/runs/24575004722/job/71857907476?pr=251).