### PR TITLE
feat: Allow custom sync hooks for jobs

### DIFF
--- a/mozcloud/application/templates/_annotations.yaml
+++ b/mozcloud/application/templates/_annotations.yaml
@@ -41,13 +41,19 @@ resources, adds a sync-wave annotation using either the user-supplied value
 or a type-specific default from mozcloud.annotations.argo.syncWaveDefaults.
 
 Params:
-  syncWave (string): (optional) Override for the ArgoCD sync-wave value.
-                     When omitted, a default is looked up by resource type.
-  type (string):     (required) The resource type. Used to determine sync-wave
-                     defaults and hook annotations. Accepted values:
-                     "configMap", "deployment", "externalSecret", "hpa",
-                     "jobPostDeployment", "jobPreDeployment", "pvc",
-                     "serviceAccount".
+  hook (string):             (optional) Override for the ArgoCD hook type.
+                             When omitted, defaults to "Sync". Accepted values:
+                             "PreSync", "Sync", "PostSync", "SyncFail", "Skip".
+  hookDeletePolicy (string): (optional) Override for the ArgoCD hook-delete-policy.
+                             When omitted, defaults to
+                             "BeforeHookCreation,HookSucceeded".
+  syncWave (string):         (optional) Override for the ArgoCD sync-wave value.
+                             When omitted, a default is looked up by resource type.
+  type (string):             (required) The resource type. Used to determine
+                             sync-wave defaults and hook annotations. Accepted
+                             values: "configMap", "deployment", "externalSecret",
+                             "hpa", "jobPostDeployment", "jobPreDeployment",
+                             "pvc", "serviceAccount".
 
 Returns:
   (string) YAML-encoded key-value pairs of ArgoCD annotations.
@@ -56,8 +62,8 @@ Returns:
 {{- $type := .type -}}
 {{- $syncWaveDefault := index (include "mozcloud.annotations.argo.syncWaveDefaults" . | fromYaml) $type -}}
 {{- if has $type (list "jobPostDeployment" "jobPreDeployment") }}
-argocd.argoproj.io/hook: Sync
-argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+argocd.argoproj.io/hook: {{ default "Sync" .hook }}
+argocd.argoproj.io/hook-delete-policy: {{ default "BeforeHookCreation,HookSucceeded" .hookDeletePolicy }}
 {{- end }}
 {{- /* Deployments do not have sync wave values */}}
 {{- if ne $type "deployment" }}

--- a/mozcloud/application/templates/task/job.yaml
+++ b/mozcloud/application/templates/task/job.yaml
@@ -30,7 +30,7 @@ metadata:
   {{- else if eq $config.type "postDeployment" }}
     {{- $type = "jobPostDeployment" }}
   {{- end }}
-  {{- $params = dict "syncWave" (($config.argo).syncWave) "type" $type }}
+  {{- $params = dict "hook" (($config.argo).hook) "hookDeletePolicy" (($config.argo).hookDeletePolicy) "syncWave" (($config.argo).syncWave) "type" $type }}
   {{- $argoAnnotations := include "mozcloud.annotations.argo" $params | fromYaml }}
   {{- $params = dict "annotations" (mergeOverwrite $argoAnnotations (default dict $config.annotations)) "context" ($context | deepCopy) "type" "job" }}
   {{- $annotations := include "mozcloud.annotations" $params | fromYaml }}

--- a/mozcloud/application/tests/__snapshot__/basic-job-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/basic-job-configuration_test.yaml.snap
@@ -151,3 +151,77 @@ Configuration matches entire snapshot:
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: mozcloud-test
+  3: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/hook-delete-policy: HookSucceeded
+        argocd.argoproj.io/sync-wave: "-1"
+      labels:
+        app.kubernetes.io/component: job
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: job
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-presync-job
+    spec:
+      backoffLimit: 6
+      parallelism: 1
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: job
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: job
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: job
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - args:
+                - echo
+                - migrating
+              command:
+                - sh
+                - -c
+              image: test-repo/db-migrate:1.0.0
+              imagePullPolicy: Always
+              name: migrate
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          restartPolicy: Never
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test

--- a/mozcloud/application/tests/basic-job-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-job-configuration_test.yaml
@@ -25,7 +25,7 @@ tests:
       - notFailedTemplate: {}
       - matchSnapshot: {}
 
-  - it: Pre- and post-deployment Jobs are configured correctly
+  - it: Job argo annotations and sync waves are configured correctly
     template: task/job.yaml
     asserts:
       # Pre-deployment job is configured correctly
@@ -262,3 +262,22 @@ tests:
         documentSelector:
           path: $[?(@.kind == "Job")].metadata.name
           value: test-postdeployment-job
+      # Custom argo annotations are rendered correctly
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-presync-job
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: HookSucceeded
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-presync-job
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-1"
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-presync-job

--- a/mozcloud/application/tests/values/basic-job-configuration.yaml
+++ b/mozcloud/application/tests/values/basic-job-configuration.yaml
@@ -19,3 +19,16 @@ tasks:
             tag: 3.0.0
           command: ["sh", "-c"]
           args: ["echo", "running", "after", "deployment"]
+    test-presync-job:
+      type: preDeployment
+      argo:
+        hook: PreSync
+        hookDeletePolicy: HookSucceeded
+        syncWave: -1
+      containers:
+        migrate:
+          image:
+            repository: test-repo/db-migrate
+            tag: "1.0.0"
+          command: ["sh", "-c"]
+          args: ["echo", "migrating"]

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -319,6 +319,19 @@
                   "argo": {
                     "type": "object",
                     "properties": {
+                      "hook": {
+                        "type": "string",
+                        "enum": [
+                          "PreSync",
+                          "Sync",
+                          "PostSync",
+                          "SyncFail",
+                          "Skip"
+                        ]
+                      },
+                      "hookDeletePolicy": {
+                        "type": "string"
+                      },
                       "syncWave": {
                         "type": "integer"
                       }

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -425,22 +425,25 @@ tasks:
       # already set.
       generateName: false
 
-      # Optionally define a Sync Wave value for ArgoCD.
+      # Optionally customize ArgoCD sync annotations for this job.
       #
-      # Sync waves are used to define an order in which resources are
-      # applied within a sync phase. Sync waves are configured using
-      # integers in ascending order, where resources with lower-value sync
-      # waves are applied first and resources with higher-value sync waves
-      # are applied last.
+      # hook: The ArgoCD hook type. Defaults to "Sync". Set to "PreSync"
+      #   for jobs that must complete before any other resources are applied
+      #   (e.g. database migrations).
+      #   Accepted values: PreSync, Sync, PostSync, SyncFail, Skip
       #
-      # This chart allows you to assign Sync Wave values for pre-deployment
-      # jobs ranging from -10 (run first) to -1 (run last).
+      # hookDeletePolicy: Controls when ArgoCD deletes the hook resource.
+      #   Defaults to "BeforeHookCreation,HookSucceeded".
       #
-      # If no values are specified, a default of -1 will be applied.
+      # syncWave: Sync waves define the order in which resources are applied
+      #   within a sync phase, using integers in ascending order. Defaults
+      #   to -1 for preDeployment jobs and 1 for postDeployment jobs.
       #
       # Format:
       #
       #   argo:
+      #     hook: PreSync
+      #     hookDeletePolicy: HookSucceeded
       #     syncWave: -1
       argo: {}
 


### PR DESCRIPTION
Before, `argocd.argoproj.io/hook` was hard-coded to `Sync` and `hook-delete-policy` to `BeforeHookCreation,HookSucceeded` for `jobPostDeployment` and `jobPreDeployment` jobs.

Now, we can specify custom hooks and hook-delete-policies. The motivation for this change was supporting the PreSync hook for [database migration jobs](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/#:~:text=argocd%2Eargoproj%2Eio%2Fhook%3A%20PreSync%20argocd%2Eargoproj%2Eio%2Fhook%2Ddelete%2Dpolicy%3A%20HookSucceeded)