### PR TITLE
chore(moztel): MZCLD-2811

### DIFF
--- a/mozcloud-opentelemetry/application/Chart.yaml
+++ b/mozcloud-opentelemetry/application/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: mozcloud-opentelemetry
-description: Opinionated application chart for MozCloud OpenTelemetry signals 
+description: Opinionated application chart for MozCloud OpenTelemetry signals
   collection
 type: application
-version: 0.2.28
+version: 0.2.29
 appVersion: 0.144.0
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-opentelemetry/application/Chart.yaml
+++ b/mozcloud-opentelemetry/application/Chart.yaml
@@ -3,7 +3,7 @@ name: mozcloud-opentelemetry
 description: Opinionated application chart for MozCloud OpenTelemetry signals
   collection
 type: application
-version: 0.2.28
+version: 0.2.29
 appVersion: 0.144.0
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-opentelemetry/application/Chart.yaml
+++ b/mozcloud-opentelemetry/application/Chart.yaml
@@ -3,7 +3,7 @@ name: mozcloud-opentelemetry
 description: Opinionated application chart for MozCloud OpenTelemetry signals
   collection
 type: application
-version: 0.2.29
+version: 0.2.28
 appVersion: 0.144.0
 dependencies:
   - name: mozcloud-labels-lib

--- a/mozcloud-opentelemetry/application/README.md
+++ b/mozcloud-opentelemetry/application/README.md
@@ -1,6 +1,6 @@
 # mozcloud-opentelemetry
 
-![Version: 0.2.28](https://img.shields.io/badge/Version-0.2.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.29](https://img.shields.io/badge/Version-0.2.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Opinionated application chart for MozCloud OpenTelemetry signals collection
 

--- a/mozcloud-opentelemetry/application/README.md
+++ b/mozcloud-opentelemetry/application/README.md
@@ -1,6 +1,6 @@
 # mozcloud-opentelemetry
 
-![Version: 0.2.28](https://img.shields.io/badge/Version-0.2.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.29](https://img.shields.io/badge/Version-0.2.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Opinionated application chart for MozCloud OpenTelemetry signals collection
 
@@ -19,7 +19,7 @@ version: 0.1.0
 type: application
 dependencies:
   - name: mozcloud-opentelemetry
-    version: ~0.2.28
+    version: ~0.2.29
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
 ```
 
@@ -62,10 +62,10 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | collectors.gateway.endpoints.otlp.port | string | `"4317"` |  |
 | collectors.gateway.endpoints.statsd.endpoint | string | `"mozcloud-opentelemetry-gateway-statsd"` |  |
 | collectors.gateway.endpoints.statsd.port | string | `"8125"` |  |
-| collectors.gateway.resources.limits.cpu | string | `"400m"` |  |
-| collectors.gateway.resources.limits.memory | string | `"2Gi"` |  |
-| collectors.gateway.resources.requests.cpu | string | `"300m"` |  |
-| collectors.gateway.resources.requests.memory | string | `"1536Mi"` |  |
+| collectors.gateway.resources.limits.cpu | string | `"1"` |  |
+| collectors.gateway.resources.limits.memory | string | `"3Gi"` |  |
+| collectors.gateway.resources.requests.cpu | string | `"500m"` |  |
+| collectors.gateway.resources.requests.memory | string | `"2Gi"` |  |
 | collectors.gateway.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | collectors.gateway.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | collectors.gateway.securityContext.privileged | bool | `false` |  |

--- a/mozcloud-opentelemetry/application/README.md
+++ b/mozcloud-opentelemetry/application/README.md
@@ -1,6 +1,6 @@
 # mozcloud-opentelemetry
 
-![Version: 0.2.29](https://img.shields.io/badge/Version-0.2.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.28](https://img.shields.io/badge/Version-0.2.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Opinionated application chart for MozCloud OpenTelemetry signals collection
 
@@ -19,7 +19,7 @@ version: 0.1.0
 type: application
 dependencies:
   - name: mozcloud-opentelemetry
-    version: ~0.2.29
+    version: ~0.2.28
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
 ```
 

--- a/mozcloud-opentelemetry/application/README.md
+++ b/mozcloud-opentelemetry/application/README.md
@@ -19,7 +19,7 @@ version: 0.1.0
 type: application
 dependencies:
   - name: mozcloud-opentelemetry
-    version: ~0.2.28
+    version: ~0.2.29
     repository: oci://us-west1-docker.pkg.dev/moz-fx-platform-artifacts/mozcloud-charts
 ```
 

--- a/mozcloud-opentelemetry/application/values.yaml
+++ b/mozcloud-opentelemetry/application/values.yaml
@@ -68,11 +68,11 @@ collectors:
       targetMemoryUtilization: 60
     resources:
       limits:
-        cpu: 400m
-        memory: 2Gi
+        cpu: "1"
+        memory: 3Gi
       requests:
-        cpu: 300m
-        memory: 1536Mi      
+        cpu: 500m
+        memory: 2Gi
 
 serviceAccount:
   create: true


### PR DESCRIPTION
- mozcloud-opentelemetry-gateway-collector is crashlooping due to high memory utilization. - increased the resources limit and requests 