### PR TITLE
feat: Allow overrindg gateway and related names

### DIFF
--- a/mozcloud/application/templates/gateway/_helpers.tpl
+++ b/mozcloud/application/templates/gateway/_helpers.tpl
@@ -4,6 +4,9 @@ multiple gateway types are present (both "external" and "internal"), the type
 is always appended as a suffix. When only a single type is present, the suffix
 is omitted for external gateways but always included for internal ones.
 
+If nameOverride is provided, it is returned as-is, bypassing all other logic.
+This is useful when migrating from a chart that used a different Gateway name.
+
 This naming logic is shared between mozcloud.gateway.gateways (which creates
 the Gateway resources) and mozcloud.gateway.httpRoutes (which references them
 in gatewayRefs) to ensure consistent names across resource types.
@@ -16,6 +19,7 @@ Params:
   hasMultipleTypes (bool): (required) Whether both "external" and "internal"
                            gateway types are present in this release. When
                            true, the type suffix is always appended.
+  nameOverride (string):   (optional) When non-empty, returned as-is.
 
 Returns:
   (string) The gateway resource name.
@@ -28,8 +32,15 @@ Example:
   # Both external and internal gateways present:
   { appCode: myapp, type: external, hasMultipleTypes: true }  → "myapp-external"
   { appCode: myapp, type: internal, hasMultipleTypes: true }  → "myapp-internal"
+
+  # Name override:
+  { appCode: myapp, type: external, hasMultipleTypes: false, nameOverride: "external" } → "external"
 */ -}}
 {{- define "mozcloud.gateway.name" -}}
+{{- $nameOverride := default "" .nameOverride -}}
+{{- if $nameOverride -}}
+{{- $nameOverride -}}
+{{- else -}}
 {{- $appCode := .appCode -}}
 {{- $type := .type -}}
 {{- $hasMultipleTypes := .hasMultipleTypes -}}
@@ -38,4 +49,5 @@ Example:
   {{- $gatewayName = printf "%s-%s" $gatewayName $type }}
 {{- end }}
 {{- $gatewayName -}}
+{{- end -}}
 {{- end -}}

--- a/mozcloud/application/templates/gateway/gateway.yaml
+++ b/mozcloud/application/templates/gateway/gateway.yaml
@@ -95,7 +95,8 @@ Returns:
         {{- end }}
       {{- end }}
       {{- /* Create a unique key for this gateway configuration */}}
-      {{- $configKey := printf "%s-%s-%s" $hostConfig.type $className ($addresses | join "-") }}
+      {{- $nameOverride := default "" $hostConfig.gatewayName }}
+      {{- $configKey := printf "%s-%s-%s-%s" $hostConfig.type $className ($addresses | join "-") $nameOverride }}
       {{- if not (hasKey $gatewayConfigs $configKey) }}
         {{- $gatewayConfig := dict }}
         {{- $_ := set $gatewayConfig "type" $hostConfig.type }}
@@ -111,6 +112,7 @@ Returns:
           {{- end }}
         {{- end }}
         {{- $_ = set $gatewayConfig "tlsType" $tlsType }}
+        {{- $_ = set $gatewayConfig "nameOverride" $nameOverride }}
         {{- $_ = set $gatewayConfigs $configKey $gatewayConfig }}
       {{- end }}
     {{- end }}
@@ -118,11 +120,14 @@ Returns:
 {{- end }}
 {{- /* Generate gateways from unique configurations */}}
 gateways:
-  {{- $gatewayCount := len $gatewayConfigs }}
-  {{- $hasMultipleTypes := gt $gatewayCount 1 }}
+  {{- $distinctTypes := dict }}
+  {{- range $k, $v := $gatewayConfigs }}
+    {{- $_ := set $distinctTypes $v.type "true" }}
+  {{- end }}
+  {{- $hasMultipleTypes := gt (len $distinctTypes) 1 }}
   {{- range $configKey, $gatewayConfig := $gatewayConfigs }}
   {{- $multiCluster := contains "-mc" $gatewayConfig.className }}
-  {{- $gatewayNameParams := dict "appCode" $globals.app_code "type" $gatewayConfig.type "hasMultipleTypes" $hasMultipleTypes "multiCluster" $multiCluster }}
+  {{- $gatewayNameParams := dict "appCode" $globals.app_code "type" $gatewayConfig.type "hasMultipleTypes" $hasMultipleTypes "multiCluster" $multiCluster "nameOverride" $gatewayConfig.nameOverride }}
   {{- $gatewayName := include "mozcloud.gateway.name" $gatewayNameParams }}
   {{ $gatewayName }}:
     component: gateway

--- a/mozcloud/application/templates/gateway/httproute.yaml
+++ b/mozcloud/application/templates/gateway/httproute.yaml
@@ -55,7 +55,7 @@ httpRoutes:
           {{- $hasMultipleTypes = true }}
         {{- end }}
         {{- $multiCluster := ($hostConfig).multiCluster }}
-        {{- $gatewayNameParams := dict "appCode" $globals.app_code "type" $hostConfig.type "hasMultipleTypes" $hasMultipleTypes "multiCluster" $multiCluster }}
+        {{- $gatewayNameParams := dict "appCode" $globals.app_code "type" $hostConfig.type "hasMultipleTypes" $hasMultipleTypes "multiCluster" $multiCluster "nameOverride" (default "" ($hostConfig).gatewayName) }}
         {{- $gatewayName = include "mozcloud.gateway.name" $gatewayNameParams }}
       {{- end }}
       - name: {{ $gatewayName }}

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -868,6 +868,10 @@
                     "name"
                   ]
                 },
+                "gatewayName": {
+                  "type": "string",
+                  "description": "Override the auto-generated Gateway resource name. Useful when migrating from a chart that used a different Gateway name."
+                },
                 "targetPort": {
                   "anyOf": [
                     {

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1415,6 +1415,20 @@ workloads:
         #  # If not specified, assumes the gateway is in the same namespace.
         #  #namespace: shared-gateway-namespace
 
+        # Override the auto-generated Gateway resource name for this host.
+        # By default, the Gateway is named after the app_code (e.g. "myapp"),
+        # with a type suffix appended when both external and internal gateways
+        # are present (e.g. "myapp-external"). Internal gateways always include
+        # the "-internal" suffix.
+        #
+        # Use this when migrating from a chart that used a different Gateway
+        # name and you need to preserve the existing resource name to avoid
+        # a destructive rename.
+        #
+        # Only applicable when "api" is set to "gateway".
+        #
+        #gatewayName: my-custom-gateway-name
+
         # The port name or number on the pod that the ingress Service should
         # route traffic to. Only applicable when "api" is set to "ingress".
         #


### PR DESCRIPTION
  ---
  feat: Add gatewayName override for hosts using the Gateway API

Problem
---

  When mozcloud creates a Gateway resource, it names it after the application's app_code (e.g. ohttp-gateway), optionally suffixed with the gateway type when both external and internal gateways are present. This works well for greenfield deployments, but causes a destructive rename when migrating a chart that
  previously named its Gateway differently.

  Concretely: the ohttp-gateway service was previously deployed using mozcloud-workload, which named its Gateway resource external (matching the host key in values). Migrating to the unified mozcloud chart would silently rename Gateway/external → Gateway/ohttp-gateway and GCPGatewayPolicy/external →                  
  GCPGatewayPolicy/ohttp-gateway. Since ArgoCD prune is disabled by default, the old resources become orphans — but the rename itself causes a brief period where the new Gateway exists without the old one being removed, which risks a traffic disruption in a live environment.
                                                                                                                                                                                                                                                                                                                              
Solution
----                                             

  Add an optional gatewayName field to the per-host configuration under workloads[].hosts[]. When set, it is passed through to the mozcloud.gateway.name helper as a nameOverride, bypassing the auto-naming logic entirely. Both the Gateway resource itself and the gatewayRefs in the corresponding HTTPRoute use the same 
  override, keeping names consistent.
                                                                                                                                                                                                                                                                                                                              
  A secondary fix is included: $hasMultipleTypes in gateway.yaml previously counted total gateway configs rather than distinct gateway types. This meant two external gateways with different name overrides would incorrectly trigger the myapp-external suffix on both — even though only one type is present.              
   
Usage
----                                                                                                                                                                                                                                                                                                                       
```bash                                                            
  workloads:
    api:
      hosts:                                                                                                                                                                                                                                                                                                                  
        external:
          gatewayName: external   # preserve the existing Gateway resource name                                                                                                                                                                                                                                               
          domains:                                          
            - stage.some-service.nonprod.webservices.mozgcp.net                                                                                                                                                                                                                                                              
```                                                                                                                                                                                                                                                                                                                              