### PR TITLE
chore(unit-tests): add merge_group to triggers

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,6 +1,7 @@
 ---
 name: Run unit tests
 on:
+  merge_group: {}
   pull_request: {}
   push:
     branches: [main]


### PR DESCRIPTION
Currently, PRs are getting stuck in the merge queue indefinitely. Hopefully this will fix that.