### PR TITLE
feat(mozcloud): rework and refine lifecycle hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,13 @@ repos:
     hooks:
       - id: helmlint
         exclude: '^deprecated/'
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v1.14.2
+    hooks:
+      - id: helm-docs
+        args:
+          - --template-files=./_README.md.gotmpl
+          - --template-files=README.md.gotmpl
   - repo: local
     hooks:
       - id: helm-unittest
@@ -32,10 +39,3 @@ repos:
         exclude: '^deprecated/'
         language: system
         pass_filenames: false
-  - repo: https://github.com/norwoodj/helm-docs
-    rev: v1.14.2
-    hooks:
-      - id: helm-docs
-        args:
-          - --template-files=./_README.md.gotmpl
-          - --template-files=README.md.gotmpl

--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -97,6 +97,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | tasks.jobs.default.containers.default.image.repository | string | `""` |  |
 | tasks.jobs.default.containers.default.image.tag | string | `""` |  |
 | tasks.jobs.default.containers.default.imagePullPolicy | string | `"Always"` |  |
+| tasks.jobs.default.containers.default.lifecycle | object | `{}` |  |
 | tasks.jobs.default.containers.default.resources | object | `{}` |  |
 | tasks.jobs.default.containers.default.secrets | list | `[]` |  |
 | tasks.jobs.default.containers.default.security | object | `{}` |  |
@@ -142,6 +143,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.containers.default.image.repository | string | `""` |  |
 | workloads.default.containers.default.image.tag | string | `""` |  |
 | workloads.default.containers.default.imagePullPolicy | string | `"Always"` |  |
+| workloads.default.containers.default.lifecycle | object | `{}` |  |
 | workloads.default.containers.default.port | int | `8000` |  |
 | workloads.default.containers.default.resources.cpu | string | `"100m"` |  |
 | workloads.default.containers.default.resources.memory | string | `"128Mi"` |  |
@@ -164,15 +166,18 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.initContainers.default.image.repository | string | `""` |  |
 | workloads.default.initContainers.default.image.tag | string | `""` |  |
 | workloads.default.initContainers.default.imagePullPolicy | string | `"Always"` |  |
+| workloads.default.initContainers.default.lifecycle | object | `{}` |  |
 | workloads.default.initContainers.default.resources.cpu | string | `"100m"` |  |
 | workloads.default.initContainers.default.resources.memory | string | `"128Mi"` |  |
 | workloads.default.initContainers.default.secrets | list | `[]` |  |
 | workloads.default.initContainers.default.security | object | `{}` |  |
 | workloads.default.initContainers.default.sidecar | bool | `false` |  |
+| workloads.default.initContainers.default.volumes | list | `[]` |  |
 | workloads.default.labels | object | `{}` |  |
 | workloads.default.nginx.enabled | bool | `true` |  |
 | workloads.default.nginx.image.repository | string | `"us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged"` |  |
 | workloads.default.nginx.image.tag | string | `"1.29"` |  |
+| workloads.default.nginx.lifecycle | object | `{}` |  |
 | workloads.default.nodeSelector | object | `{}` |  |
 | workloads.default.otel.autoInstrumentation.enabled | bool | `false` |  |
 | workloads.default.otel.autoInstrumentation.language | string | `""` |  |

--- a/mozcloud/application/templates/task/_jobTemplate.yaml
+++ b/mozcloud/application/templates/task/_jobTemplate.yaml
@@ -156,6 +156,10 @@ template:
         */}}
         securityContext:
           {{- include "pod.container.securityContext" (default dict $containerConfig.security) | nindent 10 }}
+        {{- if $containerConfig.lifecycle }}
+        lifecycle:
+          {{- $containerConfig.lifecycle | toYaml | nindent 10 }}
+        {{- end }}
         {{- if $containerConfig.volumes }}
         volumeMounts:
           {{- range $volume := $containerConfig.volumes }}

--- a/mozcloud/application/templates/workload/_helpers.tpl
+++ b/mozcloud/application/templates/workload/_helpers.tpl
@@ -247,7 +247,8 @@ Returns:
   {{- end }}
   securityContext:
     {{- include "pod.container.securityContext" (default dict $containerConfig.security) | nindent 4 }}
-  {{- if $containerConfig.lifecycle }}
+  {{- $isInitSidecar := and (eq $type "initContainer") (dig "sidecar" false $containerConfig) }}
+  {{- if and $containerConfig.lifecycle (or (eq $type "container") $isInitSidecar) }}
   lifecycle:
     {{- $containerConfig.lifecycle | toYaml | nindent 4 }}
   {{- end }}

--- a/mozcloud/application/templates/workload/_workloadTemplate.yaml
+++ b/mozcloud/application/templates/workload/_workloadTemplate.yaml
@@ -56,6 +56,19 @@ Returns:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- /* If nginx.lifecycle is explicitly set, propagate it to any app container
+     that does not have its own lifecycle configuration. */}}
+{{- $nginxLifecycle := ($config.nginx).lifecycle }}
+{{- if $nginxLifecycle }}
+  {{- $enrichedContainers := dict }}
+  {{- range $containerName, $containerConfig := $containers }}
+    {{- if not $containerConfig.lifecycle }}
+      {{- $containerConfig = mergeOverwrite (deepCopy $containerConfig) (dict "lifecycle" $nginxLifecycle) }}
+    {{- end }}
+    {{- $_ := set $enrichedContainers $containerName $containerConfig }}
+  {{- end }}
+  {{- $containers = $enrichedContainers }}
+{{- end }}
 {{- /* Add nginx configmap volume if nginx is enabled */}}
 {{- $nginxConfigMapName := default (printf "%s-nginx" $name) $config.nginx.configMap }}
 {{- if $nginxEnabled }}
@@ -117,10 +130,10 @@ template:
         {{- $nginxImageParams := dict "containerImage" $config.nginx.image "globalImage" $globals.image "workloadName" $name "containerName" "nginx" }}
         image: {{ include "mozcloud.image" $nginxImageParams }}
         imagePullPolicy: Always
+        {{- if $nginxLifecycle }}
         lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/bash", "-c", "/bin/sleep 25 && /usr/sbin/nginx -s quit"]
+          {{- $nginxLifecycle | toYaml | nindent 10 }}
+        {{- end }}
         ports:
           - name: http
             containerPort: 8080

--- a/mozcloud/application/tests/__snapshot__/basic-workload-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/basic-workload-configuration_test.yaml.snap
@@ -118,13 +118,6 @@ Configuration matches entire snapshot:
           containers:
             - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
               imagePullPolicy: Always
-              lifecycle:
-                preStop:
-                  exec:
-                    command:
-                      - /bin/bash
-                      - -c
-                      - /bin/sleep 25 && /usr/sbin/nginx -s quit
               livenessProbe:
                 failureThreshold: 5
                 httpGet:

--- a/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
@@ -271,13 +271,6 @@ Configuration matches entire snapshot:
           containers:
             - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
               imagePullPolicy: Always
-              lifecycle:
-                preStop:
-                  exec:
-                    command:
-                      - /bin/bash
-                      - -c
-                      - /bin/sleep 25 && /usr/sbin/nginx -s quit
               livenessProbe:
                 failureThreshold: 5
                 httpGet:

--- a/mozcloud/application/tests/__snapshot__/lifecycle-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/lifecycle-configuration_test.yaml.snap
@@ -1,5 +1,148 @@
 Configuration matches entire snapshot:
   1: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      annotations:
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+        argocd.argoproj.io/sync-wave: "-1"
+      labels:
+        app.kubernetes.io/component: job
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: job
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-lifecycle-job
+    spec:
+      backoffLimit: 6
+      parallelism: 1
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: job
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: job
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: job
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - image: test-repo/test-job-image:1.0.0
+              imagePullPolicy: Always
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - sleep 15
+              name: job
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          restartPolicy: Never
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test
+  2: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      annotations:
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+        argocd.argoproj.io/sync-wave: "1"
+      labels:
+        app.kubernetes.io/component: job
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: job
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-no-lifecycle-job
+    spec:
+      backoffLimit: 6
+      parallelism: 1
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: job
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: job
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: job
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - image: test-repo/test-job-image:1.0.0
+              imagePullPolicy: Always
+              name: job
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          restartPolicy: Never
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test
+  3: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -145,6 +288,55 @@ Configuration matches entire snapshot:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
+          initContainers:
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-image:1.0.0
+              imagePullPolicy: Always
+              name: init-regular
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-image:1.0.0
+              imagePullPolicy: Always
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - sleep 5
+              name: init-sidecar
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              restartPolicy: Always
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
           securityContext:
             runAsGroup: 10001
             runAsNonRoot: true
@@ -152,7 +344,315 @@ Configuration matches entire snapshot:
             seccompProfile:
               type: RuntimeDefault
           serviceAccountName: mozcloud-test
-  2: |
+  4: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service-nginx
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: web
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: web
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: web
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: web
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+              imagePullPolicy: Always
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - sleep 30
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__nginxheartbeat__
+                  port: http
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: nginx
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: http
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsGroup: 101
+                runAsUser: 101
+              volumeMounts:
+                - mountPath: /etc/nginx/nginx.conf
+                  name: nginx-conf
+                  readOnly: true
+                  subPath: nginx.conf
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-image:1.0.0
+              imagePullPolicy: Always
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - sleep 30
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: app
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-image:1.0.0
+              imagePullPolicy: Always
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - sleep 10
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: worker
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: worker
+              ports:
+                - containerPort: 8000
+                  name: worker
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: worker
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test
+          volumes:
+            - configMap:
+                name: test-service-nginx-nginx
+              name: nginx-conf
+  5: |
+    apiVersion: v1
+    data:
+      nginx.conf: |
+        # The nginx docker container has ln -sf /dev/stderr /var/log/nginx/error.log
+        error_log  /var/log/nginx/error.log warn;
+        pid        /tmp/nginx.pid;
+
+        events {
+            worker_connections  2048;
+        }
+
+        http {
+            include       /etc/nginx/mime.types;
+
+            default_type  application/octet-stream;
+
+            log_format main escape=json
+            '{'
+              '"time":"$time_local",'
+              '"remote_addr":"$remote_addr",'
+              '"remote_user":"$remote_user",'
+              '"request":"$request",'
+              '"status": "$status",'
+              '"log_type": "access",'
+              '"bytes_sent": $body_bytes_sent,'
+              '"request_time": $request_time,'
+              '"referrer":"$http_referer",'
+              '"user_agent":"$http_user_agent",'
+              '"x_forwarded_for":"$http_x_forwarded_for",'
+              '"x_forwarded_proto":"$http_x_forwarded_proto",'
+              '"trace":"$http_x_cloud_trace_context"'
+            '}';
+
+            # The nginx docker container has ln -sf /dev/stdout /var/log/nginx/access.log
+            access_log  /var/log/nginx/access.log  main;
+
+            sendfile        on;
+
+            keepalive_timeout  620;
+
+            server_tokens off;
+
+            gzip on;
+            gzip_http_version 1.1;
+            gzip_comp_level 1;
+            gzip_vary on;
+            gzip_proxied any;
+            gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+            gzip_min_length 1100;
+            gzip_types
+                text/plain
+                text/css
+                application/json
+                application/x-javascript
+                text/xml
+                application/xml
+                application/xml+rss
+                text/javascript
+                application/javascript;
+
+            upstream upstream_docker {
+                server 127.0.0.1:8000;
+            }
+
+            server {
+                listen 8080;
+
+                client_max_body_size 2g;
+
+                add_header Strict-Transport-Security "max-age=31536000" always;
+
+                location / {
+                    proxy_set_header x-forwarded-proto $http_x_forwarded_proto;
+                    proxy_set_header x-forwarded-for $proxy_add_x_forwarded_for;
+                    proxy_set_header Host $http_host;
+                    proxy_redirect off;
+                    proxy_pass http://upstream_docker;
+                }
+
+                location = /nginx_status {
+                  stub_status on;
+                  access_log off;
+                  allow 127.0.0.1;
+                  deny all;
+                }
+
+                location = /__nginxheartbeat__ {
+                  return 200;
+                }
+            }
+        }
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service-nginx-nginx
+  6: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:

--- a/mozcloud/application/tests/__snapshot__/preview-all-resources_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/preview-all-resources_test.yaml.snap
@@ -499,13 +499,6 @@ Configuration matches entire snapshot:
           containers:
             - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
               imagePullPolicy: Always
-              lifecycle:
-                preStop:
-                  exec:
-                    command:
-                      - /bin/bash
-                      - -c
-                      - /bin/sleep 25 && /usr/sbin/nginx -s quit
               livenessProbe:
                 failureThreshold: 5
                 httpGet:

--- a/mozcloud/application/tests/__snapshot__/preview-multiple-workloads_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/preview-multiple-workloads_test.yaml.snap
@@ -388,13 +388,6 @@ Configuration matches entire snapshot:
           containers:
             - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
               imagePullPolicy: Always
-              lifecycle:
-                preStop:
-                  exec:
-                    command:
-                      - /bin/bash
-                      - -c
-                      - /bin/sleep 25 && /usr/sbin/nginx -s quit
               livenessProbe:
                 failureThreshold: 5
                 httpGet:
@@ -645,13 +638,6 @@ Configuration matches entire snapshot:
           containers:
             - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
               imagePullPolicy: Always
-              lifecycle:
-                preStop:
-                  exec:
-                    command:
-                      - /bin/bash
-                      - -c
-                      - /bin/sleep 25 && /usr/sbin/nginx -s quit
               livenessProbe:
                 failureThreshold: 5
                 httpGet:
@@ -902,13 +888,6 @@ Configuration matches entire snapshot:
           containers:
             - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
               imagePullPolicy: Always
-              lifecycle:
-                preStop:
-                  exec:
-                    command:
-                      - /bin/bash
-                      - -c
-                      - /bin/sleep 25 && /usr/sbin/nginx -s quit
               livenessProbe:
                 failureThreshold: 5
                 httpGet:

--- a/mozcloud/application/tests/basic-workload-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-workload-configuration_test.yaml
@@ -212,15 +212,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
-      - isSubset:
+      - notExists:
           path: spec.template.spec.containers[0].lifecycle
-          content:
-            preStop:
-              exec:
-                command:
-                  - /bin/bash
-                  - -c
-                  - /bin/sleep 25 && /usr/sbin/nginx -s quit
       - isSubset:
           path: spec.template.spec.containers[0].readinessProbe
           content:

--- a/mozcloud/application/tests/lifecycle-configuration_test.yaml
+++ b/mozcloud/application/tests/lifecycle-configuration_test.yaml
@@ -10,48 +10,94 @@ values:
   - values/lifecycle-configuration.yaml
 templates:
   - workload/deployment.yaml
+  - task/job.yaml
 tests:
   - it: Configuration matches entire snapshot
     asserts:
       - notFailedTemplate: {}
       - matchSnapshot: {}
 
-  - it: preStop and postStart hooks render on the app container
+  - it: Workload container lifecycle hooks render correctly
     template: workload/deployment.yaml
-    documentSelector:
-      path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].name
-          value: app
+      # app container has preStop and postStart
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
           value: ["/bin/sh", "-c", "sleep 30"]
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
       - equal:
           path: spec.template.spec.containers[0].lifecycle.postStart.exec.command
           value: ["/bin/sh", "-c", "echo started"]
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
+      # worker container has preStop but no postStart
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 10"]
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
+      - notExists:
+          path: spec.template.spec.containers[1].lifecycle.postStart
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
+      # container without any lifecycle config has no lifecycle field
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service-no-lifecycle
 
-  - it: preStop hook renders on the worker container
+  - it: Init container lifecycle hooks render correctly
     template: workload/deployment.yaml
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service
     asserts:
-      - equal:
-          path: spec.template.spec.containers[1].name
-          value: worker
-      - equal:
-          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command
-          value: ["/bin/sh", "-c", "sleep 10"]
+      # init-regular is a standard init container; lifecycle is not valid and must not render
       - notExists:
-          path: spec.template.spec.containers[1].lifecycle.postStart
+          path: spec.template.spec.initContainers[0].lifecycle
+      # init-sidecar has restartPolicy: Always and supports lifecycle hooks
+      - equal:
+          path: spec.template.spec.initContainers[1].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 5"]
 
-  - it: a container without lifecycle config has no lifecycle field
+  - it: Job container lifecycle hooks render correctly
+    template: task/job.yaml
+    asserts:
+      # job container with an explicit lifecycle renders it
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 15"]
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-lifecycle-job
+      # job container without a lifecycle has no lifecycle field
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+        documentSelector:
+          path: $[?(@.kind == "Job")].metadata.name
+          value: test-no-lifecycle-job
+
+  - it: Nginx lifecycle is propagated to app containers without an explicit lifecycle
     template: workload/deployment.yaml
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
-      value: test-service-no-lifecycle
+      value: test-service-nginx
     asserts:
-      - notExists:
-          path: spec.template.spec.containers[0].lifecycle
+      # nginx container itself gets the configured lifecycle
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 30"]
+      # app container has no explicit lifecycle and inherits from nginx
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 30"]
+      # worker container has its own lifecycle and is not overridden
+      - equal:
+          path: spec.template.spec.containers[2].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 10"]

--- a/mozcloud/application/tests/values/lifecycle-configuration.yaml
+++ b/mozcloud/application/tests/values/lifecycle-configuration.yaml
@@ -1,5 +1,6 @@
 ---
 workloads:
+  # Workload with explicitly configured lifecycle hooks on each container.
   test-service:
     component: web
     containers:
@@ -22,7 +23,26 @@ workloads:
           preStop:
             exec:
               command: ["/bin/sh", "-c", "sleep 10"]
+    initContainers:
+      init-regular:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
+      init-sidecar:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+        sidecar: true
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
 
+  # Workload with no lifecycle configuration anywhere.
   test-service-no-lifecycle:
     component: worker
     containers:
@@ -30,3 +50,56 @@ workloads:
         image:
           repository: test-repo/test-image
           tag: 1.0.0
+
+  # Workload with nginx.lifecycle set. App containers without an explicit
+  # lifecycle should inherit it; containers with one should keep their own.
+  test-service-nginx:
+    component: web
+    hosts:
+      test-service-nginx:
+        domains:
+          - test-service-nginx.dev.test-domain.com
+        addresses:
+          - test-ip
+        tls:
+          certs:
+            - test-cert
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+      worker:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 10"]
+    nginx:
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "sleep 30"]
+
+tasks:
+  jobs:
+    test-lifecycle-job:
+      type: preDeployment
+      containers:
+        job:
+          image:
+            repository: test-repo/test-job-image
+            tag: 1.0.0
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 15"]
+    test-no-lifecycle-job:
+      type: postDeployment
+      containers:
+        job:
+          image:
+            repository: test-repo/test-job-image
+            tag: 1.0.0

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1051,6 +1051,9 @@
               "configMap": {
                 "type": "string"
               },
+              "lifecycle": {
+                "$ref": "#/$defs/lifecycle"
+              },
               "resources": {
                 "type": "object",
                 "additionalProperties": false,
@@ -1297,6 +1300,9 @@
             }
           }
         },
+        "lifecycle": {
+          "$ref": "#/$defs/lifecycle"
+        },
         "resources": {
           "type": "object",
           "additionalProperties": false,
@@ -1453,53 +1459,6 @@
               }
             ]
           }
-        },
-        "lifecycle": {
-          "type": "object",
-          "description": "Container lifecycle hooks. Supports preStop and postStart handlers.",
-          "properties": {
-            "preStop": {
-              "type": "object",
-              "properties": {
-                "exec": {
-                  "type": "object",
-                  "properties": {
-                    "command": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "httpGet": {
-                  "type": "object"
-                },
-                "sleep": {
-                  "type": "object"
-                }
-              }
-            },
-            "postStart": {
-              "type": "object",
-              "properties": {
-                "exec": {
-                  "type": "object",
-                  "properties": {
-                    "command": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "httpGet": {
-                  "type": "object"
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -1625,6 +1584,53 @@
         "ttlSecondsAfterFinished": {
           "type": "integer",
           "minimum": 0
+        }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "description": "Container lifecycle hooks. Supports preStop and postStart handlers.",
+      "properties": {
+        "preStop": {
+          "type": "object",
+          "properties": {
+            "exec": {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "httpGet": {
+              "type": "object"
+            },
+            "sleep": {
+              "type": "object"
+            }
+          }
+        },
+        "postStart": {
+          "type": "object",
+          "properties": {
+            "exec": {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "httpGet": {
+              "type": "object"
+            }
+          }
         }
       }
     },

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -579,6 +579,25 @@ tasks:
           # Default: Always
           imagePullPolicy: Always
 
+          # Optionally configure container lifecycle hooks. Used to run commands
+          # before a container stops (preStop) or immediately after it starts
+          # (postStart).
+          #
+          # The most common use case is a preStop sleep that gives in-flight
+          # work time to complete if the job pod is terminated before the job
+          # finishes.
+          #
+          # Example — graceful shutdown with a preStop sleep:
+          #
+          #   lifecycle:
+          #     preStop:
+          #       exec:
+          #         command: ["/bin/sh", "-c", "sleep 30"]
+          #
+          # For full lifecycle hook documentation, see:
+          # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+          lifecycle: {}
+
           # The "resources" section allows you to specify the amount of CPU and
           # memory that your container needs to run. These are equivalent to
           # requests values.
@@ -1169,6 +1188,32 @@ workloads:
         # Default: Always
         imagePullPolicy: Always
 
+        # Optionally configure container lifecycle hooks. Used to run commands
+        # before a container stops (preStop) or immediately after it starts
+        # (postStart).
+        #
+        # The most common use case is a preStop sleep that gives in-flight
+        # requests time to complete while the pod is being removed from load
+        # balancer backends.
+        #
+        # Example — graceful shutdown with a preStop sleep:
+        #
+        #   lifecycle:
+        #     preStop:
+        #       exec:
+        #         command: ["/bin/sh", "-c", "sleep 30"]
+        #
+        # Example — postStart notification:
+        #
+        #   lifecycle:
+        #     postStart:
+        #       exec:
+        #         command: ["/bin/sh", "-c", "curl -sf http://localhost:8080/started"]
+        #
+        # For full lifecycle hook documentation, see:
+        # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+        lifecycle: {}
+
         # Optionally configure a custom port for your container. The default
         # value is 8000.
         #
@@ -1725,6 +1770,27 @@ workloads:
         # Default: Always
         imagePullPolicy: Always
 
+        # Optionally configure container lifecycle hooks. Used to run commands
+        # before a container stops (preStop) or immediately after it starts
+        # (postStart).
+        #
+        # IMPORTANT: Kubernetes does not support lifecycle hooks on regular init
+        # containers. This field is only valid when "sidecar: true" is also set,
+        # which configures the init container as a long-running sidecar
+        # (restartPolicy: Always). Configuring lifecycle on a regular init
+        # container will cause Kubernetes to reject the pod spec.
+        #
+        # Example — graceful shutdown with a preStop sleep:
+        #
+        #   lifecycle:
+        #     preStop:
+        #       exec:
+        #         command: ["/bin/sh", "-c", "sleep 30"]
+        #
+        # For full lifecycle hook documentation, see:
+        # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+        lifecycle: {}
+
         # Optionally configure a custom port for your container. The default
         # value is none/unset.
         #
@@ -1893,32 +1959,7 @@ workloads:
         #       mountOptions: implicit-dirs
         #       readOnly: true
         #
-        #volumes: []
-
-        # Optionally configure container lifecycle hooks. Used to run commands
-        # before a container stops (preStop) or immediately after it starts
-        # (postStart).
-        #
-        # The most common use case is a preStop sleep that gives in-flight
-        # requests time to complete while the pod is being removed from load
-        # balancer backends.
-        #
-        # Example — graceful shutdown with a preStop sleep:
-        #
-        #   lifecycle:
-        #     preStop:
-        #       exec:
-        #         command: ["/bin/sh", "-c", "sleep 30"]
-        #
-        # Example — postStart notification:
-        #
-        #   lifecycle:
-        #     postStart:
-        #       exec:
-        #         command: ["/bin/sh", "-c", "curl -sf http://localhost:8080/started"]
-        #
-        # For full lifecycle hook documentation, see:
-        # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+        volumes: []
 
     # Labels to pass down to workload resources, e.g. Deployments and Pods. In
     # some scenarios, this can be useful to apply, e.g. when you spawn multiple
@@ -1973,6 +2014,22 @@ workloads:
       image:
         repository: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged
         tag: "1.29"
+
+      # Optionally configure a lifecycle hook for the nginx sidecar container.
+      #
+      # When set, this lifecycle configuration is also inherited by any
+      # application or init containers in the same workload that do not have
+      # their own lifecycle configuration. This ensures a consistent graceful
+      # shutdown window across all containers.
+      #
+      # Example — graceful shutdown with a preStop sleep:
+      #
+      #   lifecycle:
+      #     preStop:
+      #       exec:
+      #         command: ["/bin/sh", "-c", "sleep 30"]
+      #
+      lifecycle: {}
 
     # Configure auto instrumentation for the OTEL Collector.
     #


### PR DESCRIPTION
## Description
This change adds comprehensive lifecycle hook support across all container types in the mozcloud chart. Previously, lifecycle hooks were only functional for workload app and init containers: job containers had schema support but the field was silently dropped during rendering, and the NGINX sidecar had a hardcoded `preStop` hook that could not be overridden or disabled. This brings all container types into alignment, gives users full control over lifecycle behavior, and removes hidden defaults that were difficult to reason about.

Changes:
- Added lifecycle hook support to Job and CronJob containers.
- Made the NGINX sidecar lifecycle hook fully configurable via `nginx.lifecycle`, removing the previously hardcoded `preStop` hook. NGINX now has no lifecycle hook by default.
  - When `nginx.lifecycle` is set on a workload, any app container in that workload that does not define its own `lifecycle` automatically inherits it, ensuring a consistent graceful shutdown window across all containers without requiring repeated configuration.
  - **If we want to restore a default (eg. `sleep 25`), we can do that. Let me know your thoughts.**
  - Init containers are intentionally excluded from this propagation and must always be configured explicitly.
- Guarded lifecycle hook rendering for init containers so it only applies when `sidecar: true` is set.
  - Kubernetes does not support lifecycle hooks on regular init containers and will reject the pod spec if one is present. Only sidecar init containers (`sidecar: true`, which sets `restartPolicy: Always`) support lifecycle hooks.
- Updated unit tests to cover lifecycle hook behavior across workload containers, init containers, job containers, and NGINX propagation scenarios.
- Now running `helm-docs` before unit tests in pre-commit so we don't have to wait for unit tests to complete before finding out we needed to update docs and do it all over again.

## Related Tickets & Documents
MZCLD-2710
