### PR TITLE
feat(mozcloud): Allow customization of podmonitoring, port, path, and interval

### DIFF
--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -113,6 +113,9 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | tasks.jobs.default.tolerations | list | `[]` |  |
 | tasks.jobs.default.type | string | `"preDeployment"` |  |
 | telegraf.enabled | bool | `false` |  |
+| telegraf.interval | string | `"30s"` |  |
+| telegraf.path | string | `"/metrics"` |  |
+| telegraf.port | int | `8080` |  |
 | workloads.default.affinity | object | `{}` |  |
 | workloads.default.autoscaling.enabled | bool | `true` |  |
 | workloads.default.autoscaling.metrics[0].threshold | int | `60` |  |

--- a/mozcloud/application/templates/gke/podmonitoring.yaml
+++ b/mozcloud/application/templates/gke/podmonitoring.yaml
@@ -10,10 +10,11 @@
 
 {{- if $workloads }}
 {{- /* Default PodMonitoring template for all tenants */}}
+{{- $telegraf := default dict .Values.telegraf }}
 {{- if and .Values.enabled
   (not (include "mozcloud.preview.enabled" .))
   (eq $provider "gke")
-  (dig "enabled" false (default dict .Values.telegraf))
+  (dig "enabled" false $telegraf)
 }}
 ---
 apiVersion: monitoring.googleapis.com/v1
@@ -26,10 +27,10 @@ metadata:
     {{- $labels.labels | toYaml | nindent 4 }}
 spec:
   endpoints:
-    - port: 8080
+    - port: {{ dig "port" 8080 $telegraf }}
       scheme: http
-      interval: 30s
-      path: /metrics
+      interval: {{ dig "interval" "30s" $telegraf | quote }}
+      path: {{ dig "path" "/metrics" $telegraf | quote }}
   selector:
     matchLabels:
       app.kubernetes.io/name: telegraf

--- a/mozcloud/application/tests/telegraf-podmonitoring_test.yaml
+++ b/mozcloud/application/tests/telegraf-podmonitoring_test.yaml
@@ -16,7 +16,7 @@ tests:
       - notFailedTemplate: {}
       - matchSnapshot: {}
 
-  - it: PodMonitoring is rendered with correct name, kind, and telegraf selector when enabled
+  - it: PodMonitoring is rendered with correct name, kind, telegraf selector, and default endpoint when enabled
     asserts:
       # PodMonitoring is rendered when telegraf.enabled is true
       - hasDocuments:
@@ -36,6 +36,19 @@ tests:
           path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: telegraf
         documentIndex: 0
+      # Endpoint uses the documented defaults when not overridden
+      - equal:
+          path: spec.endpoints[0].port
+          value: 8080
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].path
+          value: /metrics
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 30s
+        documentIndex: 0
 
   - it: PodMonitoring is not rendered when telegraf.enabled is false
     set:
@@ -43,3 +56,22 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: PodMonitoring honors custom port (named string), path, and interval
+    set:
+      telegraf.port: prometheus
+      telegraf.path: /__metrics__
+      telegraf.interval: 60s
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: prometheus
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].path
+          value: /__metrics__
+        documentIndex: 0
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 60s
+        documentIndex: 0

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -357,6 +357,21 @@
         "enabled": {
           "type": "boolean",
           "default": false
+        },
+        "port": {
+          "description": "Port telegraf exposes Prometheus-format metrics on. May be a port number or a named port.",
+          "oneOf": [
+            { "type": "integer" },
+            { "type": "string" }
+          ]
+        },
+        "path": {
+          "type": "string",
+          "description": "HTTP path metrics are scraped from."
+        },
+        "interval": {
+          "type": "string",
+          "description": "How often Cloud Managed Prometheus should scrape metrics. Duration string (e.g. \"15s\", \"30s\", \"1m\")."
         }
       }
     },

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -856,8 +856,23 @@ tasks:
 # Telegraf PodMonitoring configuration - only for tenants that have not yet
 # migrated to the OTEL Collector. When enabled, a PodMonitoring resource is
 # created to scrape Telegraf metrics.
+#
+# If you need to customize beyond the fields exposed here (e.g.
+# metricRelabeling, multiple endpoints, custom selectors), ship your own
+# PodMonitoring resource instead.
 telegraf:
   enabled: false
+
+  # The port telegraf exposes Prometheus-format metrics on. May be a port
+  # number or a named port defined on the telegraf pod.
+  port: 8080
+
+  # The HTTP path metrics are scraped from.
+  path: /metrics
+
+  # How often Cloud Managed Prometheus should scrape metrics. Accepts a
+  # duration string (e.g. "15s", "30s", "1m").
+  interval: 30s
 
 workloads:
   # The name of your workload and all related components. Use any name other


### PR DESCRIPTION
## Description
Allow customization of PodMonitoring, port, path, and interval when `telegraf.enabled` is true

## Related Tickets & Documents
* MZCLD-2931
