### PR TITLE
feat: Allow setting service port

### DIFF
--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -154,6 +154,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.hosts.default.api | string | `"gateway"` |  |
 | workloads.default.hosts.default.domains[0] | string | `"example.com"` |  |
 | workloads.default.hosts.default.httpRoutes.createHttpRoutes | bool | `true` |  |
+| workloads.default.hosts.default.servicePort | int | `8080` |  |
 | workloads.default.hosts.default.targetPort | string | `"http"` |  |
 | workloads.default.hosts.default.tls.certs | list | `[]` |  |
 | workloads.default.hosts.default.tls.create | bool | `true` |  |

--- a/mozcloud/application/templates/gateway/backend.yaml
+++ b/mozcloud/application/templates/gateway/backend.yaml
@@ -68,7 +68,7 @@ backends:
     component: {{ $workloadConfig.component }}
     api: {{ default "gateway" $hostConfig.api }}
     service:
-      port: 8080
+      port: {{ default 8080 $hostConfig.servicePort }}
       targetPort: {{ include "mozcloud.portName" (default "http" $hostConfig.targetPort) }}
     {{- if eq $provider "gke" }}
     backendPolicy:

--- a/mozcloud/application/templates/gateway/backend.yaml
+++ b/mozcloud/application/templates/gateway/backend.yaml
@@ -68,7 +68,7 @@ backends:
     component: {{ $workloadConfig.component }}
     api: {{ default "gateway" $hostConfig.api }}
     service:
-      port: {{ default 8080 $hostConfig.servicePort }}
+      port: {{ $hostConfig.servicePort }}
       targetPort: {{ include "mozcloud.portName" (default "http" $hostConfig.targetPort) }}
     {{- if eq $provider "gke" }}
     backendPolicy:

--- a/mozcloud/application/templates/gateway/httproute.yaml
+++ b/mozcloud/application/templates/gateway/httproute.yaml
@@ -81,7 +81,7 @@ httpRoutes:
       */}}
     rules:
       {{- $rules := (list) -}}
-      {{- $defaultBackendRef := dict "name" $workloadName "port" 8080 -}}
+      {{- $defaultBackendRef := dict "name" $workloadName "port" (default 8080 $hostConfig.servicePort) -}}
       {{- if ($hostConfig.httpRoutes).rules }}
         {{- range $ruleConfig := $hostConfig.httpRoutes.rules }}
           {{- $rule := dict }}

--- a/mozcloud/application/templates/gateway/httproute.yaml
+++ b/mozcloud/application/templates/gateway/httproute.yaml
@@ -81,7 +81,7 @@ httpRoutes:
       */}}
     rules:
       {{- $rules := (list) -}}
-      {{- $defaultBackendRef := dict "name" $workloadName "port" (default 8080 $hostConfig.servicePort) -}}
+      {{- $defaultBackendRef := dict "name" $workloadName "port" $hostConfig.servicePort -}}
       {{- if ($hostConfig.httpRoutes).rules }}
         {{- range $ruleConfig := $hostConfig.httpRoutes.rules }}
           {{- $rule := dict }}

--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -63,7 +63,7 @@ ingresses:
                 {{- end }}
               service:
                 name: {{ $workloadName }}
-                port: {{ default 8080 $hostConfig.servicePort }}
+                port: {{ $hostConfig.servicePort }}
                 protocol: TCP
                 targetPort: {{ include "mozcloud.portName" (default "http" $hostConfig.targetPort) }}
         tls:

--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -63,7 +63,7 @@ ingresses:
                 {{- end }}
               service:
                 name: {{ $workloadName }}
-                port: 8080
+                port: {{ default 8080 $hostConfig.servicePort }}
                 protocol: TCP
                 targetPort: {{ include "mozcloud.portName" (default "http" $hostConfig.targetPort) }}
         tls:

--- a/mozcloud/application/tests/__snapshot__/custom-service-port-gateway-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/custom-service-port-gateway-configuration_test.yaml.snap
@@ -1,0 +1,354 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      ports:
+        - name: http
+          port: 9090
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: default-port-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP
+  3: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      annotations:
+        networking.gke.io/certmap: custom-port-service-nonprod-dev
+      labels:
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: gateway
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: mozcloud-test
+    spec:
+      addresses:
+        - type: NamedAddress
+          value: mozcloud-dev-ip-v4
+      gatewayClassName: gke-l7-global-external-managed
+      listeners:
+        - allowedRoutes:
+            namespaces:
+              from: Same
+          name: http
+          port: 80
+          protocol: HTTP
+        - allowedRoutes:
+            namespaces:
+              from: Same
+          name: https
+          port: 443
+          protocol: HTTPS
+  4: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      hostnames:
+        - custom-port-service.dev.test-domain.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: mozcloud-test
+          sectionName: https
+      rules:
+        - backendRefs:
+            - group: ""
+              kind: Service
+              name: custom-port-service
+              port: 9090
+              weight: 1
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+  5: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service-http-redirect
+    spec:
+      hostnames:
+        - custom-port-service.dev.test-domain.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: mozcloud-test
+          sectionName: http
+      rules:
+        - filters:
+            - requestRedirect:
+                scheme: https
+                statusCode: 302
+              type: RequestRedirect
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+  6: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: default-port-service
+    spec:
+      hostnames:
+        - default-port-service.dev.test-domain.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: mozcloud-test
+          sectionName: https
+      rules:
+        - backendRefs:
+            - group: ""
+              kind: Service
+              name: default-port-service
+              port: 8080
+              weight: 1
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+  7: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: default-port-service-http-redirect
+    spec:
+      hostnames:
+        - default-port-service.dev.test-domain.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: mozcloud-test
+          sectionName: http
+      rules:
+        - filters:
+            - requestRedirect:
+                scheme: https
+                statusCode: 302
+              type: RequestRedirect
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+  8: |
+    apiVersion: networking.gke.io/v1
+    kind: GCPBackendPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      default:
+        logging:
+          enabled: true
+          sampleRate: 100000
+      targetRef:
+        group: ""
+        kind: Service
+        name: custom-port-service
+  9: |
+    apiVersion: networking.gke.io/v1
+    kind: HealthCheckPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      default:
+        config:
+          httpHealthCheck:
+            requestPath: /__lbheartbeat__
+          type: HTTP
+      targetRef:
+        group: ""
+        kind: Service
+        name: custom-port-service
+  10: |
+    apiVersion: networking.gke.io/v1
+    kind: GCPBackendPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: default-port-service
+    spec:
+      default:
+        logging:
+          enabled: true
+          sampleRate: 100000
+      targetRef:
+        group: ""
+        kind: Service
+        name: default-port-service
+  11: |
+    apiVersion: networking.gke.io/v1
+    kind: HealthCheckPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: default-port-service
+    spec:
+      default:
+        config:
+          httpHealthCheck:
+            requestPath: /__lbheartbeat__
+          type: HTTP
+      targetRef:
+        group: ""
+        kind: Service
+        name: default-port-service
+  12: |
+    apiVersion: networking.gke.io/v1
+    kind: GCPGatewayPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: gateway
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: mozcloud-test
+    spec:
+      default:
+        sslPolicy: mozilla-intermediate
+      targetRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: mozcloud-test

--- a/mozcloud/application/tests/__snapshot__/custom-service-port-ingress-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/custom-service-port-ingress-configuration_test.yaml.snap
@@ -1,0 +1,235 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: networking.gke.io/v1beta1
+    kind: FrontendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      redirectToHttps:
+        enabled: true
+        responseCodeName: MOVED_PERMANENTLY_DEFAULT
+      sslPolicy: mozilla-intermediate
+  2: |
+    apiVersion: networking.gke.io/v1beta1
+    kind: FrontendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: default-port-service
+    spec:
+      redirectToHttps:
+        enabled: true
+        responseCodeName: MOVED_PERMANENTLY_DEFAULT
+      sslPolicy: mozilla-intermediate
+  3: |
+    apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      logging:
+        enable: true
+        sampleRate: 0.1
+  4: |
+    apiVersion: networking.gke.io/v1
+    kind: ManagedCertificate
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: mcrt-custom-port-service-dev-test-domain-com
+    spec:
+      domains:
+        - custom-port-service.dev.test-domain.com
+  5: |
+    apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: default-port-service
+    spec:
+      logging:
+        enable: true
+        sampleRate: 0.1
+  6: |
+    apiVersion: networking.gke.io/v1
+    kind: ManagedCertificate
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: mcrt-default-port-service-dev-test-domain-com
+    spec:
+      domains:
+        - default-port-service.dev.test-domain.com
+  7: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: gce
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
+        networking.gke.io/managed-certificates: mcrt-custom-port-service-dev-test-domain-com
+        networking.gke.io/v1beta1.FrontendConfig: custom-port-service
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      defaultBackend:
+        service:
+          name: custom-port-service
+          port:
+            number: 9090
+  8: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/backend-config: '{"default": "custom-port-service"}'
+        cloud.google.com/neg: '{"ingress": true}'
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      ports:
+        - name: http
+          port: 9090
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP
+  9: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: gce
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
+        networking.gke.io/managed-certificates: mcrt-default-port-service-dev-test-domain-com
+        networking.gke.io/v1beta1.FrontendConfig: default-port-service
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: default-port-service
+    spec:
+      defaultBackend:
+        service:
+          name: default-port-service
+          port:
+            number: 8080
+  10: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/backend-config: '{"default": "default-port-service"}'
+        cloud.google.com/neg: '{"ingress": true}'
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: default-port-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP

--- a/mozcloud/application/tests/custom-service-port-gateway-configuration_test.yaml
+++ b/mozcloud/application/tests/custom-service-port-gateway-configuration_test.yaml
@@ -1,0 +1,77 @@
+---
+suite: "mozcloud: Custom service port gateway configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+# By overriding the chart version, we are preventing the labels chart from
+# updating the mozcloud_chart_version label for every snapshot every time we
+# bump chart versions.
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/custom-service-port-gateway-configuration.yaml
+templates:
+  - gateway/backend.yaml
+  - gateway/gateway.yaml
+  - gateway/httproute.yaml
+  - gke/backend.yaml
+  - gke/gateway.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: Service port and HTTPRoute backendRef respect servicePort when set and default to 8080 when omitted
+    asserts:
+      - contains:
+          path: spec.ports
+          count: 1
+          content:
+            name: http
+            port: 9090
+            protocol: TCP
+            targetPort: http
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: custom-port-service
+      - contains:
+          path: spec.rules[0].backendRefs
+          count: 1
+          content:
+            group: ""
+            kind: Service
+            name: custom-port-service
+            port: 9090
+            weight: 1
+        template: gateway/httproute.yaml
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: custom-port-service
+      - contains:
+          path: spec.ports
+          count: 1
+          content:
+            name: http
+            port: 8080
+            protocol: TCP
+            targetPort: http
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: default-port-service
+      - contains:
+          path: spec.rules[0].backendRefs
+          count: 1
+          content:
+            group: ""
+            kind: Service
+            name: default-port-service
+            port: 8080
+            weight: 1
+        template: gateway/httproute.yaml
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: default-port-service

--- a/mozcloud/application/tests/custom-service-port-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/custom-service-port-ingress-configuration_test.yaml
@@ -1,0 +1,50 @@
+---
+suite: "mozcloud: Custom service port ingress configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+# By overriding the chart version, we are preventing the labels chart from
+# updating the mozcloud_chart_version label for every snapshot every time we
+# bump chart versions.
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/custom-service-port-ingress-configuration.yaml
+templates:
+  - gateway/gateway.yaml
+  - gke/frontendconfig.yaml
+  - gke/ingress.yaml
+  - ingress/ingress.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: Service port respects servicePort when set and defaults to 8080 when omitted
+    asserts:
+      - contains:
+          path: spec.ports
+          count: 1
+          content:
+            name: http
+            port: 9090
+            protocol: TCP
+            targetPort: http
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: custom-port-service
+      - contains:
+          path: spec.ports
+          count: 1
+          content:
+            name: http
+            port: 8080
+            protocol: TCP
+            targetPort: http
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: default-port-service

--- a/mozcloud/application/tests/values/custom-service-port-gateway-configuration.yaml
+++ b/mozcloud/application/tests/values/custom-service-port-gateway-configuration.yaml
@@ -1,0 +1,36 @@
+---
+workloads:
+  custom-port-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      custom-port-service:
+        domains:
+          - custom-port-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        servicePort: 9090
+        tls:
+          certs:
+            - custom-port-service-nonprod-dev
+
+  default-port-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      default-port-service:
+        domains:
+          - default-port-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        tls:
+          certs:
+            - default-port-service-nonprod-dev

--- a/mozcloud/application/tests/values/custom-service-port-ingress-configuration.yaml
+++ b/mozcloud/application/tests/values/custom-service-port-ingress-configuration.yaml
@@ -1,0 +1,36 @@
+---
+workloads:
+  custom-port-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      custom-port-service:
+        domains:
+          - custom-port-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        servicePort: 9090
+        tls:
+          type: ManagedCertificate
+
+  default-port-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      default-port-service:
+        domains:
+          - default-port-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        tls:
+          type: ManagedCertificate

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -872,6 +872,11 @@
                   "type": "string",
                   "description": "Override the auto-generated Gateway resource name. Useful when migrating from a chart that used a different Gateway name."
                 },
+                "servicePort": {
+                  "type": "integer",
+                  "description": "The Kubernetes Service port exposed to the load balancer. Defaults to 8080.",
+                  "default": 8080
+                },
                 "targetPort": {
                   "anyOf": [
                     {

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1555,6 +1555,10 @@ workloads:
         #
         #gatewayName: my-custom-gateway-name
 
+        # The Kubernetes Service port exposed to the load balancer. Defaults to
+        # 8080. Set this when your service needs to listen on a different port.
+        #servicePort: 8080
+
         # The port name or number on the pod that the ingress Service should
         # route traffic to. Only applicable when "api" is set to "ingress".
         #

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1557,7 +1557,7 @@ workloads:
 
         # The Kubernetes Service port exposed to the load balancer. Defaults to
         # 8080. Set this when your service needs to listen on a different port.
-        #servicePort: 8080
+        servicePort: 8080
 
         # The port name or number on the pod that the ingress Service should
         # route traffic to. Only applicable when "api" is set to "ingress".


### PR DESCRIPTION
## Description

This should aide in creating minimal diffs when migrating existing charts to MozCloud charts.

## Related Tickets & Documents
* MZCLD-2932


