### PR TITLE
feat(mozcloud): allow users to specify app container port names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+fail_fast: true
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0

--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -145,6 +145,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.containers.default.imagePullPolicy | string | `"Always"` |  |
 | workloads.default.containers.default.lifecycle | object | `{}` |  |
 | workloads.default.containers.default.port | int | `8000` |  |
+| workloads.default.containers.default.portName | string | `""` |  |
 | workloads.default.containers.default.resources.cpu | string | `"100m"` |  |
 | workloads.default.containers.default.resources.memory | string | `"128Mi"` |  |
 | workloads.default.containers.default.secrets | list | `[]` |  |

--- a/mozcloud/application/templates/_helpers.tpl
+++ b/mozcloud/application/templates/_helpers.tpl
@@ -62,39 +62,33 @@ Returns:
 
 
 {{- /*
-Produces an RFC 6335-compliant port name from an arbitrary string. Lowercases
-the input, replaces any character that is not a letter, digit, or hyphen with a
-hyphen, truncates to 15 characters, and strips any trailing hyphen.
+Produces an RFC 6335-compliant port name. Lowercases the input name,
+replaces any character that is not a letter, digit, or hyphen with a hyphen,
+truncates to 15 characters, and strips any trailing hyphen.
+
+When config.portName is set it takes precedence over name; otherwise name is
+used as the source string.
 
 Note: regexReplaceAll takes (regex, inputString, replacement) — the input must
 be passed as an explicit argument, not via pipeline, to avoid it being treated
 as the replacement value.
 
 Params:
-  . (string): (required) The source string (e.g. a container name).
+  containerConfig (map): (optional) Container config dict. When
+                         containerConfig.portName is set, it overrides name.
+  name         (string): (required) Fallback source string (e.g. a container
+                         name).
 
 Returns:
   (string) An RFC 6335-compliant port name.
 */ -}}
 {{- define "mozcloud.portName" -}}
-{{- $s := . | toString | lower -}}
-{{- regexReplaceAll "[^a-z0-9-]" $s "-" | trunc 15 | trimSuffix "-" -}}
+{{- $containerConfig := default dict .containerConfig -}}
+{{- $name := default .name $containerConfig.portName | toString | lower -}}
+{{- regexReplaceAll "[^a-z0-9-]" $name "-" | trunc 15 | trimSuffix "-" -}}
 {{- end }}
 
 
-{{- /*
-A debug utility that serializes the piped-in value as pretty-printed JSON and
-immediately fails the template render with that output as the error message.
-Use this to inspect any Helm variable or context dict during template
-development.
-
-Params:
-  . (any): (required) The value to serialize and dump.
-
-Returns:
-  Never returns — always fails with the JSON-serialized value as the error
-  message.
-*/ -}}
 {{- /*
 Resolves and renders a fully qualified container image string (repository:tag).
 
@@ -111,8 +105,8 @@ convention).
 Params:
   containerImage (dict): The container-level image config (image.repository, image.tag).
   globalImage    (dict): The global image config (.Values.global.mozcloud.image).
-  workloadName   (string): Name of the workload (for error messages).
   containerName  (string): Name of the container (for error messages).
+  workloadName   (string): Name of the workload (for error messages).
 
 Returns:
   (string) A fully qualified image reference, e.g. "registry/repo:tag".
@@ -139,6 +133,19 @@ Returns:
 {{- end }}
 
 
+{{- /*
+A debug utility that serializes the piped-in value as pretty-printed JSON and
+immediately fails the template render with that output as the error message.
+Use this to inspect any Helm variable or context dict during template
+development.
+
+Params:
+  . (any): (required) The value to serialize and dump.
+
+Returns:
+  Never returns — always fails with the JSON-serialized value as the error
+  message.
+*/ -}}
 {{- define "mozcloud.debug" -}}
 {{- . | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
 {{- end -}}

--- a/mozcloud/application/templates/gateway/backend.yaml
+++ b/mozcloud/application/templates/gateway/backend.yaml
@@ -69,7 +69,7 @@ backends:
     api: {{ default "gateway" $hostConfig.api }}
     service:
       port: {{ $hostConfig.servicePort }}
-      targetPort: {{ include "mozcloud.portName" (default "http" $hostConfig.targetPort) }}
+      targetPort: {{ include "mozcloud.portName" (dict "name" (default "http" $hostConfig.targetPort)) }}
     {{- if eq $provider "gke" }}
     backendPolicy:
       logging:

--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -65,7 +65,7 @@ ingresses:
                 name: {{ $workloadName }}
                 port: {{ $hostConfig.servicePort }}
                 protocol: TCP
-                targetPort: {{ include "mozcloud.portName" (default "http" $hostConfig.targetPort) }}
+                targetPort: {{ include "mozcloud.portName" (dict "name" (default "http" $hostConfig.targetPort)) }}
         tls:
           {{- $type := ($hostConfig.tls.type) }}
           {{- if or (not $type) (eq $type "certmap") }}

--- a/mozcloud/application/templates/workload/_helpers.tpl
+++ b/mozcloud/application/templates/workload/_helpers.tpl
@@ -117,7 +117,7 @@ Returns:
 {{- $otelContainerNames := default list .otelContainerNames -}}
 {{- $otelAutoInstrumentationEnabled := default false .otelAutoInstrumentationEnabled -}}
 {{- range $containerName, $containerConfig := $containers }}
-{{- $portName := include "mozcloud.portName" $containerName }}
+{{- $portName := include "mozcloud.portName" (dict "name" $containerName "containerConfig" $containerConfig) }}
 - name: {{ $containerName }}
   {{- $imageParams := dict "containerImage" $containerConfig.image "globalImage" $globals.image "workloadName" $name "containerName" $containerName }}
   image: {{ include "mozcloud.image" $imageParams }}

--- a/mozcloud/application/tests/__snapshot__/container-port-name_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/container-port-name_test.yaml.snap
@@ -1,0 +1,692 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: grpc
+      selector:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: my-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP
+  3: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      annotations:
+        networking.gke.io/certmap: custom-port-service-nonprod-dev
+      labels:
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: gateway
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: mozcloud-test
+    spec:
+      addresses:
+        - type: NamedAddress
+          value: mozcloud-dev-ip-v4
+      gatewayClassName: gke-l7-global-external-managed
+      listeners:
+        - allowedRoutes:
+            namespaces:
+              from: Same
+          name: http
+          port: 80
+          protocol: HTTP
+        - allowedRoutes:
+            namespaces:
+              from: Same
+          name: https
+          port: 443
+          protocol: HTTPS
+  4: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      hostnames:
+        - custom-port-service.dev.test-domain.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: mozcloud-test
+          sectionName: https
+      rules:
+        - backendRefs:
+            - group: ""
+              kind: Service
+              name: custom-port-service
+              port: 8080
+              weight: 1
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+  5: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service-http-redirect
+    spec:
+      hostnames:
+        - custom-port-service.dev.test-domain.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: mozcloud-test
+          sectionName: http
+      rules:
+        - filters:
+            - requestRedirect:
+                scheme: https
+                statusCode: 302
+              type: RequestRedirect
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+  6: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: my-service
+    spec:
+      hostnames:
+        - my-service.dev.test-domain.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: mozcloud-test
+          sectionName: https
+      rules:
+        - backendRefs:
+            - group: ""
+              kind: Service
+              name: my-service
+              port: 8080
+              weight: 1
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+  7: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: my-service-http-redirect
+    spec:
+      hostnames:
+        - my-service.dev.test-domain.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: mozcloud-test
+          sectionName: http
+      rules:
+        - filters:
+            - requestRedirect:
+                scheme: https
+                statusCode: 302
+              type: RequestRedirect
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+  8: |
+    apiVersion: networking.gke.io/v1
+    kind: GCPBackendPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      default:
+        logging:
+          enabled: true
+          sampleRate: 100000
+      targetRef:
+        group: ""
+        kind: Service
+        name: custom-port-service
+  9: |
+    apiVersion: networking.gke.io/v1
+    kind: HealthCheckPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      default:
+        config:
+          httpHealthCheck:
+            requestPath: /__lbheartbeat__
+          type: HTTP
+      targetRef:
+        group: ""
+        kind: Service
+        name: custom-port-service
+  10: |
+    apiVersion: networking.gke.io/v1
+    kind: GCPBackendPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: my-service
+    spec:
+      default:
+        logging:
+          enabled: true
+          sampleRate: 100000
+      targetRef:
+        group: ""
+        kind: Service
+        name: my-service
+  11: |
+    apiVersion: networking.gke.io/v1
+    kind: HealthCheckPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: my-service
+    spec:
+      default:
+        config:
+          httpHealthCheck:
+            requestPath: /__lbheartbeat__
+          type: HTTP
+      targetRef:
+        group: ""
+        kind: Service
+        name: my-service
+  12: |
+    apiVersion: networking.gke.io/v1
+    kind: GCPGatewayPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: gateway
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: mozcloud-test
+    spec:
+      default:
+        sslPolicy: mozilla-intermediate
+      targetRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: mozcloud-test
+  13: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: custom-port-service
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: web
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: web
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: web
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: web
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-image:1.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: grpc
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: grpc
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: grpc
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test
+  14: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: my-service
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: web
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: web
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: web
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: web
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__nginxheartbeat__
+                  port: http
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: nginx
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: http
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsGroup: 101
+                runAsUser: 101
+              volumeMounts:
+                - mountPath: /etc/nginx/nginx.conf
+                  name: nginx-conf
+                  readOnly: true
+                  subPath: nginx.conf
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-image:1.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: web
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: web
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: web
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test
+          volumes:
+            - configMap:
+                name: my-service-nginx
+              name: nginx-conf
+  15: |
+    apiVersion: v1
+    data:
+      nginx.conf: |
+        # The nginx docker container has ln -sf /dev/stderr /var/log/nginx/error.log
+        error_log  /var/log/nginx/error.log warn;
+        pid        /tmp/nginx.pid;
+
+        events {
+            worker_connections  2048;
+        }
+
+        http {
+            include       /etc/nginx/mime.types;
+
+            default_type  application/octet-stream;
+
+            log_format main escape=json
+            '{'
+              '"time":"$time_local",'
+              '"remote_addr":"$remote_addr",'
+              '"remote_user":"$remote_user",'
+              '"request":"$request",'
+              '"status": "$status",'
+              '"log_type": "access",'
+              '"bytes_sent": $body_bytes_sent,'
+              '"request_time": $request_time,'
+              '"referrer":"$http_referer",'
+              '"user_agent":"$http_user_agent",'
+              '"x_forwarded_for":"$http_x_forwarded_for",'
+              '"x_forwarded_proto":"$http_x_forwarded_proto",'
+              '"trace":"$http_x_cloud_trace_context"'
+            '}';
+
+            # The nginx docker container has ln -sf /dev/stdout /var/log/nginx/access.log
+            access_log  /var/log/nginx/access.log  main;
+
+            sendfile        on;
+
+            keepalive_timeout  620;
+
+            server_tokens off;
+
+            gzip on;
+            gzip_http_version 1.1;
+            gzip_comp_level 1;
+            gzip_vary on;
+            gzip_proxied any;
+            gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+            gzip_min_length 1100;
+            gzip_types
+                text/plain
+                text/css
+                application/json
+                application/x-javascript
+                text/xml
+                application/xml
+                application/xml+rss
+                text/javascript
+                application/javascript;
+
+            upstream upstream_docker {
+                server 127.0.0.1:8000;
+            }
+
+            server {
+                listen 8080;
+
+                client_max_body_size 2g;
+
+                add_header Strict-Transport-Security "max-age=31536000" always;
+
+                location / {
+                    proxy_set_header x-forwarded-proto $http_x_forwarded_proto;
+                    proxy_set_header x-forwarded-for $proxy_add_x_forwarded_for;
+                    proxy_set_header Host $http_host;
+                    proxy_redirect off;
+                    proxy_pass http://upstream_docker;
+                }
+
+                location = /nginx_status {
+                  stub_status on;
+                  access_log off;
+                  allow 127.0.0.1;
+                  deny all;
+                }
+
+                location = /__nginxheartbeat__ {
+                  return 200;
+                }
+            }
+        }
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: my-service-nginx

--- a/mozcloud/application/tests/container-port-name_test.yaml
+++ b/mozcloud/application/tests/container-port-name_test.yaml
@@ -1,0 +1,57 @@
+---
+suite: "mozcloud: Container portName configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+# By overriding the chart version, we are preventing the labels chart from
+# updating the mozcloud_chart_version label for every snapshot every time we
+# bump chart versions.
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/container-port-name.yaml
+templates:
+  - gateway/backend.yaml
+  - gateway/gateway.yaml
+  - gateway/httproute.yaml
+  - gke/backend.yaml
+  - gke/gateway.yaml
+  - workload/deployment.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: portName is used as the container port name
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="app")].ports[0].name
+          value: web
+        template: workload/deployment.yaml
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: my-service
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="app")].ports[0].name
+          value: grpc
+        template: workload/deployment.yaml
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: custom-port-service
+
+  - it: targetPort respects explicit override when portName and targetPort are both set
+    asserts:
+      - contains:
+          path: spec.ports
+          count: 1
+          content:
+            name: http
+            port: 8080
+            protocol: TCP
+            targetPort: grpc
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: custom-port-service

--- a/mozcloud/application/tests/values/container-port-name.yaml
+++ b/mozcloud/application/tests/values/container-port-name.yaml
@@ -1,0 +1,40 @@
+---
+workloads:
+  my-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+        portName: web
+    hosts:
+      my-service:
+        domains:
+          - my-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        tls:
+          certs:
+            - my-service-nonprod-dev
+
+  custom-port-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+        portName: grpc
+    nginx:
+      enabled: false
+    hosts:
+      custom-port-service:
+        domains:
+          - custom-port-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        targetPort: grpc
+        tls:
+          certs:
+            - custom-port-service-nonprod-dev

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -632,6 +632,10 @@
                 "port": {
                   "type": "integer",
                   "default": 8000
+                },
+                "portName": {
+                  "type": "string",
+                  "description": "Override the name used for this container's port. Defaults to the container name normalized to RFC 6335 format."
                 }
               }
             }

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1220,6 +1220,18 @@ workloads:
         # This value should be an integer.
         port: 8000
 
+        # Optionally override the name used for this container's port. Defaults
+        # to the container name, normalized to RFC 6335 format (lowercase,
+        # hyphens only, max 15 characters).
+        #
+        # When nginx is disabled and the "targetPort" host setting is not
+        # explicitly set, use this value as the "targetPort" so that the Service
+        # routes traffic to the correct container port.
+        #
+        # Example:
+        #   portName: web
+        portName: ''
+
         # The "resources" section allows you to specify the amount of CPU and
         # memory that your container needs to run. These are equivalent to
         # requests values.
@@ -1559,12 +1571,12 @@ workloads:
         # 8080. Set this when your service needs to listen on a different port.
         servicePort: 8080
 
-        # The port name or number on the pod that the ingress Service should
-        # route traffic to. Only applicable when "api" is set to "ingress".
+        # The port name or number on the pod that the Service should route
+        # traffic to. Applies to both "gateway" and "ingress" API types.
         #
-        # Defaults to "http", which routes to the nginx sidecar. Set this to
-        # your container name (e.g. "my-container") or a port number when nginx
-        # is disabled and the ingress should route directly to an app container.
+        # Defaults to "http", which routes to the nginx sidecar. When nginx is
+        # disabled, set this to the app container's "portName" if configured,
+        # or the container name otherwise.
         targetPort: http
 
         # Global certificate details for external gateways. Certificates MUST be


### PR DESCRIPTION
## Description
Previously, container port names in the mozcloud chart were always derived from the container name, with no way to override them. This made it difficult to use stable, meaningful port names independent of the container name, and required users to manually keep `targetPort` in sync. This PR adds a `portName` field to container configuration, consolidates port name resolution logic into the `mozcloud.portName` helper, and fixes a pre-existing inaccuracy in the `targetPort` comment.

**Note: If you configure `portName` at the container level and need to route traffic there for some reason (ie. you're not using nginx), be sure to update `targetPort` in the host configuration to reflect that value.**

Changes:
- Adds `portName` to container configuration (`workloads.*.containers.<name>`)
  - Defaults to the container name normalized to RFC 6335 format (existing behavior)
  - When set, overrides the port `name:` field on the container spec
  - When nginx is disabled, users should set `targetPort` on the host to match
- Refactors `mozcloud.portName` helper to accept explicit `name` and `containerConfig` params
  - `portName` override logic is now consolidated inside the helper rather than at each call site
  - Callers that don't need a `containerConfig` override (e.g. gateway, ingress `targetPort`) pass only `name`
- Fixes the `targetPort` comment in `values.yaml`
  - Previously stated it only applied to `api: ingress` — it applies to both `gateway` and `ingress`
- Adds `fail_fast: true` to `.pre-commit-config.yaml`
  - Stops subsequent hooks (e.g. `helm-unittest`) from running when an earlier hook fails
  - This basically makes it so we don't have to wait for unit tests to run if a previous hook fails as that's a big waste of time


## Related Tickets & Documents
* MZCLD-2942