### PR TITLE
feat!: stop automatically prefixing ManagedCertificate resource names

### DIFF
--- a/mozcloud-ingress/application/README.md
+++ b/mozcloud-ingress/application/README.md
@@ -55,6 +55,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | ingresses.default.staticIpName | string | `"mozcloud-ingress-dev-ip-v4"` |  |
 | ingresses.default.tls.createCertificates | bool | `true` |  |
 | ingresses.default.tls.multipleHosts | bool | `true` |  |
+| ingresses.default.tls.prefix | string | `""` |  |
 | ingresses.default.tls.type | string | `"ManagedCertificate"` |  |
 
 ---

--- a/mozcloud-ingress/application/tests/__snapshot__/managed-cert-prefix-configuration_test.yaml.snap
+++ b/mozcloud-ingress/application/tests/__snapshot__/managed-cert-prefix-configuration_test.yaml.snap
@@ -1,0 +1,47 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: gce
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-test-dev-ip-v4
+        networking.gke.io/managed-certificates: mcrt-test-ingress-0
+        networking.gke.io/v1beta1.FrontendConfig: test-ingress
+      labels:
+        app.kubernetes.io/component: ingress
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: ingress
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud-ingress
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-ingress
+    spec:
+      defaultBackend:
+        service:
+          name: test-ingress
+          port:
+            number: 8080
+  2: |
+    apiVersion: networking.gke.io/v1
+    kind: ManagedCertificate
+    metadata:
+      labels:
+        app.kubernetes.io/component: ingress
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: ingress
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud-ingress
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: mcrt-test-ingress-0
+    spec:
+      domains:
+        - test-service.dev.test-domain.com

--- a/mozcloud-ingress/application/tests/basic-configuration_test.yaml
+++ b/mozcloud-ingress/application/tests/basic-configuration_test.yaml
@@ -54,7 +54,7 @@ tests:
           content:
             kubernetes.io/ingress.class: gce
             kubernetes.io/ingress.global-static-ip-name: mozcloud-test-dev-ip-v4
-            networking.gke.io/managed-certificates: mcrt-test-ingress-0
+            networking.gke.io/managed-certificates: test-ingress-0
             networking.gke.io/v1beta1.FrontendConfig: test-ingress
         template: ingress.yaml
         documentSelector:
@@ -79,14 +79,14 @@ tests:
         template: managedcertificate.yaml
         documentSelector:
           path: $[?(@.kind == "ManagedCertificate")].metadata.name
-          value: mcrt-test-ingress-0
+          value: test-ingress-0
       - contains:
           path: spec.domains
           content: "test-service.dev.test-domain.com"
         template: managedcertificate.yaml
         documentSelector:
           path: $[?(@.kind == "ManagedCertificate")].metadata.name
-          value: mcrt-test-ingress-0
+          value: test-ingress-0
       # Service is configured correctly
       - contains:
           path: spec.ports

--- a/mozcloud-ingress/application/tests/managed-cert-prefix-configuration_test.yaml
+++ b/mozcloud-ingress/application/tests/managed-cert-prefix-configuration_test.yaml
@@ -1,0 +1,36 @@
+---
+suite: "mozcloud-ingress: ManagedCertificate prefix override configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/managed-cert-prefix-configuration.yaml
+templates:
+  - managedcertificate.yaml
+  - ingress.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: ManagedCertificate name uses the configured prefix
+    asserts:
+      - contains:
+          path: spec.domains
+          content: "test-service.dev.test-domain.com"
+        template: managedcertificate.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: mcrt-test-ingress-0
+      - isSubset:
+          path: metadata.annotations
+          content:
+            networking.gke.io/managed-certificates: mcrt-test-ingress-0
+        template: ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-ingress

--- a/mozcloud-ingress/application/tests/values/managed-cert-prefix-configuration.yaml
+++ b/mozcloud-ingress/application/tests/values/managed-cert-prefix-configuration.yaml
@@ -1,16 +1,13 @@
 ---
 ingresses:
-  # This names the Ingress and all related components "test-ingress".
-  #
-  # The ManagedCertificate resource gets a "-N" suffix (where "N" is the
-  # instance number, eg. 0) appended to its name. For example:
-  #
-  #   "test-ingress-0"
   test-ingress:
     staticIpName: mozcloud-test-dev-ip-v4
     hosts:
       - domains:
           - test-service.dev.test-domain.com
+        tls:
+          type: ManagedCertificate
+          prefix: mcrt
         paths:
           - path: /
             backend:

--- a/mozcloud-ingress/application/values.yaml
+++ b/mozcloud-ingress/application/values.yaml
@@ -228,11 +228,10 @@ ingresses:
       # host.
       multipleHosts: true
 
-      # Prefix to use for ManagedCertificate names. This setting is ignored if
+      # Prefix to use for auto-generated ManagedCertificate names. Set to
+      # "mcrt" to restore the legacy prefix. This setting is ignored if
       # certificate type is cert-manager or pre-shared.
-      #
-      # Default is "mcrt". Set to empty string ("") for no prefix.
-      #prefix: mcrt
+      prefix: ""
 
       # A comma-separated string containing pre-shared certificate names. This
       # is required if certificate type is pre-shared.

--- a/mozcloud-ingress/library/templates/_helpers.tpl
+++ b/mozcloud-ingress/library/templates/_helpers.tpl
@@ -221,7 +221,7 @@ ManagedCertificate template helpers
     {{- $ingress_name := include "mozcloud-ingress-lib.config.name" $params -}}
     {{- $managed_cert := dict -}}
     {{- $name := "" -}}
-    {{- $prefix := default "mcrt" $tls.prefix -}}
+    {{- $prefix := dig "prefix" "" $tls -}}
     {{- $suffixes := list -}}
     {{- $host_tls := default (dict) $host.tls -}}
     {{- if and (eq $tls.type "ManagedCertificate") (not $tls.createCertificates) (not $host_tls.certNames) -}}

--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -159,6 +159,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.hosts.default.targetPort | string | `"http"` |  |
 | workloads.default.hosts.default.tls.certs | list | `[]` |  |
 | workloads.default.hosts.default.tls.create | bool | `true` |  |
+| workloads.default.hosts.default.tls.prefix | string | `""` |  |
 | workloads.default.hosts.default.tls.type | string | `"certmap"` |  |
 | workloads.default.hosts.default.type | string | `"external"` |  |
 | workloads.default.initContainers.default.args | list | `[]` |  |

--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -86,6 +86,9 @@ ingresses:
           {{- else if and (hasKey $hostConfig.tls "create") ($hostConfig.tls.create) (eq $type "ManagedCertificate") }}
           multipleHosts: false
           {{- end }}
+          {{- if eq $type "ManagedCertificate" }}
+          prefix: {{ default "" $hostConfig.tls.prefix | quote }}
+          {{- end }}
           {{- if eq $type "pre-shared" }}
           preSharedCerts: {{ join "," (uniq $hostConfig.tls.certs | sortAlpha) | quote }}
           {{- end }}

--- a/mozcloud/application/tests/__snapshot__/basic-ingress-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/basic-ingress-configuration_test.yaml.snap
@@ -76,7 +76,7 @@ Configuration matches entire snapshot:
         mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: mcrt-nginx-disabled-service-dev-test-domain-com
+      name: nginx-disabled-service-dev-test-domain-com
     spec:
       domains:
         - nginx-disabled-service.dev.test-domain.com
@@ -115,7 +115,7 @@ Configuration matches entire snapshot:
         mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: mcrt-test-service-dev-test-domain-com
+      name: test-service-dev-test-domain-com
     spec:
       domains:
         - test-service.dev.test-domain.com
@@ -126,7 +126,7 @@ Configuration matches entire snapshot:
       annotations:
         kubernetes.io/ingress.class: gce
         kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
-        networking.gke.io/managed-certificates: mcrt-nginx-disabled-service-dev-test-domain-com
+        networking.gke.io/managed-certificates: nginx-disabled-service-dev-test-domain-com
         networking.gke.io/v1beta1.FrontendConfig: nginx-disabled-service
       labels:
         app.kubernetes.io/component: web
@@ -183,7 +183,7 @@ Configuration matches entire snapshot:
       annotations:
         kubernetes.io/ingress.class: gce
         kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
-        networking.gke.io/managed-certificates: mcrt-test-service-dev-test-domain-com
+        networking.gke.io/managed-certificates: test-service-dev-test-domain-com
         networking.gke.io/v1beta1.FrontendConfig: test-service
       labels:
         app.kubernetes.io/component: web

--- a/mozcloud/application/tests/__snapshot__/custom-service-port-ingress-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/custom-service-port-ingress-configuration_test.yaml.snap
@@ -76,7 +76,7 @@ Configuration matches entire snapshot:
         mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: mcrt-custom-port-service-dev-test-domain-com
+      name: custom-port-service-dev-test-domain-com
     spec:
       domains:
         - custom-port-service.dev.test-domain.com
@@ -115,7 +115,7 @@ Configuration matches entire snapshot:
         mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: mcrt-default-port-service-dev-test-domain-com
+      name: default-port-service-dev-test-domain-com
     spec:
       domains:
         - default-port-service.dev.test-domain.com
@@ -126,7 +126,7 @@ Configuration matches entire snapshot:
       annotations:
         kubernetes.io/ingress.class: gce
         kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
-        networking.gke.io/managed-certificates: mcrt-custom-port-service-dev-test-domain-com
+        networking.gke.io/managed-certificates: custom-port-service-dev-test-domain-com
         networking.gke.io/v1beta1.FrontendConfig: custom-port-service
       labels:
         app.kubernetes.io/component: web
@@ -183,7 +183,7 @@ Configuration matches entire snapshot:
       annotations:
         kubernetes.io/ingress.class: gce
         kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
-        networking.gke.io/managed-certificates: mcrt-default-port-service-dev-test-domain-com
+        networking.gke.io/managed-certificates: default-port-service-dev-test-domain-com
         networking.gke.io/v1beta1.FrontendConfig: default-port-service
       labels:
         app.kubernetes.io/component: web

--- a/mozcloud/application/tests/__snapshot__/ingress-backend-options-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/ingress-backend-options-configuration_test.yaml.snap
@@ -58,7 +58,7 @@ Configuration matches entire snapshot:
         mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: mcrt-test-service-dev-test-domain-com
+      name: test-service-dev-test-domain-com
     spec:
       domains:
         - test-service.dev.test-domain.com
@@ -69,7 +69,7 @@ Configuration matches entire snapshot:
       annotations:
         kubernetes.io/ingress.class: gce
         kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
-        networking.gke.io/managed-certificates: mcrt-test-service-dev-test-domain-com
+        networking.gke.io/managed-certificates: test-service-dev-test-domain-com
         networking.gke.io/v1beta1.FrontendConfig: test-service
       labels:
         app.kubernetes.io/component: app

--- a/mozcloud/application/tests/__snapshot__/ingress-multi-domain-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/ingress-multi-domain-configuration_test.yaml.snap
@@ -34,7 +34,7 @@ Configuration matches entire snapshot:
         mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: mcrt-test-service-dev-test-domain-com
+      name: test-service-dev-test-domain-com
     spec:
       domains:
         - test-service.dev.test-domain.com
@@ -53,7 +53,7 @@ Configuration matches entire snapshot:
         mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: mcrt-www-test-service-dev-test-domain-com
+      name: www-test-service-dev-test-domain-com
     spec:
       domains:
         - www.test-service.dev.test-domain.com
@@ -64,7 +64,7 @@ Configuration matches entire snapshot:
       annotations:
         kubernetes.io/ingress.class: gce
         kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
-        networking.gke.io/managed-certificates: mcrt-test-service-dev-test-domain-com,mcrt-www-test-service-dev-test-domain-com
+        networking.gke.io/managed-certificates: test-service-dev-test-domain-com,www-test-service-dev-test-domain-com
         networking.gke.io/v1beta1.FrontendConfig: test-service
       labels:
         app.kubernetes.io/component: web

--- a/mozcloud/application/tests/__snapshot__/managed-cert-prefix-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/managed-cert-prefix-configuration_test.yaml.snap
@@ -4,107 +4,86 @@ Configuration matches entire snapshot:
     kind: BackendConfig
     metadata:
       labels:
-        app.kubernetes.io/component: ingress
+        app.kubernetes.io/component: web
         app.kubernetes.io/managed-by: argocd
         app.kubernetes.io/name: mozcloud-test
         app_code: mozcloud-test
-        component_code: ingress
+        component_code: web
         env_code: dev
         helm.sh/chart: test-chart
-        mozcloud_chart: mozcloud-ingress
+        mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: test-ingress
+      name: test-service
     spec:
       logging:
         enable: true
         sampleRate: 0.1
   2: |
-    apiVersion: networking.gke.io/v1beta1
-    kind: FrontendConfig
+    apiVersion: networking.gke.io/v1
+    kind: ManagedCertificate
     metadata:
       labels:
-        app.kubernetes.io/component: ingress
+        app.kubernetes.io/component: web
         app.kubernetes.io/managed-by: argocd
         app.kubernetes.io/name: mozcloud-test
         app_code: mozcloud-test
-        component_code: ingress
+        component_code: web
         env_code: dev
         helm.sh/chart: test-chart
-        mozcloud_chart: mozcloud-ingress
+        mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: test-ingress
+      name: mcrt-test-service-dev-test-domain-com
     spec:
-      redirectToHttps:
-        enabled: true
-        responseCodeName: MOVED_PERMANENTLY_DEFAULT
-      sslPolicy: mozilla-intermediate
+      domains:
+        - test-service.dev.test-domain.com
   3: |
     apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       annotations:
         kubernetes.io/ingress.class: gce
-        kubernetes.io/ingress.global-static-ip-name: mozcloud-test-dev-ip-v4
-        networking.gke.io/managed-certificates: test-ingress-0
-        networking.gke.io/v1beta1.FrontendConfig: test-ingress
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
+        networking.gke.io/managed-certificates: mcrt-test-service-dev-test-domain-com
+        networking.gke.io/v1beta1.FrontendConfig: test-service
       labels:
-        app.kubernetes.io/component: ingress
+        app.kubernetes.io/component: web
         app.kubernetes.io/managed-by: argocd
         app.kubernetes.io/name: mozcloud-test
         app_code: mozcloud-test
-        component_code: ingress
+        component_code: web
         env_code: dev
         helm.sh/chart: test-chart
-        mozcloud_chart: mozcloud-ingress
+        mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: test-ingress
+      name: test-service
     spec:
       defaultBackend:
         service:
-          name: test-ingress
+          name: test-service
           port:
             number: 8080
   4: |
-    apiVersion: networking.gke.io/v1
-    kind: ManagedCertificate
-    metadata:
-      labels:
-        app.kubernetes.io/component: ingress
-        app.kubernetes.io/managed-by: argocd
-        app.kubernetes.io/name: mozcloud-test
-        app_code: mozcloud-test
-        component_code: ingress
-        env_code: dev
-        helm.sh/chart: test-chart
-        mozcloud_chart: mozcloud-ingress
-        mozcloud_chart_version: 1.0.0
-        realm: nonprod
-      name: test-ingress-0
-    spec:
-      domains:
-        - test-service.dev.test-domain.com
-  5: |
     apiVersion: v1
     kind: Service
     metadata:
       annotations:
-        cloud.google.com/backend-config: '{"default": "test-ingress"}'
+        cloud.google.com/backend-config: '{"default": "test-service"}'
         cloud.google.com/neg: '{"ingress": true}'
       labels:
-        app.kubernetes.io/component: ingress
+        app.kubernetes.io/component: web
         app.kubernetes.io/managed-by: argocd
         app.kubernetes.io/name: mozcloud-test
         app_code: mozcloud-test
-        component_code: ingress
+        component_code: web
         env_code: dev
         helm.sh/chart: test-chart
-        mozcloud_chart: mozcloud-ingress
+        mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: test-ingress
+      name: test-service
     spec:
       ports:
         - name: http
@@ -112,7 +91,7 @@ Configuration matches entire snapshot:
           protocol: TCP
           targetPort: http
       selector:
-        app.kubernetes.io/component: ingress
+        app.kubernetes.io/component: web
         app.kubernetes.io/name: mozcloud-test
         env_code: dev
       type: ClusterIP

--- a/mozcloud/application/tests/__snapshot__/mixed-gateway-ingress-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/mixed-gateway-ingress-configuration_test.yaml.snap
@@ -261,7 +261,7 @@ Configuration matches entire snapshot:
         mozcloud_chart: mozcloud
         mozcloud_chart_version: 1.0.0
         realm: nonprod
-      name: mcrt-ingress-service-dev-test-domain-com
+      name: ingress-service-dev-test-domain-com
     spec:
       domains:
         - ingress-service.dev.test-domain.com
@@ -272,7 +272,7 @@ Configuration matches entire snapshot:
       annotations:
         kubernetes.io/ingress.class: gce
         kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4-ingress
-        networking.gke.io/managed-certificates: mcrt-ingress-service-dev-test-domain-com
+        networking.gke.io/managed-certificates: ingress-service-dev-test-domain-com
         networking.gke.io/v1beta1.FrontendConfig: ingress-service
       labels:
         app.kubernetes.io/component: web

--- a/mozcloud/application/tests/basic-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-ingress-configuration_test.yaml
@@ -53,7 +53,7 @@ tests:
           content:
             kubernetes.io/ingress.class: gce
             kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
-            networking.gke.io/managed-certificates: mcrt-test-service-dev-test-domain-com
+            networking.gke.io/managed-certificates: test-service-dev-test-domain-com
             networking.gke.io/v1beta1.FrontendConfig: test-service
         template: ingress/ingress.yaml
         documentSelector:
@@ -78,14 +78,14 @@ tests:
         template: gke/ingress.yaml
         documentSelector:
           path: $[?(@.kind == "ManagedCertificate")].metadata.name
-          value: mcrt-test-service-dev-test-domain-com
+          value: test-service-dev-test-domain-com
       - contains:
           path: spec.domains
           content: "test-service.dev.test-domain.com"
         template: gke/ingress.yaml
         documentSelector:
           path: $[?(@.kind == "ManagedCertificate")].metadata.name
-          value: mcrt-test-service-dev-test-domain-com
+          value: test-service-dev-test-domain-com
       # Service is configured correctly
       - contains:
           path: spec.ports

--- a/mozcloud/application/tests/managed-cert-prefix-configuration_test.yaml
+++ b/mozcloud/application/tests/managed-cert-prefix-configuration_test.yaml
@@ -1,0 +1,43 @@
+---
+suite: "mozcloud: ManagedCertificate prefix override configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/managed-cert-prefix-configuration.yaml
+templates:
+  - gke/ingress.yaml
+  - ingress/ingress.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: ManagedCertificate name uses the configured prefix
+    asserts:
+      - lengthEqual:
+          path: spec.domains
+          count: 1
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: mcrt-test-service-dev-test-domain-com
+      - contains:
+          path: spec.domains
+          content: "test-service.dev.test-domain.com"
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "ManagedCertificate")].metadata.name
+          value: mcrt-test-service-dev-test-domain-com
+      - isSubset:
+          path: metadata.annotations
+          content:
+            networking.gke.io/managed-certificates: mcrt-test-service-dev-test-domain-com
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/mixed-gateway-ingress-configuration_test.yaml
+++ b/mozcloud/application/tests/mixed-gateway-ingress-configuration_test.yaml
@@ -113,7 +113,7 @@ tests:
         template: gke/ingress.yaml
         documentSelector:
           path: $[?(@.kind == "ManagedCertificate")].metadata.name
-          value: mcrt-ingress-service-dev-test-domain-com
+          value: ingress-service-dev-test-domain-com
 
   - it: No resource leakage between gateway and ingress templates
     asserts:

--- a/mozcloud/application/tests/values/managed-cert-prefix-configuration.yaml
+++ b/mozcloud/application/tests/values/managed-cert-prefix-configuration.yaml
@@ -1,0 +1,19 @@
+---
+workloads:
+  test-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      test-service:
+        domains:
+          - test-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        tls:
+          type: ManagedCertificate
+          prefix: mcrt

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -907,17 +907,6 @@
                       "type": "boolean",
                       "default": true
                     },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "certmap",
-                        "ManagedCertificate",
-                        "pre-shared",
-                        "secret",
-                        "certManager"
-                      ],
-                      "default": "certmap"
-                    },
                     "issuer": {
                       "type": "string",
                       "description": "cert-manager ClusterIssuer or Issuer name. Overrides cloud.certManager.issuer for this host."
@@ -929,6 +918,22 @@
                         "ClusterIssuer",
                         "Issuer"
                       ]
+                    },
+                    "prefix": {
+                      "type": "string",
+                      "description": "Prefix to use for auto-generated ManagedCertificate names. Only applies when type is \"ManagedCertificate\" and certs is empty. Set to \"mcrt\" to restore the legacy prefix.",
+                      "default": ""
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "certmap",
+                        "ManagedCertificate",
+                        "pre-shared",
+                        "secret",
+                        "certManager"
+                      ],
+                      "default": "certmap"
                     }
                   }
                 },

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1595,7 +1595,7 @@ workloads:
           #   pre-shared: All entries are pre-shared certificate names.
           #   ManagedCertificate: Names to use for the created
           #     ManagedCertificate resources, overriding the default
-          #     auto-generated names (which use the "mcrt-" prefix).
+          #     auto-generated names.
           #   certManager: The first entry is used as the TLS secret name.
           #
           # Certificate maps and pre-shared certificates are created
@@ -1607,6 +1607,21 @@ workloads:
           # chart. Only applicable when "type" is "ManagedCertificate" and
           # "api" is "ingress".
           create: true
+
+          # Required when type is "certManager". The name of the cert-manager
+          # ClusterIssuer or Issuer to use (e.g. "letsencrypt-prod").
+          # Overrides cloud.certManager.issuer for this host.
+          #issuer: ''
+
+          # Required when type is "certManager". "ClusterIssuer" (default) or
+          # "Issuer" for namespace-scoped issuers.
+          # Overrides cloud.certManager.issuerKind for this host.
+          #issuerKind: ClusterIssuer
+
+          # Prefix to use for auto-generated ManagedCertificate names. Only
+          # applies when "type" is "ManagedCertificate" and "certs" is empty.
+          # Set to "mcrt" to restore the legacy prefix.
+          prefix: ""
 
           # Can be "certmap", "ManagedCertificate", "pre-shared",
           # "certManager", or "secret". What you use depends on the type of
@@ -1627,16 +1642,6 @@ workloads:
           #
           # As the default API is "gateway", the default TLS type is "certmap".
           type: certmap
-
-          # Required when type is "certManager". The name of the cert-manager
-          # ClusterIssuer or Issuer to use (e.g. "letsencrypt-prod").
-          # Overrides cloud.certManager.issuer for this host.
-          #issuer: ''
-
-          # Required when type is "certManager". "ClusterIssuer" (default) or
-          # "Issuer" for namespace-scoped issuers.
-          # Overrides cloud.certManager.issuerKind for this host.
-          #issuerKind: ClusterIssuer
 
         # Optionally configure the log sample rate for the load balancer, IAP
         # details, a custom backend timeout, or a Cloud Armor security policy.


### PR DESCRIPTION
## Description
We currently automatically prefix `ManagedCertificate` resources we create with the mozcloud-ingress-lib chart with `mcrt-` by default. This seems unnecessary and I’d like to change this behavior now before we migrate a bunch of tenants.

**This will be a breaking change**, but it appears that only the **fx-sharing**, **tokenserver**, and **treeherder** tenants are currently have ManagedCertificate resources created with that prefix. I will coordinate a PR for those tenants to manually set the prefix so nothing changes/breaks for them as part of this.

Users can still specify `prefix: mcrt` in their TLS configurations if they've already migrated tenants and don't want to recreate certificates.

Changes:
  - `mozcloud-ingress-lib` no longer prepends `mcrt-` to auto-generated `ManagedCertificate` names by default.
    - The lib's `prefix` schema field already existed; only its default behavior changed.
  - The parent `mozcloud` chart exposes a new `tls.prefix` field on host TLS config.
    - Defaults to `""` (no prefix). Set to `mcrt` to restore the legacy auto-generated names.
    - Sibling keys in the `tls` block were alphabetized in `values.schema.json` and `values.yaml` while editing.
  - The standalone `mozcloud-ingress` chart's `values.yaml` reflects the new default.
    - `prefix: ""` is shown uncommented at default per the chart's convention of showing default scalars.
    - Comments referencing the old `mcrt-` default were updated.
  - Tests were updated to reflect new default format where the prefix is omitted... tests were also created to ensure the prefix exists when specified

## Related Tickets & Documents
* MZCLD-2966