### PR TITLE
feat(docs): update chart-standards skill and CONTRIBUTING.md

### DIFF
--- a/.claude/skills/chart-standards/SKILL.md
+++ b/.claude/skills/chart-standards/SKILL.md
@@ -11,6 +11,11 @@ description: "Invoke this skill whenever the user is contributing to the mozclou
   - If functions are copied from other sources, convert the new function and variable names to camelCase.
 - Function and variable names should always be named and have helpful names. Single word is preferable if possible, but prompt for more complex names.
 - Prompt for approval for any changes to templates and helpers required outside of the current task.
+- Before any tool call that requires user approval (Bash command, Edit, Write, etc.), narrate what you're about to do and why in the preceding text response, so the user can decide on the approval prompt with full context.
+- Writing convention for "nginx" in prose (comments in `values.yaml`, schema `description` fields, template/helper comments, READMEs):
+  - Use "NGINX" (all caps) when referring to NGINX generically as a product/brand.
+  - Use lowercase `nginx` when referring to: a literal string value (image name, service identifier, file path), the `nginx` config block or its fields, the nginx sidecar container we deploy, or Kubernetes resources whose names contain lowercase `nginx`.
+  - Never use "Nginx" (mixed case).
 
 ## Core Helm Chart
 The `mozcloud` Helm chart is our core component and what will be consumed by users of our internal platform. It generally consumes library charts and contains the vast majority of our logic. We want to keep this chart maintainable and reduce the reliance on library charts where possible.
@@ -61,6 +66,20 @@ Any changes to library Helm charts should result in a new version of the `mozclo
 - Complex functions in templates should be limited and offloaded to a helper function.
 - Template folders should match the top level keys used in values.yaml. `configmap`, `workload`, etc.
 
+### Reading optional values
+Prefer the `default` function for reading optional values from a dict. Reach for `dig` only when a falsy value (empty string, `false`, `0`) is a meaningful signal that must be honored — i.e., when the alternative would be a `hasKey` presence check.
+
+- **Default form:** `{{- $v := default "fallback" $d.k -}}` — use whenever a falsy value should fall back to the default. This is the common case.
+- **Use `dig` when** an empty/false/zero value is a legitimate signal that must not be overridden:
+  ```
+  {{- $prefix := dig "prefix" "pr-" $config -}}
+  ```
+  Here, `$config.prefix: ""` (intentionally disabling the prefix) is preserved. `default "pr-" $config.prefix` would incorrectly fall back to `"pr-"`.
+- Avoid `hasKey` guards followed by reads — `dig` collapses that pattern into one expression.
+- `hasKey` is still appropriate when you genuinely need the boolean "was the key set?" for branching logic (rare).
+
+The mental rule: "Would I need `hasKey` here to distinguish absent from present-but-falsy?" If yes → `dig`. Otherwise → `default`.
+
 ### Dict-based configuration with protected default keys
 Resources in mozcloud use dicts keyed by resource name rather than lists. Within each dict, a specially named entry acts as the default that gets merged into all real entries — it is omitted from rendered output. The protected keys are:
 
@@ -100,6 +119,56 @@ In addition to the template and helper rules above, ensure the following are upd
 - **`common.values.yaml.example`** — add representative examples showing the key configuration options a user would need. It does not need to cover every variant, but should illustrate the most common usage (e.g., if a resource type supports subtypes like Deployment, StatefulSet, or Rollout, show the type field with an example).
 - **`templates/_annotations.yaml` sync-wave defaults** — if the new resource type uses `mozcloud.annotations.argo`, add it to the `mozcloud.annotations.argo.syncWaveDefaults` lookup table with an appropriate sync-wave value, and add it to the accepted types listed in the helper's JSDoc comment. Current defaults for reference: `configMap: -11`, `externalSecret: -11`, `serviceAccount: -11`, `jobPreDeployment: -1`, `jobPostDeployment: 1` (deployments intentionally have no sync-wave).
 
+## When editing `values.yaml` or `values.schema.json`
+
+### Sibling key ordering
+Order sibling keys alphabetically, with priority keys floated to the top of their block. This applies anywhere keys appear at the same nesting level: top-level properties, properties under `$defs.<X>.properties`, and sibling blocks in `values.yaml`.
+
+**Priority keys** sit at the top, in this order:
+1. **Gates** — turn the block on/off: `enabled`, `create`.
+2. **Discriminators** — determine which other fields are meaningful: `type`, `provider` (under `cloud`).
+3. **Merge sources** — `default` (the protected key in dict-based config; see "Dict-based configuration with protected default keys").
+
+The mental model: priority keys are gates, discriminators, or merge sources — keys whose value determines whether the block is active or which other keys apply. New keys that fit one of those shapes (e.g., a future `kind`, `mode`, `api` field that gates or discriminates) should be treated as priority keys too.
+
+When inserting a new key:
+- If it's a priority key, place it at the top in the order above.
+- Otherwise, slot it into the correct alphabetical position among non-priority siblings.
+- Don't silently re-sort an existing block whose neighbors are already non-alphabetical — place only the new key correctly.
+
+Does NOT apply to: `enum:` arrays and other ordered lists where order is semantically significant; `.tpl` template code; `Chart.yaml` (Helm-prescribed order); test fixtures.
+
+### Strict typing
+Prefer strict, single-type definitions for fields in `values.schema.json`. Do not introduce new `anyOf`/`oneOf` to let a field accept multiple shapes (e.g., string OR object) — instead, add a new, separately-named field with its own strict type. (Existing `anyOf`/`oneOf` usages aren't a sweep-replace target — leave them unless the surrounding code is being refactored anyway.)
+
+**Example:** rather than making `tls.certs` accept both `[string]` and `[{name, domains}]`, add a new `tls.managedCertificates: [{name, domains}]` field — or use separate scalar fields (e.g. a toggle + an override) instead of an overloaded object list.
+
+**Exception:** when the upstream Kubernetes CRD or resource genuinely accepts multiple types for a field (most commonly number-vs-string, e.g. `IntOrString` types), mirroring that ambiguity with `anyOf`/`oneOf` is acceptable. Validate against the actual CRD definition before going this route.
+
+### Default values left uncommented
+Prefer to leave default values **uncommented** in `values.yaml`. The chart's template logic should gracefully evaluate defaults — including empty values like `""`, `{}`, `[]` — and handle boolean conditionals correctly.
+
+**Why:** uncommented defaults exercise the merging path with the actual default value, surfacing bugs in template logic that would otherwise be hidden by commented-out lines. They also serve as documentation AND as a sanity check that the rendering pipeline handles the default case.
+
+**Exception:** values that should be **conditionally defined** based on another field's value (e.g., a field that's only meaningful when another field has a specific `type`) should remain commented out **if** uncommenting them would change the rendered template output.
+
+**Test for "is this conditional?":** uncomment the value with its default, render the chart, and compare output. If output changes, keep commented. If output is unchanged, leave uncommented.
+
+If uncommenting a default DOES change output but the field isn't conceptually conditional, that's a sign the template logic isn't handling the default gracefully — fix the template, then uncomment.
+
+### Schema and values.yaml stay in sync
+Every value referenced by a template should appear in both `values.yaml` (as a documented default) and `values.schema.json` (with a strict type definition).
+
+Three checks when adding or auditing values:
+1. **Schema covers values.yaml:** every key in `values.yaml` (including commented examples) has a corresponding schema entry.
+2. **Schema covers template usage:** every value referenced from a template (`.Values.foo`, `$.Values.bar`) has a schema entry.
+3. **Schema entries are used:** every property defined in the schema is referenced somewhere in templates. Dead schema entries should be removed.
+
+When a check fails:
+- Missing schema entry → add it with a strict type.
+- Missing values.yaml entry → add a documented default (commented or uncommented per the "Default values left uncommented" rule above).
+- Unused schema entry → remove it (or wire up the template, if the entry was added in anticipation).
+
 ## When testing changes to library charts
 Before running unit tests after modifying a library chart, always run `make update-dependencies` first. Application charts cache library chart `.tgz` files under their `charts/` directory — without a dependency refresh, tests will run against the old cached version and changes will not be picked up.
 
@@ -111,7 +180,21 @@ Before running unit tests after modifying a library chart, always run `make upda
 - Do not update existing tests unless we are reflecting a change to a template related to the test.
 - Ensure `make unit-tests` results in all tests passing before finishing a change.
 
+### Running tests efficiently (Claude/agent guidance)
+When running `make unit-tests` programmatically, redirect output to a scratch file and grep against the file rather than re-running tests just to re-read output. Re-run only after code changes. Use `UPDATE_SNAPSHOTS=1` when snapshots need updating.
+
+```
+make unit-tests > .scratch/unit-test-output.txt 2>&1
+UPDATE_SNAPSHOTS=1 make unit-tests > .scratch/unit-test-output.txt 2>&1
+```
+
+The `.scratch/` directory is gitignored.
+
+This is a recommendation, not a hard rule. If the user hasn't expressed a preference, ask before applying it the first time, and offer to save the answer as a memory so it can become durable across sessions.
+
 ### Unit test structure
 Every test suite must open with a single `Configuration matches entire snapshot` case whose `asserts` contains both `notFailedTemplate: {}` and `matchSnapshot: {}`, in that order, before any feature-specific assertions.
+
+**Exception:** test suites whose entire purpose is to verify a template fails (every `it:` uses `failedTemplate` or similar) are exempt — a `matchSnapshot` baseline cannot be rendered when the template fails. These suites should have a clear name indicating they test a failure case.
 
 helm-unittest re-renders the full chart for every `it:` block, so keep the total number of `it:` blocks in a suite small. Group feature-specific assertions under a single `it:` when they share a theme, and use per-assert `template` and `documentSelector` to target different documents within a group. Only split into a new `it:` when the test needs a different `set` / `values` override, or when splitting genuinely clarifies intent.

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ gha-creds*.json
 bump-result.json
 .claude
 **/.claude
+.scratch
+**/.scratch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,10 @@ The release label applies uniformly to every chart changed in the PR. When a PR 
 
 If the inferred label is wrong, apply the correct one manually from the PR sidebar before merging:
 
-- `major` — significant change warranting a major version increment; often breaking, but not necessarily
-- `minor` — new functionality, backwards compatible
-- `patch` — bug fix or non-functional change
-- `no-release` — merge without bumping or publishing (e.g. docs-only changes)
+- `major`: significant change warranting a major version increment; often breaking, but not necessarily
+- `minor`: new functionality, backwards compatible
+- `patch`: bug fix or non-functional change
+- `no-release`: merge without bumping or publishing (e.g. docs-only changes)
 
 `no-release` takes precedence over any other label. To use it, add `no-release` to the PR. The other labels follow highest-severity-wins: if both `minor` and `patch` are present, `minor` wins. To avoid confusion, remove any label you are replacing rather than adding on top of it.
 
@@ -68,11 +68,11 @@ To bump and publish charts without opening a PR (for example, to cut a hotfix or
 ## Pre-commit hooks
 
 Running `make install` sets up pre-commit hooks that run automatically on commit:
-- **ruff** — formats and lints Python/TOML files (with auto-fix)
-- **helm update dependencies** — runs `make update-dependencies` when chart files change
-- **helm lint** — lints all non-deprecated charts
-- **helm unittest** — runs `make unit-tests-affected` when chart files change
-- **helm-docs** — regenerates `README.md` files from `.gotmpl` templates
+- **ruff**: formats and lints Python/TOML files (with auto-fix)
+- **helm update dependencies**: runs `make update-dependencies` when chart files change
+- **helm lint**: lints all non-deprecated charts
+- **helm unittest**: runs `make unit-tests-affected` when chart files change
+- **helm-docs**: regenerates `README.md` files from `.gotmpl` templates
 
 If a hook fails, address the reported issue before committing. Do not skip hooks.
 
@@ -231,6 +231,23 @@ All application chart schemas in this repo target [JSON Schema draft 2020-12](ht
 
 - **`default`** values in the schema should match the defaults in `values.yaml`. If they diverge, the schema governs validation but `values.yaml` governs rendering. Keep them in sync.
 
+- **Strict typing.** Prefer single-type definitions for fields. Don't introduce new `anyOf`/`oneOf` to let a field accept multiple shapes (e.g., string OR object). Instead, add a new, separately-named field with its own strict type. Existing `anyOf`/`oneOf` usages aren't a sweep-replace target. Leave them unless the surrounding code is being refactored anyway. Exception: when the upstream Kubernetes CRD or resource genuinely accepts multiple types for a field (most commonly number-vs-string, e.g. `IntOrString` types), mirroring that ambiguity with `anyOf`/`oneOf` is acceptable. Validate against the actual CRD definition before going this route.
+
+### Keep schema and values.yaml in sync
+
+Every value referenced by a template should appear in both `values.yaml` (as a documented default) and `values.schema.json` (with a strict type definition). Letting the two files drift causes one of two problems: unrecognized keys silently pass through without validation, or valid keys are rejected with confusing errors. The schema also surfaces documentation in editor tooling (e.g. the VS Code YAML extension), so keeping it accurate and well-described benefits every team using the chart.
+
+Three checks when adding or auditing values:
+
+1. **Schema covers values.yaml.** Every key in `values.yaml` (including commented examples) has a corresponding schema entry.
+2. **Schema covers template usage.** Every value referenced from a template (`.Values.foo`, `$.Values.bar`) has a schema entry.
+3. **Schema entries are used.** Every property defined in the schema is referenced somewhere in templates. Dead schema entries should be removed.
+
+When a check fails:
+- Missing schema entry → add it with a strict type.
+- Missing values.yaml entry → add a documented default (commented or uncommented per [Default values left uncommented](#default-values-left-uncommented)).
+- Unused schema entry → remove it (or wire up the template, if the entry was added in anticipation).
+
 ### What to do when changing values
 
 | Change type | Schema action required |
@@ -283,6 +300,101 @@ Charts that use dict-based collections can designate a **protected key** per col
 All charts that use this pattern designate `default` as the protected key for each collection. A user who defines a workload named `my-service` will automatically inherit all defaults from the `default` entry without having to repeat them.
 
 Avoid naming your objects `default`, as that entry is treated as a defaults template rather than a real object (unless it is the only entry in the collection).
+
+### Sibling key ordering in values.yaml and values.schema.json
+
+At every nesting level in `values.yaml` and `values.schema.json`, sibling keys should be ordered alphabetically, with **priority keys** floated to the top of their block in this order:
+
+1. **Gates**: keys that turn the block on/off: `enabled`, `create`.
+2. **Discriminators**: keys whose value determines which other fields apply: `type`, `provider` (under `cloud`).
+3. **Merge sources**: `default` (the protected key in dict-based collections; see [Protected default keys](#protected-default-keys)).
+
+Priority keys are gates, discriminators, or merge sources — keys whose value determines whether the block is active or which other keys apply. New keys that fit one of those shapes (e.g., a future `kind`, `mode`, or `api` field that gates or discriminates) should be treated as priority keys too.
+
+When inserting a new key:
+
+- If it's a priority key, place it at the top in the order above.
+- Otherwise, slot it into the correct alphabetical position among non-priority siblings.
+- Don't silently re-sort an existing block whose neighbors are already non-alphabetical, unless that's the intentional scope of your change.
+
+This rule does not apply to ordered constructs (`enum:` arrays, ordered lists), `Chart.yaml` (Helm-prescribed order), or test fixtures.
+
+### Default values left uncommented
+
+Prefer to leave default values **uncommented** in `values.yaml`. The chart's template logic should gracefully evaluate defaults (including empty values like `""`, `{}`, `[]`) and handle boolean conditionals correctly.
+
+Uncommented defaults allow Helm to merge user-provided values with the actual default value, surfacing bugs in template logic that would otherwise be hidden by commented-out lines. They also serve as documentation and as a sanity check that the rendering pipeline handles the default case.
+
+**Exception:** values that should be **conditionally defined** based on another field's value (e.g., a field that's only meaningful when another field has a specific `type`) should remain commented out **if** uncommenting them would change the rendered template output.
+
+The test for "_is this conditional?_": uncomment the value with its default, render the chart, and compare output. If output changes, keep commented. If output is unchanged, leave uncommented.
+
+If uncommenting a default changes output but the field isn't conceptually conditional, that's a sign the template logic isn't handling the default gracefully. Fix the template, then uncomment.
+
+### Helper organization
+
+Helper templates and named templates live in shared files within a chart's `templates/` directory:
+
+- **`_helpers.tpl`**: pure Go template helpers: utility functions, name generators, and logic that doesn't produce YAML directly.
+- **`_*.yaml`** (e.g. `_pod.yaml`, `_formatter.yaml`, `_annotations.yaml`, `_labels.yaml`): named templates that produce YAML structure or rely heavily on Helm template syntax.
+
+**Single-use helpers should be inlined** in the template that uses them. Only extract a helper when it's reused across templates.
+
+#### Helper naming conventions
+
+Where a helper lives determines its prefix:
+
+| Location | Prefix | Example |
+|---|---|---|
+| `templates/_helpers.tpl` | `mozcloud.` | `mozcloud.name`, `mozcloud.fullname` |
+| `templates/<subdir>/_helpers.tpl` | `mozcloud.<subdir>.` | `mozcloud.configMap.<name>`, `mozcloud.preview.<name>` |
+| `templates/_pod.yaml` | `pod.` | `pod.container.<name>` |
+| `templates/_formatter.yaml` | `mozcloud.formatter.` | `mozcloud.formatter.workloads` |
+
+Library charts use their own root prefix (e.g. `mozcloud-gateway-lib.<name>`).
+
+#### Documenting helpers
+
+Every helper should have a JSDoc-style comment block immediately above its definition:
+
+```
+{{- /*
+Brief description of what the helper does.
+
+Params:
+  paramName (type): (required/optional) Description.
+
+Returns:
+  (type) Description of the return value.
+*/ -}}
+```
+
+If a helper takes no params or returns nothing, omit those sections rather than writing "None".
+
+#### Parameter naming
+
+Function parameters should use `config` as the standard name across helpers. Avoid uniquely named parameters like `jobConfig` or `workloadConfig`. These make helpers harder to compose and obscure the fact that the same shape is being passed around.
+
+### Reading optional values: prefer `default` over `dig`
+
+When reading an optional value from a dict, use Helm's `default` function:
+
+```
+{{- $port := default 8080 $container.port -}}
+```
+
+Use `dig` only when:
+
+1. You need to traverse a nested key chain that may have absent intermediate keys: `dig "otel" "enabled" true $config`.
+2. A falsy value (empty string, `false`, `0`) is a meaningful signal that must be honored, not coerced back to the fallback. For example, `prefix: ""` to disable a default prefix:
+
+   ```
+   {{- $prefix := dig "prefix" "pr-" $config -}}
+   ```
+
+   Here, `$config.prefix: ""` (intentionally disabling the prefix) is preserved. `default "pr-" $config.prefix` would incorrectly fall back to `"pr-"`.
+
+Avoid the `if hasKey ... then read` pattern; collapse it into a single `dig` call. `hasKey` is still appropriate when you genuinely need the boolean "was the key set?" for branching logic (rare).
 
 ---
 


### PR DESCRIPTION
## Description
This PR updates the `chart-standards` Claude Code skill to include learnings and preferences we've saved as we've developed within this repo and expands `CONTRIBUTING.md` with the contributor-facing subset of those conventions. The skill is invoked automatically when Claude is contributing to chart code in this repo.

Changes:
  - Updates `.claude/skills/chart-standards/SKILL.md`
    - Helper organization: file types (`_helpers.tpl` vs `_*.yaml`), prefix conventions (`mozcloud.<name>`, `mozcloud.<subdir>.<name>`, library prefixes), JSDoc-style helper comments, `config` parameter naming
    - Values authoring: sibling key ordering (priority gates/discriminators/merge-sources), default values left uncommented (with conditional carve-out), schema/`values.yaml` sync via 3 checks
    - Schema authoring: strict typing (no `anyOf`/`oneOf` for multi-shape fields, with CRD exception for `IntOrString` types)
    - Reading optional values: prefer `default` over `dig`; use `dig` only when traversing nested keys or when falsy values must be honored
    - Test structure: `Configuration matches entire snapshot` baseline first, with `notFailedTemplate` and `matchSnapshot` asserts; failure-only suites exempted
    - Writing style: `NGINX` in product/brand prose; lowercase `nginx` for literal values, config blocks, sidecars, and Kubernetes resource names
    - Agent-behavior rules: narrate before approval prompts; recommend `.scratch/` redirect-and-grep when running tests
  - Expands `CONTRIBUTING.md` with the contributor-facing subset of these standards
    - Adds **Strict typing** under `Schema conventions`
    - Replaces the existing 1-line schema/`values.yaml` sync rule with a fuller `Keep schema and values.yaml in sync` subsection (3-check approach: schema covers `values.yaml`, schema covers template usage, schema entries are used)
    - Adds 4 new subsections under `General chart authoring standards`: sibling key ordering, default values left uncommented, helper organization, reading optional values
    - Omits the NGINX writing convention (kept skill-only)
  - Adds `.scratch` and `**/.scratch` to `.gitignore` for ephemeral agent scratch files

## Related Tickets & Documents
* MZCLD-2972
