### PR TITLE
feat!(mozcloud): hosts.*.backends list => dict, now also handles ingress backends

### DIFF
--- a/mozcloud-gateway/library/templates/_helpers.tpl
+++ b/mozcloud-gateway/library/templates/_helpers.tpl
@@ -100,18 +100,23 @@ BackendPolicy template helpers
   {{- if or $backend.backendPolicy $backend_policy }}
   {{- $backend_policy_config := dict -}}
   {{- /* Merge service backend policy, default backend policy, and library defaults */ -}}
-  {{- $default_policy := mergeOverwrite ($defaults | deepCopy) $backend_policy -}}
+  {{- $default_policy := mergeOverwrite (deepCopy $defaults) $backend_policy -}}
   {{- $service_policy := default (dict) $backend.backendPolicy -}}
   {{- $merged_policy := mergeOverwrite $default_policy $service_policy -}}
   {{- if and (($merged_policy).sessionAffinity).type (ne (($merged_policy).sessionAffinity).type "GENERATED_COOKIE") -}}
     {{- $_ := unset $merged_policy.sessionAffinity "cookieTtlSec" -}}
   {{- end -}}
   {{- $_ := set $backend_policy_config "config" $merged_policy -}}
+  {{- /* Policy keeps the backend dict-key name; targetService points at the
+     resolved Service name so the targetRef stays correct when the Service is
+     renamed via $backend.service.name. */ -}}
+  {{- $service_name := default $name ($backend.service).name -}}
   {{- if $name_override -}}
     {{- $name = $name_override -}}
+    {{- $service_name = $name_override -}}
   {{- end -}}
   {{- $_ = set $backend_policy_config "name" $name -}}
-  {{- $_ = set $backend_policy_config "targetService" $name -}}
+  {{- $_ = set $backend_policy_config "targetService" $service_name -}}
   {{- /* Generate labels */ -}}
   {{- $label_params := dict "labels" (default (dict) $backend.labels) -}}
   {{- $labels := include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml -}}
@@ -218,17 +223,21 @@ HealthCheckPolicy template helpers
   {{- $health_check_policy_config := dict -}}
   {{- /* Configure health check spec */ -}}
   {{- $backend_health_check_policy := default (dict) $backend.healthCheck -}}
-  {{- $config := mergeOverwrite ($defaults | deepCopy) $backend_health_check_policy -}}
+  {{- $config := mergeOverwrite (deepCopy $defaults) $backend_health_check_policy -}}
   {{- $_ := set $config "protocol" (upper $config.protocol) -}}
   {{- $protocol_property := include "mozcloud-gateway-lib.defaults.healthCheckPolicy.protocolProperty" . | fromYaml -}}
   {{- $_ = set $config "protocolProperty" (index $protocol_property $config.protocol) -}}
   {{- $_ = set $health_check_policy_config "config" $config -}}
-  {{- /* Use name helper function to populate name and targetService using rules hierarchy */ -}}
+  {{- /* Policy keeps the backend dict-key name; targetService points at the
+     resolved Service name so the targetRef stays correct when the Service is
+     renamed via $backend.service.name. */ -}}
+  {{- $service_name := default $name ($backend.service).name -}}
   {{- if $name_override -}}
     {{- $name = $name_override -}}
+    {{- $service_name = $name_override -}}
   {{- end -}}
   {{- $_ = set $health_check_policy_config "name" $name -}}
-  {{- $_ = set $health_check_policy_config "targetService" $name -}}
+  {{- $_ = set $health_check_policy_config "targetService" $service_name -}}
   {{- /* Generate labels */ -}}
   {{- $label_params := dict "labels" (default (dict) $backend.labels) -}}
   {{- $labels := include "mozcloud-gateway-lib.labels" (mergeOverwrite ($ | deepCopy) $label_params) | fromYaml -}}
@@ -315,18 +324,20 @@ Service template helpers
   {{- if $backend.service }}
   {{- $defaults := include "mozcloud-gateway-lib.defaults.service.config" . | fromYaml -}}
   {{- $service_config := dict -}}
-  {{- $backend_service := $backend.service | deepCopy -}}
+  {{- $backend_service := deepCopy $backend.service -}}
   {{- /* Only create the service if "create" is not "false" */ -}}
   {{- $create_service := (include "mozcloud-gateway-lib.defaults.service.config" . | fromYaml).create -}}
   {{- if hasKey $backend_service "create" -}}
     {{- $create_service = $backend_service.create -}}
   {{- end -}}
   {{- $_ := set $service_config "create" $create_service -}}
-  {{- /* Use name helper function to populate name using rules hierarchy */ -}}
+  {{- /* Resolve the Service resource name: prefer service.name, fall back to
+     the backend dict key. nameOverride wins over both. */ -}}
+  {{- $service_name := default $name $backend_service.name -}}
   {{- if $name_override -}}
-    {{- $name := $name_override -}}
+    {{- $service_name = $name_override -}}
   {{- end -}}
-  {{- $_ = set $service_config "fullnameOverride" $name -}}
+  {{- $_ = set $service_config "fullnameOverride" $service_name -}}
   {{- /* Include annotations, if specified */ -}}
   {{- if $backend_service.annotations -}}
     {{- $_ := set $service_config "annotations" $backend_service.annotations -}}

--- a/mozcloud-ingress/library/templates/_helpers.tpl
+++ b/mozcloud-ingress/library/templates/_helpers.tpl
@@ -102,16 +102,21 @@ BackendConfig template helpers
 {{- range $ingress := $ingresses.ingresses -}}
   {{- range $host := $ingress.hosts -}}
     {{- range $path := $host.paths -}}
-      {{- $backend := mergeOverwrite $defaults (default (dict) $path.backend.config) -}}
+      {{- $backend := mergeOverwrite (deepCopy $defaults) (default (dict) $path.backend.config) -}}
       {{- if kindIs "string" $backend.securityPolicy -}}
         {{- $_ := set $backend "securityPolicy" (dict "name" $backend.securityPolicy) -}}
       {{- end -}}
-      {{/* If a backend name is not specified, use the service name for the backend */}}
-      {{- $params := mergeOverwrite $context (dict "backendConfig" $backend "ingressConfig" $ingress "backendService" $path.backend.service) -}}
+      {{- /* Build $params via direct set (not mergeOverwrite) so reassigning
+         backendConfig replaces the reference instead of recursively merging
+         into the previous iteration's $backend. */ -}}
+      {{- $params := deepCopy $context -}}
+      {{- $_ := set $params "backendConfig" $backend -}}
+      {{- $_ = set $params "ingressConfig" $ingress -}}
+      {{- $_ = set $params "backendService" $path.backend.service -}}
       {{- if $name_override -}}
         {{- $_ := set $params "nameOverride" $name_override -}}
       {{- end -}}
-      {{- $backend_name := include "mozcloud-ingress-lib.config.backend.name" $params -}}
+      {{- $backend_name := include "mozcloud-ingress-lib.config.backendConfig.name" $params -}}
       {{- $_ := set $backend "name" $backend_name -}}
       {{- $_ = set $backend "ingressConfig" (omit $ingress "hosts") -}}
       {{- $backends = append $backends $backend -}}
@@ -122,11 +127,49 @@ backends:
   {{ $backends | toYaml | nindent 2 }}
 {{- end -}}
 
-{{- define "mozcloud-ingress-lib.config.backend.name" -}}
-{{- if (.backendService).name -}}
+{{- /*
+Resolve the BackendConfig resource name. Prefers backendConfig.name, falls
+back to backendService.name (legacy callers that only set the service name),
+then to the chart fullname. The cloud.google.com/backend-config annotation on
+the generated Service uses this same value so the binding always points at
+the BackendConfig this library renders.
+
+Params:
+  backendConfig (dict):  (optional) BackendConfig spec from path.backend.config.
+  backendService (dict): (optional) Service spec from path.backend.service.
+  nameOverride (string): (optional) Forwarded to mozcloud-ingress-lib.config.name.
+
+Returns:
+  (string) Resolved BackendConfig resource name.
+*/ -}}
+{{- define "mozcloud-ingress-lib.config.backendConfig.name" -}}
+{{- if (.backendConfig).name -}}
+{{- include "mozcloud-ingress-lib.config.name" (dict "name" .backendConfig.name) }}
+{{- else if (.backendService).name -}}
 {{- include "mozcloud-ingress-lib.config.name" (dict "name" .backendService.name) }}
 {{- else -}}
 {{- include "mozcloud-ingress-lib.config.name" . }}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+Resolve the Service resource name. Prefers backendService.name, falls back
+to the resolved BackendConfig name so single-name configurations continue to
+produce a Service and BackendConfig that share a name.
+
+Params:
+  backendConfig (dict):  (optional) BackendConfig spec from path.backend.config.
+  backendService (dict): (optional) Service spec from path.backend.service.
+  nameOverride (string): (optional) Forwarded to mozcloud-ingress-lib.config.name.
+
+Returns:
+  (string) Resolved Service resource name.
+*/ -}}
+{{- define "mozcloud-ingress-lib.config.service.name" -}}
+{{- if (.backendService).name -}}
+{{- include "mozcloud-ingress-lib.config.name" (dict "name" .backendService.name) }}
+{{- else -}}
+{{- include "mozcloud-ingress-lib.config.backendConfig.name" . }}
 {{- end -}}
 {{- end -}}
 
@@ -282,16 +325,16 @@ Service template helpers
       {{- if $name_override -}}
         {{- $_ := set $params "nameOverride" $name_override -}}
       {{- end -}}
-      {{- $service_name := include "mozcloud-ingress-lib.config.backend.name" $params -}}
-      {{- /* Check if service was already included. If so, skip to avoid duplicates. */}}
-      {{- /* Configure args for library chart */}}
-      {{- /* Service annotations */}}
-      {{- /* This allows users to explicitly specify "false" without overriding with "true" from defaults */}}
+      {{- $service_name := include "mozcloud-ingress-lib.config.service.name" $params -}}
+      {{- $backend_config_name := include "mozcloud-ingress-lib.config.backendConfig.name" $params -}}
       {{- $create_neg := (include "mozcloud-ingress-lib.defaults.service.config" . | fromYaml).createNeg -}}
       {{- if hasKey $backend_service "createNeg" -}}
         {{- $create_neg = $backend_service.createNeg -}}
       {{- end -}}
-      {{- $annotation_params := dict "backendName" $service_name "createNeg" $create_neg "provider" (default "gke" $context.provider) -}}
+      {{- /* The cloud.google.com/backend-config annotation must point at the
+         BackendConfig resource — never the Service. When service.name and
+         config.name diverge, the binding still resolves correctly. */}}
+      {{- $annotation_params := dict "backendName" $backend_config_name "createNeg" $create_neg "provider" (default "gke" $context.provider) -}}
       {{- if $ingress.annotations -}}
         {{- $_ := set $annotation_params "annotations" $ingress.annotations -}}
       {{- end -}}

--- a/mozcloud-ingress/library/templates/_ingress.yaml
+++ b/mozcloud-ingress/library/templates/_ingress.yaml
@@ -82,7 +82,7 @@ spec:
       {{- if $name_override }}
       {{- $_ := set $params "nameOverride" $name_override }}
       {{- end }}
-      name: {{ include "mozcloud-ingress-lib.config.backend.name" $params }}
+      name: {{ include "mozcloud-ingress-lib.config.service.name" $params }}
       port:
         number: {{ $backend_service.port }}
   {{- end }}
@@ -105,7 +105,7 @@ spec:
                   {{- if $name_override }}
                   {{- $_ := set $params "nameOverride" $name_override }}
                   {{- end }}
-                  name: {{ include "mozcloud-ingress-lib.config.backend.name" $params }}
+                  name: {{ include "mozcloud-ingress-lib.config.service.name" $params }}
                   port:
                     number: {{ $backend_service.port }}
             {{- end }}

--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -158,6 +158,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.enabled | bool | `true` |  |
 | workloads.default.hosts.default.addresses | list | `[]` |  |
 | workloads.default.hosts.default.api | string | `"gateway"` |  |
+| workloads.default.hosts.default.backends | object | `{}` |  |
 | workloads.default.hosts.default.domains[0] | string | `"example.com"` |  |
 | workloads.default.hosts.default.httpRoutes.createHttpRoutes | bool | `true` |  |
 | workloads.default.hosts.default.servicePort | int | `8080` |  |

--- a/mozcloud/application/templates/gateway/backend.yaml
+++ b/mozcloud/application/templates/gateway/backend.yaml
@@ -26,6 +26,10 @@ Returns:
 {{- define "mozcloud.gateway.backends" -}}
 {{- $workloads := .workloads -}}
 {{- $provider := index (index .Values "cloud" | default dict) "provider" | default "gke" -}}
+{{- /* Default LB health check path mirrors the chart's default container
+   readiness probe path so both probe systems agree on the same endpoint
+   unless the user overrides either. */ -}}
+{{- $defaultHealthCheckPath := .Values.workloads.default.containers.default.healthCheck.readiness.path -}}
 backends:
   {{- range $workloadName, $workloadConfig := $workloads }}
   {{- range $hostName, $hostConfig := default dict $workloadConfig.hosts }}
@@ -40,6 +44,9 @@ backends:
     {{- end }}
     {{- if and $backendConfig.backendPolicy (eq $provider "gke") }}
     backendPolicy:
+      {{- /* targetRef is optional. When omitted, the library auto-populates a
+         targetRef referencing the resolved Service name. */}}
+      {{- if $backendConfig.backendPolicy.targetRef }}
       targetRef:
         {{- if and $backendConfig.backendPolicy.targetRef.kind (eq $backendConfig.backendPolicy.targetRef.kind "ServiceImport" )}}
         {{- $_ := set $backendConfig.backendPolicy.targetRef "group" "net.gke.io" }}
@@ -47,16 +54,20 @@ backends:
         group: {{ default "" $backendConfig.backendPolicy.targetRef.group | quote }}
         kind: {{ $backendConfig.backendPolicy.targetRef.kind }}
         name: {{ $backendConfig.backendPolicy.targetRef.name }}
+      {{- end }}
     {{- end }}
     {{- if and $backendConfig.healthCheck (eq $provider "gke") }}
     healthCheck:
-      path: {{ $backendConfig.healthCheck.path }}
+      path: {{ default $defaultHealthCheckPath $backendConfig.healthCheck.path }}
       {{- if ($backendConfig.healthCheck).port }}
       port: {{ $backendConfig.healthCheck.port }}
       {{- end }}
       {{- if ($backendConfig.healthCheck).host }}
       host: {{ $backendConfig.healthCheck.host }}
       {{- end }}
+      {{- /* targetRef is optional. When omitted, the library auto-populates a
+         targetRef referencing the resolved Service name. */}}
+      {{- if $backendConfig.healthCheck.targetRef }}
       targetRef:
         {{- if and $backendConfig.healthCheck.targetRef.kind (eq $backendConfig.healthCheck.targetRef.kind "ServiceImport" )}}
         {{- $_ := set $backendConfig.healthCheck.targetRef "group" "net.gke.io" }}
@@ -64,6 +75,7 @@ backends:
         group: {{ default "" $backendConfig.healthCheck.targetRef.group | quote }}
         kind: {{ default "Service" $backendConfig.healthCheck.targetRef.kind }}
         name: {{ $backendConfig.healthCheck.targetRef.name }}
+      {{- end }}
     {{- end }}
   {{- end }}
   {{- else }}
@@ -109,9 +121,9 @@ backends:
       {{- if (($hostConfig.options).healthCheck).path }}
       path: {{ $hostConfig.options.healthCheck.path }}
       {{- else if kindIs "string" (($hostConfig).healthCheckEndpoints).loadBalancer }}
-      path: {{ default "/__lbheartbeat__" (($hostConfig).healthCheckEndpoints).loadBalancer }}
+      path: {{ default $defaultHealthCheckPath (($hostConfig).healthCheckEndpoints).loadBalancer }}
       {{- else if kindIs "map" (($hostConfig).healthCheckEndpoints).loadBalancer }}
-      path: {{ default "/__lbheartbeat__" ($hostConfig.healthCheckEndpoints.loadBalancer).path }}
+      path: {{ default $defaultHealthCheckPath ($hostConfig.healthCheckEndpoints.loadBalancer).path }}
       {{- end }}
       protocol: HTTP
     {{- end }}

--- a/mozcloud/application/templates/gateway/backend.yaml
+++ b/mozcloud/application/templates/gateway/backend.yaml
@@ -34,7 +34,13 @@ backends:
   {{- range $workloadName, $workloadConfig := $workloads }}
   {{- range $hostName, $hostConfig := default dict $workloadConfig.hosts }}
   {{- if $hostConfig.backends }}
-  {{- range $backendName, $backendConfig := $hostConfig.backends }}
+  {{- $enabledBackends := dict }}
+  {{- range $name, $config := $hostConfig.backends }}
+    {{- if dig "enabled" true $config }}
+      {{- $_ := set $enabledBackends $name $config }}
+    {{- end }}
+  {{- end }}
+  {{- range $backendName, $backendConfig := $enabledBackends }}
   {{ $backendName }}:
     component: {{ $workloadConfig.component }}
     api: {{ default "gateway" $hostConfig.api }}
@@ -42,7 +48,7 @@ backends:
     service:
       {{- $backendConfig.service | toYaml | nindent 6 }}
     {{- end }}
-    {{- if and $backendConfig.backendPolicy (eq $provider "gke") }}
+    {{- if and $backendConfig.backendPolicy (eq $provider "gke") (dig "enabled" true $backendConfig.backendPolicy) }}
     backendPolicy:
       {{- /* targetRef is optional. When omitted, the library auto-populates a
          targetRef referencing the resolved Service name. */}}
@@ -56,7 +62,7 @@ backends:
         name: {{ $backendConfig.backendPolicy.targetRef.name }}
       {{- end }}
     {{- end }}
-    {{- if and $backendConfig.healthCheck (eq $provider "gke") }}
+    {{- if and $backendConfig.healthCheck (eq $provider "gke") (dig "enabled" true $backendConfig.healthCheck) }}
     healthCheck:
       path: {{ default $defaultHealthCheckPath $backendConfig.healthCheck.path }}
       {{- if ($backendConfig.healthCheck).port }}

--- a/mozcloud/application/templates/gateway/backend.yaml
+++ b/mozcloud/application/templates/gateway/backend.yaml
@@ -4,8 +4,11 @@ mozcloud-gateway-lib library chart. For each workload host, produces backend
 entries that drive Service, BackendPolicy, and HealthCheckPolicy resource
 generation.
 
-When a host defines explicit "backends" entries, those are used as-is with
-optional backendPolicy and healthCheck overrides. When no explicit backends are
+When a host defines explicit "backends" entries (a dict keyed by backend name),
+each entry's key becomes the resource name for the Service, BackendPolicy, and
+HealthCheckPolicy. Entries may optionally set service, backendPolicy, and
+healthCheck overrides; an empty entry (`my-backend: {}`) renames the default
+resources without otherwise changing behavior. When no explicit backends are
 defined, a default backend is generated for the workload with:
   - A Service on port 8080.
   - A BackendPolicy with access logging enabled (and optional IAP, sample rate,
@@ -27,40 +30,40 @@ backends:
   {{- range $workloadName, $workloadConfig := $workloads }}
   {{- range $hostName, $hostConfig := default dict $workloadConfig.hosts }}
   {{- if $hostConfig.backends }}
-  {{- range $backend := (default list $hostConfig.backends) }}
-  {{ $backend.name }}:
+  {{- range $backendName, $backendConfig := $hostConfig.backends }}
+  {{ $backendName }}:
     component: {{ $workloadConfig.component }}
     api: {{ default "gateway" $hostConfig.api }}
-    {{- if $backend.service }}
+    {{- if $backendConfig.service }}
     service:
-      {{- $backend.service | toYaml | nindent 6 }}
+      {{- $backendConfig.service | toYaml | nindent 6 }}
     {{- end }}
-    {{- if and $backend.backendPolicy (eq $provider "gke") }}
+    {{- if and $backendConfig.backendPolicy (eq $provider "gke") }}
     backendPolicy:
       targetRef:
-        {{- if and $backend.backendPolicy.targetRef.kind (eq $backend.backendPolicy.targetRef.kind "ServiceImport" )}}
-        {{- $_ := set $backend.backendPolicy.targetRef "group" "net.gke.io" }}
+        {{- if and $backendConfig.backendPolicy.targetRef.kind (eq $backendConfig.backendPolicy.targetRef.kind "ServiceImport" )}}
+        {{- $_ := set $backendConfig.backendPolicy.targetRef "group" "net.gke.io" }}
         {{- end }}
-        group: {{ default "" $backend.backendPolicy.targetRef.group | quote }}
-        kind: {{ $backend.backendPolicy.targetRef.kind }}
-        name: {{ $backend.backendPolicy.targetRef.name }}
+        group: {{ default "" $backendConfig.backendPolicy.targetRef.group | quote }}
+        kind: {{ $backendConfig.backendPolicy.targetRef.kind }}
+        name: {{ $backendConfig.backendPolicy.targetRef.name }}
     {{- end }}
-    {{- if and $backend.healthCheck (eq $provider "gke") }}
+    {{- if and $backendConfig.healthCheck (eq $provider "gke") }}
     healthCheck:
-      path: {{ $backend.healthCheck.path }}
-      {{- if ($backend.healthCheck).port }}
-      port: {{ $backend.healthCheck.port }}
+      path: {{ $backendConfig.healthCheck.path }}
+      {{- if ($backendConfig.healthCheck).port }}
+      port: {{ $backendConfig.healthCheck.port }}
       {{- end }}
-      {{- if ($backend.healthCheck).host }}
-      host: {{ $backend.healthCheck.host }}
+      {{- if ($backendConfig.healthCheck).host }}
+      host: {{ $backendConfig.healthCheck.host }}
       {{- end }}
       targetRef:
-        {{- if and $backend.healthCheck.targetRef.kind (eq $backend.healthCheck.targetRef.kind "ServiceImport" )}}
-        {{- $_ := set $backend.healthCheck.targetRef "group" "net.gke.io" }}
+        {{- if and $backendConfig.healthCheck.targetRef.kind (eq $backendConfig.healthCheck.targetRef.kind "ServiceImport" )}}
+        {{- $_ := set $backendConfig.healthCheck.targetRef "group" "net.gke.io" }}
         {{- end }}
-        group: {{ default "" $backend.healthCheck.targetRef.group | quote }}
-        kind: {{ default "Service" $backend.healthCheck.targetRef.kind }}
-        name: {{ $backend.healthCheck.targetRef.name }}
+        group: {{ default "" $backendConfig.healthCheck.targetRef.group | quote }}
+        kind: {{ default "Service" $backendConfig.healthCheck.targetRef.kind }}
+        name: {{ $backendConfig.healthCheck.targetRef.name }}
     {{- end }}
   {{- end }}
   {{- else }}

--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -33,6 +33,24 @@ ingresses:
   {{- range $workloadName, $workloadConfig := $workloads }}
   {{- range $hostName, $hostConfig := default dict $workloadConfig.hosts }}
   {{- if eq $hostConfig.type "external" }}
+  {{- /* When hosts.<host>.backends is set, each dict key becomes the Service /
+     BackendConfig name and the cloud.google.com/backend-config annotation
+     reference. When backends is unset, fall back to a single default entry
+     named after the workload. */}}
+  {{- $backends := default (dict $workloadName (dict)) $hostConfig.backends }}
+  {{- /* Reject duplicate (path, pathType) tuples up front. Kubernetes does not
+     enforce uniqueness; GKE silently routes duplicates non-deterministically. */}}
+  {{- if gt (len $backends) 1 }}
+    {{- $paths := list }}
+    {{- range $name, $cfg := $backends }}
+      {{- $path := default "/" $cfg.path }}
+      {{- $pathType := default "Prefix" $cfg.pathType }}
+      {{- $paths = append $paths (printf "%s|%s" $path $pathType) }}
+    {{- end }}
+    {{- if ne (len $paths) (len (uniq $paths)) }}
+      {{- fail (printf "hosts.%s.backends contains duplicate (path, pathType) entries; each backend on a single host must have a unique path/pathType combination." $hostName) }}
+    {{- end }}
+  {{- end }}
   {{ $hostName }}:
     component: {{ $workloadConfig.component }}
     hosts:
@@ -41,11 +59,18 @@ ingresses:
           - {{ $domain | quote }}
           {{- end }}
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range $backendName, $backendConfig := $backends }}
+          {{- $backendService := default dict $backendConfig.service }}
+          {{- $serviceName := default $backendName $backendService.name }}
+          {{- $port := default $hostConfig.servicePort $backendService.port }}
+          {{- $targetPort := $backendService.targetPort | default $hostConfig.targetPort | default "http" }}
+          {{- $path := default "/" $backendConfig.path }}
+          {{- $pathType := default "Prefix" $backendConfig.pathType }}
+          - path: {{ $path }}
+            pathType: {{ $pathType }}
             backend:
               config:
-                name: {{ $workloadName }}
+                name: {{ $backendName }}
                 {{- if (($hostConfig.options).iap).enabled }}
                 iap:
                   enabled: {{ $hostConfig.options.iap.enabled }}
@@ -62,10 +87,11 @@ ingresses:
                 securityPolicy: {{ $hostConfig.options.securityPolicy }}
                 {{- end }}
               service:
-                name: {{ $workloadName }}
-                port: {{ $hostConfig.servicePort }}
+                name: {{ $serviceName }}
+                port: {{ $port }}
                 protocol: TCP
-                targetPort: {{ include "mozcloud.portName" (dict "name" (default "http" $hostConfig.targetPort)) }}
+                targetPort: {{ include "mozcloud.portName" (dict "name" $targetPort) }}
+          {{- end }}
         tls:
           {{- $type := ($hostConfig.tls.type) }}
           {{- if or (not $type) (eq $type "certmap") }}

--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -38,13 +38,22 @@ ingresses:
      reference. When backends is unset, fall back to a single default entry
      named after the workload. */}}
   {{- $backends := default (dict $workloadName (dict)) $hostConfig.backends }}
+  {{- /* Filter out backends with enabled: false so they are skipped during
+     rendering and the duplicate-path check. */}}
+  {{- $enabledBackends := dict }}
+  {{- range $name, $config := $backends }}
+    {{- if dig "enabled" true $config }}
+      {{- $_ := set $enabledBackends $name $config }}
+    {{- end }}
+  {{- end }}
+  {{- $backends = $enabledBackends }}
   {{- /* Reject duplicate (path, pathType) tuples up front. Kubernetes does not
      enforce uniqueness; GKE silently routes duplicates non-deterministically. */}}
   {{- if gt (len $backends) 1 }}
     {{- $paths := list }}
-    {{- range $name, $cfg := $backends }}
-      {{- $path := default "/" $cfg.path }}
-      {{- $pathType := default "Prefix" $cfg.pathType }}
+    {{- range $name, $config := $backends }}
+      {{- $path := default "/" $config.path }}
+      {{- $pathType := default "Prefix" $config.pathType }}
       {{- $paths = append $paths (printf "%s|%s" $path $pathType) }}
     {{- end }}
     {{- if ne (len $paths) (len (uniq $paths)) }}

--- a/mozcloud/application/tests/__snapshot__/gateway-divergent-service-name-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/gateway-divergent-service-name-configuration_test.yaml.snap
@@ -1,0 +1,55 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: divergent-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP
+  2: |
+    apiVersion: networking.gke.io/v1
+    kind: HealthCheckPolicy
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: divergent-backend
+    spec:
+      default:
+        config:
+          httpHealthCheck:
+            port: 8080
+            requestPath: /readiness/
+          type: HTTP
+      targetRef:
+        group: ""
+        kind: Service
+        name: divergent-service

--- a/mozcloud/application/tests/__snapshot__/ingress-multi-backend-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/ingress-multi-backend-configuration_test.yaml.snap
@@ -1,0 +1,160 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: api-backend
+    spec:
+      logging:
+        enable: true
+        sampleRate: 0.1
+  2: |
+    apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: ui-backend
+    spec:
+      logging:
+        enable: true
+        sampleRate: 0.1
+  3: |
+    apiVersion: networking.gke.io/v1
+    kind: ManagedCertificate
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: multi-backend-dev-test-domain-com
+    spec:
+      domains:
+        - multi-backend.dev.test-domain.com
+  4: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: gce
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
+        networking.gke.io/managed-certificates: multi-backend-dev-test-domain-com
+        networking.gke.io/v1beta1.FrontendConfig: multi-backend-host
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: multi-backend-host
+    spec:
+      rules:
+        - host: multi-backend.dev.test-domain.com
+          http:
+            paths:
+              - backend:
+                  service:
+                    name: api-backend
+                    port:
+                      number: 8000
+                path: /api
+                pathType: Prefix
+              - backend:
+                  service:
+                    name: ui-backend
+                    port:
+                      number: 3000
+                path: /
+                pathType: Prefix
+  5: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/backend-config: '{"default": "api-backend"}'
+        cloud.google.com/neg: '{"ingress": true}'
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: api-backend
+    spec:
+      ports:
+        - name: http
+          port: 8000
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP
+  6: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/backend-config: '{"default": "ui-backend"}'
+        cloud.google.com/neg: '{"ingress": true}'
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: ui-backend
+    spec:
+      ports:
+        - name: http
+          port: 3000
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP

--- a/mozcloud/application/tests/__snapshot__/ingress-named-backend-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/ingress-named-backend-configuration_test.yaml.snap
@@ -1,0 +1,193 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: divergent-backend
+    spec:
+      logging:
+        enable: true
+        sampleRate: 0.1
+  2: |
+    apiVersion: networking.gke.io/v1
+    kind: ManagedCertificate
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: divergent-dev-test-domain-com
+    spec:
+      domains:
+        - divergent.dev.test-domain.com
+  3: |
+    apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: same-name-backend
+    spec:
+      logging:
+        enable: true
+        sampleRate: 0.1
+  4: |
+    apiVersion: networking.gke.io/v1
+    kind: ManagedCertificate
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: same-name-dev-test-domain-com
+    spec:
+      domains:
+        - same-name.dev.test-domain.com
+  5: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: gce
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
+        networking.gke.io/managed-certificates: divergent-dev-test-domain-com
+        networking.gke.io/v1beta1.FrontendConfig: divergent-host
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: divergent-host
+    spec:
+      defaultBackend:
+        service:
+          name: divergent-service
+          port:
+            number: 9000
+  6: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/backend-config: '{"default": "divergent-backend"}'
+        cloud.google.com/neg: '{"ingress": true}'
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: divergent-service
+    spec:
+      ports:
+        - name: http
+          port: 9000
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP
+  7: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: gce
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
+        networking.gke.io/managed-certificates: same-name-dev-test-domain-com
+        networking.gke.io/v1beta1.FrontendConfig: same-name-host
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: same-name-host
+    spec:
+      defaultBackend:
+        service:
+          name: same-name-backend
+          port:
+            number: 8080
+  8: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/backend-config: '{"default": "same-name-backend"}'
+        cloud.google.com/neg: '{"ingress": true}'
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: same-name-backend
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP

--- a/mozcloud/application/tests/gateway-divergent-service-name-configuration_test.yaml
+++ b/mozcloud/application/tests/gateway-divergent-service-name-configuration_test.yaml
@@ -1,0 +1,56 @@
+---
+suite: "mozcloud: Gateway divergent service name configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+# By overriding the chart version, we are preventing the labels chart from
+# updating the mozcloud_chart_version label for every snapshot every time we
+# bump chart versions.
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/gateway-divergent-service-name-configuration.yaml
+templates:
+  - gateway/backend.yaml
+  - gke/backend.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: service.name renames only the Service; HealthCheckPolicy keeps dict-key name and targetRef follows the Service
+    asserts:
+      # Service is named after service.name, not the backend dict key
+      - exists:
+          path: metadata.name
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: divergent-service
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+        template: gateway/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: divergent-service
+      # HealthCheckPolicy keeps the dict-key name
+      - exists:
+          path: metadata.name
+        template: gke/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: divergent-backend
+      # HealthCheckPolicy targetRef.name follows the renamed Service
+      - equal:
+          path: spec.targetRef
+          value:
+            group: ""
+            kind: Service
+            name: divergent-service
+        template: gke/backend.yaml
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: divergent-backend

--- a/mozcloud/application/tests/ingress-multi-backend-configuration_test.yaml
+++ b/mozcloud/application/tests/ingress-multi-backend-configuration_test.yaml
@@ -1,0 +1,88 @@
+---
+suite: "mozcloud: Ingress multi-backend configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+# By overriding the chart version, we are preventing the labels chart from
+# updating the mozcloud_chart_version label for every snapshot every time we
+# bump chart versions.
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/ingress-multi-backend-configuration.yaml
+templates:
+  - gke/ingress.yaml
+  - ingress/ingress.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: Each backend renders its own Service, BackendConfig, and Ingress path rule
+    asserts:
+      # Each backend produces its own Service named after the dict key
+      - exists:
+          path: metadata.name
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: api-backend
+      - exists:
+          path: metadata.name
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: ui-backend
+      # Each backend produces its own BackendConfig named after the dict key
+      - exists:
+          path: metadata.name
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: api-backend
+      - exists:
+          path: metadata.name
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: ui-backend
+      # Ingress has both path rules with the right backends and ports
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: api-backend
+                port:
+                  number: 8000
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: multi-backend-host
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ui-backend
+                port:
+                  number: 3000
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: multi-backend-host
+
+  - it: Template rejects duplicate (path, pathType) tuples across backends
+    set:
+      # Override api-backend.path so both entries resolve to (/ , Prefix)
+      workloads.my-app.hosts.multi-backend-host.backends.api-backend.path: "/"
+    template: ingress/ingress.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "duplicate \\(path, pathType\\) entries"

--- a/mozcloud/application/tests/ingress-multi-backend-configuration_test.yaml
+++ b/mozcloud/application/tests/ingress-multi-backend-configuration_test.yaml
@@ -86,3 +86,37 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "duplicate \\(path, pathType\\) entries"
+
+  - it: enabled false skips a backend from rendered output
+    set:
+      workloads.my-app.hosts.multi-backend-host.backends.api-backend.enabled: false
+    asserts:
+      # The surviving backend's Service is still rendered
+      - exists:
+          path: metadata.name
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: ui-backend
+      # The surviving backend's BackendConfig is still rendered
+      - exists:
+          path: metadata.name
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: ui-backend
+      # Single remaining path collapses the Ingress to defaultBackend form pointing at the survivor.
+      # If api-backend had also rendered we would see `spec.rules[]` instead.
+      - equal:
+          path: spec.defaultBackend.service.name
+          value: ui-backend
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: multi-backend-host
+      - notExists:
+          path: spec.rules
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: multi-backend-host

--- a/mozcloud/application/tests/ingress-named-backend-configuration_test.yaml
+++ b/mozcloud/application/tests/ingress-named-backend-configuration_test.yaml
@@ -1,0 +1,97 @@
+---
+suite: "mozcloud: Ingress named backend configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+# By overriding the chart version, we are preventing the labels chart from
+# updating the mozcloud_chart_version label for every snapshot every time we
+# bump chart versions.
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/ingress-named-backend-configuration.yaml
+templates:
+  - gke/ingress.yaml
+  - ingress/ingress.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: Backend dict key drives all resource names by default; service.name diverges only the Service
+    asserts:
+      # === same-name-host: dict key drives Service, BackendConfig, and annotation ===
+      - exists:
+          path: metadata.name
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: same-name-backend
+      - equal:
+          path: metadata.annotations["cloud.google.com/backend-config"]
+          value: '{"default": "same-name-backend"}'
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: same-name-backend
+      - exists:
+          path: metadata.name
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: same-name-backend
+      - equal:
+          path: spec.defaultBackend.service.name
+          value: same-name-backend
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: same-name-host
+
+      # === divergent-host: service.name overrides only the Service ===
+      - equal:
+          path: spec.ports[0].port
+          value: 9000
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: divergent-service
+      - exists:
+          path: metadata.name
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: divergent-backend
+      - equal:
+          path: metadata.annotations["cloud.google.com/backend-config"]
+          value: '{"default": "divergent-backend"}'
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Service")].metadata.name
+          value: divergent-service
+      - equal:
+          path: spec.defaultBackend.service.name
+          value: divergent-service
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: divergent-host
+      - equal:
+          path: spec.defaultBackend.service.port.number
+          value: 9000
+        template: ingress/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "Ingress")].metadata.name
+          value: divergent-host
+
+  - it: Schema rejects backendPolicy on a backend under an ingress host
+    set:
+      workloads.my-app.hosts.same-name-host.backends.same-name-backend.backendPolicy:
+        targetRef:
+          kind: Service
+          name: same-name-backend
+    asserts:
+      - failedTemplate:
+          errorPattern: "backends/same-name-backend.*'not' failed"

--- a/mozcloud/application/tests/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-additional-region_test.yaml
+++ b/mozcloud/application/tests/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-additional-region_test.yaml
@@ -10,7 +10,6 @@ chart:
   version: 1.0.0
 values:
   - values/globals.yaml
-  - values/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-primary-region.yaml
   - values/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-additional-region.yaml
 templates:
   - gateway/backend.yaml

--- a/mozcloud/application/tests/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-primary-region_test.yaml
+++ b/mozcloud/application/tests/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-primary-region_test.yaml
@@ -290,3 +290,25 @@ tests:
         documentSelector:
           path: $[?(@.kind == "Gateway")].metadata.name
           value: mozcloud-test
+
+  - it: Disabling backendPolicy and healthCheck suppresses policy creation for a single backend
+    set:
+      workloads.mozcloud-test.hosts.mozcloud-test.backends.mozcloud-test-us-west1.backendPolicy.enabled: false
+      workloads.mozcloud-test.hosts.mozcloud-test.backends.mozcloud-test-us-west1.healthCheck.enabled: false
+    template: gke/backend.yaml
+    asserts:
+      # The disabled backend's policies are gone; europe-west1 still renders.
+      # us-west1 documents not existing surfaces here as the europe-west1 selectors succeeding
+      # while the structure of the file (4 docs total before) shrinks to 2.
+      - exists:
+          path: metadata.name
+        documentSelector:
+          path: $[?(@.kind == "HealthCheckPolicy")].metadata.name
+          value: mozcloud-test-europe-west1
+      - exists:
+          path: metadata.name
+        documentSelector:
+          path: $[?(@.kind == "GCPBackendPolicy")].metadata.name
+          value: mozcloud-test-europe-west1
+      - hasDocuments:
+          count: 2

--- a/mozcloud/application/tests/values/gateway-divergent-service-name-configuration.yaml
+++ b/mozcloud/application/tests/values/gateway-divergent-service-name-configuration.yaml
@@ -1,0 +1,31 @@
+---
+workloads:
+  my-app:
+    component: app
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      my-host:
+        domains:
+          - my-host.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: gateway
+        tls:
+          type: ManagedCertificate
+          create: true
+        backends:
+          # The dict key drives the HealthCheckPolicy name. service.name renames
+          # only the Service; healthCheck omits `targetRef` so the library
+          # auto-populates `targetService` from the resolved Service name.
+          divergent-backend:
+            service:
+              name: divergent-service
+              port: 8080
+              targetPort: http
+            healthCheck:
+              port: 8080
+              path: /readiness/

--- a/mozcloud/application/tests/values/ingress-multi-backend-configuration.yaml
+++ b/mozcloud/application/tests/values/ingress-multi-backend-configuration.yaml
@@ -1,0 +1,32 @@
+---
+workloads:
+  my-app:
+    component: app
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      # Ingress host with path-based routing across two backends. Each backend
+      # entry produces its own Service + BackendConfig pair and its own path
+      # rule in the generated Ingress.
+      multi-backend-host:
+        domains:
+          - multi-backend.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        tls:
+          type: ManagedCertificate
+          create: true
+        backends:
+          api-backend:
+            path: /api
+            pathType: Prefix
+            service:
+              port: 8000
+          ui-backend:
+            path: /
+            service:
+              port: 3000

--- a/mozcloud/application/tests/values/ingress-named-backend-configuration.yaml
+++ b/mozcloud/application/tests/values/ingress-named-backend-configuration.yaml
@@ -1,0 +1,41 @@
+---
+workloads:
+  my-app:
+    component: app
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      # Backend, Service, BackendConfig, and the cloud.google.com/backend-config
+      # annotation all share the dict-key name (`same-name-backend`).
+      same-name-host:
+        domains:
+          - same-name.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        tls:
+          type: ManagedCertificate
+          create: true
+        backends:
+          same-name-backend: {}
+      # Service uses a custom name (`divergent-service`) on a non-default port
+      # while the BackendConfig and the cloud.google.com/backend-config
+      # annotation still use the dict-key name (`divergent-backend`).
+      divergent-host:
+        domains:
+          - divergent.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        tls:
+          type: ManagedCertificate
+          create: true
+        backends:
+          divergent-backend:
+            service:
+              name: divergent-service
+              port: 9000
+              targetPort: http

--- a/mozcloud/application/tests/values/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-additional-region.yaml
+++ b/mozcloud/application/tests/values/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-additional-region.yaml
@@ -9,10 +9,12 @@ workloads:
     hosts:
       mozcloud-test:
         api: none
+        domains:
+          - mozcloud-test.allizom.org
         httpRoutes:
           createHttpRoutes: false
         backends:
-          - name: mozcloud-test-europe-west1
+          mozcloud-test-europe-west1:
             service:
               portName: http
               port: 8080

--- a/mozcloud/application/tests/values/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-primary-region.yaml
+++ b/mozcloud/application/tests/values/multi-cluster-gateway-configuration-across-two-regions-with-weighted-traffic-splitting-primary-region.yaml
@@ -19,7 +19,7 @@ workloads:
           certs:
             - mozcloud-test-nonprod-dev
         backends:
-          - name: mozcloud-test-us-west1
+          mozcloud-test-us-west1:
             service:
               portName: http
               port: 8080
@@ -34,7 +34,7 @@ workloads:
               targetRef:
                 kind: ServiceImport
                 name: mozcloud-test-us-west1
-          - name: mozcloud-test-europe-west1
+          mozcloud-test-europe-west1:
             backendPolicy:
               targetRef:
                 kind: ServiceImport

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -830,10 +830,20 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Whether to render this backend. Defaults to true. Set to false to omit the backend from rendered resources (useful for selectively disabling a backend via a per-environment values override)."
+                      },
                       "backendPolicy": {
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
+                          "enabled": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Whether to render a GCPBackendPolicy for this backend. Defaults to true. Set to false to suppress GCPBackendPolicy creation without removing the backendPolicy block; useful for selectively disabling an inherited policy in a per-environment values override."
+                          },
                           "targetRef": {
                             "type": "object",
                             "additionalProperties": false,
@@ -852,6 +862,11 @@
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
+                          "enabled": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Whether to render a HealthCheckPolicy for this backend. Defaults to true. Set to false to suppress HealthCheckPolicy creation without removing the healthCheck block; useful for selectively disabling an inherited health check in a per-environment values override."
+                          },
                           "host": {
                             "type": "string"
                           },

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -825,45 +825,11 @@
                   }
                 },
                 "backends": {
-                  "type": "array",
-                  "items": {
+                  "type": "object",
+                  "additionalProperties": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "service": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                          "portName": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "type": "number"
-                          },
-                          "targetPort": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ]
-                          },
-                          "createServiceExport": {
-                            "type": "boolean"
-                          }
-                        }
-                      },
-                      "disableBackendPolicy": {
-                        "type": "boolean"
-                      },
-                      "disableHealthCheck": {
-                        "type": "boolean"
-                      },
                       "backendPolicy": {
                         "type": "object",
                         "additionalProperties": false,
@@ -886,10 +852,10 @@
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
-                          "path": {
+                          "host": {
                             "type": "string"
                           },
-                          "host": {
+                          "path": {
                             "type": "string"
                           },
                           "port": {
@@ -913,6 +879,47 @@
                                 "type": "string"
                               }
                             }
+                          }
+                        }
+                      },
+                      "path": {
+                        "type": "string",
+                        "description": "URL path for the Ingress path rule. Ingress only (api: ingress); for Gateway API hosts use httpRoutes.rules[].matches[].path. Defaults to '/' when the host has exactly one backend; required when the host has more than one backend."
+                      },
+                      "pathType": {
+                        "type": "string",
+                        "description": "pathType for the Ingress path rule. Ingress only (api: ingress); for Gateway API hosts use httpRoutes.rules[].matches[].path.type. Defaults to 'Prefix'.",
+                        "enum": [
+                          "Exact",
+                          "ImplementationSpecific",
+                          "Prefix"
+                        ]
+                      },
+                      "service": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "createServiceExport": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "type": "number"
+                          },
+                          "portName": {
+                            "type": "string"
+                          },
+                          "targetPort": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ]
                           }
                         }
                       }
@@ -1090,6 +1097,64 @@
               },
               "required": [
                 "domains"
+              ],
+              "allOf": [
+                {
+                  "if": {
+                    "properties": {
+                      "api": {
+                        "const": "ingress"
+                      }
+                    },
+                    "required": [
+                      "api"
+                    ]
+                  },
+                  "then": {
+                    "properties": {
+                      "backends": {
+                        "additionalProperties": {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "backendPolicy"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "healthCheck"
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "else": {
+                    "properties": {
+                      "backends": {
+                        "additionalProperties": {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "path"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "pathType"
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               ]
             }
           },

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1587,6 +1587,11 @@ workloads:
         #
         # Per-entry fields and which API they apply to:
         #
+        # * enabled (gateway + ingress): defaults to true. Set to false to omit
+        #   this backend from rendered output. Useful for selectively disabling
+        #   a backend in a per-environment values file without removing its
+        #   definition from the base values file.
+        #
         # * service (gateway + ingress): a Service is built for the backend.
         #   Use service.name to rename the Service independently of the
         #   BackendConfig. Use service.port and service.targetPort to override
@@ -1596,10 +1601,16 @@ workloads:
         #   ServiceExport, used for multi-cluster setups.
         #
         # * backendPolicy (gateway only, "api: gateway"): a GCPBackendPolicy
-        #   is built for the backend. Not valid under "api: ingress".
+        #   is built for the backend. Not valid under "api: ingress". Set
+        #   `backendPolicy.enabled: false` to suppress creation without
+        #   removing the block (useful for disabling an inherited policy in
+        #   a per-environment values override).
         #
         # * healthCheck (gateway only, "api: gateway"): a HealthCheckPolicy
-        #   is built for the backend. Not valid under "api: ingress".
+        #   is built for the backend. Not valid under "api: ingress". Set
+        #   `healthCheck.enabled: false` to suppress creation without
+        #   removing the block (useful for disabling an inherited health
+        #   check in a per-environment values override).
         #
         # * path (ingress only, "api: ingress"): the URL path for the Ingress
         #   path rule. Defaults to "/". Required to be unique when multiple

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1561,35 +1561,65 @@ workloads:
         #              value: bar
         #
 
-        # Use this array to specify custom backends for your Gateway API-based
-        # workloads.
+        # Use this dictionary to specify custom backends for this host. Each
+        # key is the backend name. By default, the same name is reused for
+        # every resource generated for that backend:
         #
-        # Enabling this array will not render the default backend anymore. Using
-        # this with Ingress will not have any effect.
+        # * Gateway API: Service (and optional ServiceExport), GCPBackendPolicy,
+        #   and HealthCheckPolicy resources are all created with the dict key
+        #   as their name.
         #
-        # A custom backend can build different kinds of resources:
+        # * Ingress: the BackendConfig is created with the dict key as its
+        #   name, and the Service's "cloud.google.com/backend-config"
+        #   annotation always references that name. The Service itself
+        #   defaults to the dict key but can be renamed independently via
+        #   "service.name" under the entry — handy when you need the Service
+        #   to be discoverable under a name distinct from the BackendConfig.
         #
-        # * if the service dictionary is set, we build a Service for this
-        #   backend.
+        # Setting this dictionary disables the default backend that would
+        # otherwise be generated using the workload name. An empty entry value
+        # (`my-backend: {}`) is supported and renames the default resources
+        # without otherwise altering them — handy when you only need to
+        # override the backend name.
         #
-        # * if the service dictionary contains createServiceExport: true, we
-        #   also build a ServiceExport.
+        # Per-entry fields and which API they apply to:
         #
-        # * if the backendPolicy dictionary is set, we build a GCPBackendPolicy
-        #   for this backend.
+        # * service (gateway + ingress): a Service is built for the backend.
+        #   Use service.name to rename the Service independently of the
+        #   BackendConfig. Use service.port and service.targetPort to override
+        #   the host-level servicePort/targetPort for this backend.
         #
-        # * if the healthCheck dictionary is set, we build a HealthCheckPolicy
-        #   for this backend.
+        # * service.createServiceExport (gateway only): also builds a
+        #   ServiceExport, used for multi-cluster setups.
         #
-        # This is handy in situations where you want a MultiCluster Gateway, for
-        # example. E.g., in cases where you want to apply split traffic
-        # scenarios across regions, you want a region-based Service per region,
-        # as well as a ServiceExport, but you only want HealthCheckPolicies and
-        # GCPPBBackendPolicies to exist on the primary region that holds your
-        # Gateway.
+        # * backendPolicy (gateway only, "api: gateway"): a GCPBackendPolicy
+        #   is built for the backend. Not valid under "api: ingress".
+        #
+        # * healthCheck (gateway only, "api: gateway"): a HealthCheckPolicy
+        #   is built for the backend. Not valid under "api: ingress".
+        #
+        # * path (ingress only, "api: ingress"): the URL path for the Ingress
+        #   path rule. Defaults to "/". Required to be unique when multiple
+        #   backends are defined on the same host — duplicate paths in a
+        #   single Ingress are rejected by Kubernetes. Not valid under
+        #   "api: gateway" — for Gateway API path-based routing, use
+        #   httpRoutes.rules[].matches[].path on this host.
+        #
+        # * pathType (ingress only, "api: ingress"): the pathType for the
+        #   Ingress path rule. Defaults to "Prefix". Not valid under
+        #   "api: gateway" — for Gateway API, use
+        #   httpRoutes.rules[].matches[].path.type on this host.
+        #
+        # Multi-cluster Gateway scenarios benefit from per-backend
+        # backendPolicy/healthCheck targeting: a region-scoped Service and
+        # ServiceExport are generated in each region while the
+        # HealthCheckPolicy and GCPBackendPolicy resources only exist in the
+        # primary region that holds the Gateway.
+        #
+        # Example — Gateway API host with two named backends:
         #
         #backends:
-        #  - name: my-custom-backend
+        #  my-custom-backend:
         #    service:
         #      portName: http
         #      port: 8000
@@ -1606,6 +1636,36 @@ workloads:
         #      targetRef:
         #        kind: ServiceImport
         #        name: my-custom-backend
+        #
+        # Example — Ingress host that only renames the backend:
+        #
+        #backends:
+        #  my-custom-backend: {}
+        #
+        # Example — Ingress host where the Service uses a different name from
+        # the BackendConfig (the annotation still references the BackendConfig
+        # name, "my-custom-backend") and a non-default port:
+        #
+        #backends:
+        #  my-custom-backend:
+        #    service:
+        #      name: my-custom-service
+        #      port: 9000
+        #      targetPort: http
+        #
+        # Example — Ingress host with path-based routing across two backends:
+        #
+        #backends:
+        #  api-backend:
+        #    path: /api
+        #    pathType: Prefix
+        #    service:
+        #      port: 8000
+        #  ui-backend:
+        #    path: /
+        #    service:
+        #      port: 3000
+        backends: {}
 
         # Configure the type of load balancer to use for your host.
         #
@@ -1656,6 +1716,11 @@ workloads:
 
         # The Kubernetes Service port exposed to the load balancer. Defaults to
         # 8080. Set this when your service needs to listen on a different port.
+        #
+        # Prefer this host-level setting for single-backend hosts. When using
+        # the "backends" dictionary with multiple per-backend ports, set the
+        # port under each entry's "service.port" instead; that per-backend
+        # value overrides this default.
         servicePort: 8080
 
         # The port name or number on the pod that the Service should route
@@ -1664,6 +1729,10 @@ workloads:
         # Defaults to "http", which routes to the nginx sidecar. When nginx is
         # disabled, set this to the app container's "portName" if configured,
         # or the container name otherwise.
+        #
+        # As with "servicePort", prefer this host-level setting for
+        # single-backend hosts; use the per-entry "service.targetPort" under
+        # "backends" when multiple backends need different target ports.
         targetPort: http
 
         # Global certificate details for external gateways. Certificates MUST be

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1565,9 +1565,12 @@ workloads:
         # key is the backend name. By default, the same name is reused for
         # every resource generated for that backend:
         #
-        # * Gateway API: Service (and optional ServiceExport), GCPBackendPolicy,
-        #   and HealthCheckPolicy resources are all created with the dict key
-        #   as their name.
+        # * Gateway API: Service (and optional ServiceExport),
+        #   GCPBackendPolicy, and HealthCheckPolicy resources are all created
+        #   with the dict key as their name. The Service can be renamed
+        #   independently via "service.name" under the entry, in which case
+        #   the GCPBackendPolicy and HealthCheckPolicy keep the dict-key name
+        #   but their targetRef.name follows the renamed Service.
         #
         # * Ingress: the BackendConfig is created with the dict key as its
         #   name, and the Service's "cloud.google.com/backend-config"


### PR DESCRIPTION
## Description
Generalizes `hosts.<host>.backends` to a dictionary that works for both Gateway API and Ingress hosts. The dict key drives resource naming and per-API fields are schema-gated, so each API only accepts the knobs that apply to it. This unlocks multi-path Ingress routing and lets users rename a Service independently of the backend it serves, on both APIs. Existing tenants on the list form have a one-step migration; nothing else materially changes.

**Breaking changes:**
  - Pivoted `hosts.<host>.backends` from `array` to `object`
    - The dict key replaces the now-removed `name` field on each entry
    - Affects the one tenant currently using the list form; migration is mechanical

**Subtle behavior changes:**
  - Default LB health check path now sources from `.Values.workloads.default.containers.default.healthCheck.readiness.path` instead of a hardcoded `/__lbheartbeat__`
    - Output is identical when that field is unchanged (the chart default is still `/__lbheartbeat__`)
    - If a tenant customizes the container readiness probe path AND does not explicitly set an LB health check path (`backends.<name>.healthCheck.path` or `hosts.<name>.options.healthCheck.path`), the LB health check now follows the readiness path instead of staying on `/__lbheartbeat__`. An explicit LB health check path still wins.

**Pre-existing bug fixes:**
  - Fixed a memory-aliasing bug in `mozcloud-ingress-lib.config.backends`
    - `mergeOverwrite` was recursively merging across loop iterations and corrupting earlier backend entries
    - Made multi-path Ingress configs renderable for the first time
  - Made `backendPolicy.targetRef` and `healthCheck.targetRef` optional in `templates/gateway/backend.yaml`
    - Omitting either previously caused a nil-pointer crash during render
    - When omitted, the library now auto-fills `targetService` from the resolved Service name

**Internal refactors (no tenant-facing impact):**
  - Renamed `mozcloud-ingress-lib.config.backend.name` to `config.backendConfig.name` and added `config.service.name`
    - Only consumers in the repo are `mozcloud/application` and `mozcloud-ingress/application`, both updated in this PR
    - Annotation now always references the BackendConfig name so the binding survives a Service rename
  - Decoupled Service and policy naming in `mozcloud-gateway-lib`
    - `config.service` resolves Service name from `service.name`, falling back to dict key
    - `config.backendPolicies` and `config.healthCheckPolicies` keep policy names tied to the dict key while `targetService` follows the renamed Service

**Additive flexibility:**
  - Added per-entry `enabled`, `service.name`, `path`, `pathType`, `backendPolicy.enabled`, and `healthCheck.enabled` fields under `backends.<name>`
    - `enabled` (default true) lets a per-environment values override disable a whole backend without removing its definition from the base values file
    - `backendPolicy.enabled` and `healthCheck.enabled` (each default true) selectively suppress GCPBackendPolicy or HealthCheckPolicy rendering, useful when a per-environment values override needs to drop an inherited policy or health check
    - `service.name` lets users rename the Service independently of the backend on both APIs
    - `path` and `pathType` produce per-backend Ingress path rules; template fails on duplicate `(path, pathType)` tuples since GKE silently routes them non-deterministically
  - Schema field-gating per API
    - Host-level `if/then/else` rejects gateway-only fields under `api: ingress` and ingress-only fields under `api: gateway`/`none`
    - Only restricts the new fields; existing field shapes are untouched
  - Rewrote the `backends` block in `values.yaml`
    - Per-field docs explain which fields apply under each `api` and point gateway users at `httpRoutes.rules` for path-based routing
    - Examples cover gateway named-backends, ingress rename-only, ingress divergent Service-name, and multi-backend path-routing cases
    - `backends: {}` is now an uncommented default per chart conventions
  - Added/updated unit tests

**This is a breaking change, but only for one tenant as the `hosts.<name>.backends` value is not used super widely.**

**Migration:**
  - For the one tenant on the list form, convert `backends: [{name: foo, ...}, ...]` to `backends: {foo: {...}, ...}`
    - Same fields per entry; the dict key replaces the now-removed `name` field

## Related Tickets & Documents
* MZCLD-3010
* MZCLD-2994
