### PR TITLE
feat(mozcloud): make defining custom HTTPRoutes possible

### DIFF
--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -44,6 +44,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 |-----|------|---------|-------------|
 | cloud.provider | string | `"gke"` |  |
 | configMaps | object | `{}` |  |
+| customRoutes | object | `{}` |  |
 | enabled | bool | `true` |  |
 | externalSecrets.default.enabled | bool | `true` |  |
 | persistentVolumes | object | `{}` |  |

--- a/mozcloud/application/templates/gateway/customroutes.yaml
+++ b/mozcloud/application/templates/gateway/customroutes.yaml
@@ -1,0 +1,134 @@
+{{- /*
+Renders custom HTTPRoute resources from the top-level `customRoutes` values key.
+
+Custom routes are not tied to a specific workload and can reference any
+Kubernetes Service as a backend, including services provided by dependency
+charts. This is useful for:
+
+  - A single HTTP-to-HTTPS redirect HTTPRoute that spans hostnames from
+    multiple services (e.g. mlpa + litellm sharing one redirect route).
+  - An HTTPS backend route pointing at a service not managed by mozcloud
+    workloads (e.g. a litellm subchart service).
+
+Each custom route entry supports:
+
+  httpToHttpsRedirect (bool): when true, renders a scheme-redirect-only rule
+    (no backendRefs). Use this to create a single redirect route spanning
+    multiple hostnames from different services without generating separate
+    per-host redirect routes via the workload httpRoutes mechanism.
+
+  rules (list): when httpToHttpsRedirect is false/absent, each rule may
+    contain backendRefs (pointing at any Service) and optional matches.
+
+Example values:
+
+  customRoutes:
+    llm-proxy-redirect:
+      component: llm-proxy-data
+      gatewayRefs:
+        - name: llm-proxy-redirect
+          section: http
+      hostnames:
+        - mlpa.example.com
+        - litellm.example.com
+      httpToHttpsRedirect: true
+    litellm-https:
+      component: llm-proxy-data
+      gatewayRefs:
+        - name: llm-proxy-redirect
+          section: https
+      hostnames:
+        - litellm.example.com
+      rules:
+        - backendRefs:
+            - name: litellm
+              port: 8000
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+*/ -}}
+{{- $chartMetadata := dict "Chart" .Chart "Release" .Release }}
+{{- $globalLabelParams := mergeOverwrite $chartMetadata (include "mozcloud.labelParams" . | fromYaml) }}
+{{- range $routeName, $routeConfig := .Values.customRoutes }}
+{{- if $routeConfig }}
+{{- $labelCtx := mergeOverwrite ($ | deepCopy) ($globalLabelParams | deepCopy) }}
+{{- $_ := set $labelCtx "component_code" (default "gateway" $routeConfig.component) }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $routeName }}
+  labels:
+    {{- include "mozcloud-gateway-lib.labels" $labelCtx | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range $gatewayRef := $routeConfig.gatewayRefs }}
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ $gatewayRef.name }}
+      {{- if $gatewayRef.namespace }}
+      namespace: {{ $gatewayRef.namespace }}
+      {{- end }}
+      sectionName: {{ $gatewayRef.section }}
+    {{- end }}
+  {{- if $routeConfig.hostnames }}
+  hostnames:
+    {{- range $hostname := $routeConfig.hostnames }}
+    - {{ $hostname | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if $routeConfig.httpToHttpsRedirect }}
+    - filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+          statusCode: 302
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+    {{- else }}
+    {{- range $rule := $routeConfig.rules }}
+    - backendRefs:
+        {{- range $backendRef := $rule.backendRefs }}
+        - group: {{ default "" $backendRef.group | quote }}
+          kind: {{ default "Service" $backendRef.kind }}
+          name: {{ $backendRef.name }}
+          port: {{ $backendRef.port }}
+          weight: {{ default 1 $backendRef.weight }}
+        {{- end }}
+      matches:
+        {{- if $rule.matches }}
+        {{- range $match := $rule.matches }}
+        {{- if and $match.path $match.headers }}
+        - path:
+            type: {{ $match.path.type }}
+            value: {{ $match.path.value }}
+          headers:
+            {{- range $header := $match.headers }}
+            - name: {{ $header.name }}
+              value: {{ $header.value }}
+            {{- end }}
+        {{- else if $match.path }}
+        - path:
+            type: {{ $match.path.type }}
+            value: {{ $match.path.value }}
+        {{- else if $match.headers }}
+        - headers:
+            {{- range $header := $match.headers }}
+            - name: {{ $header.name }}
+              value: {{ $header.value }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/mozcloud/application/tests/__snapshot__/custom-routes-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/custom-routes-configuration_test.yaml.snap
@@ -1,0 +1,71 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: llm-proxy-data
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: llm-proxy-data
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: litellm-https
+    spec:
+      hostnames:
+        - litellm.example.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: llm-proxy-redirect
+          sectionName: https
+      rules:
+        - backendRefs:
+            - group: ""
+              kind: Service
+              name: litellm
+              port: 8000
+              weight: 1
+          matches:
+            - path:
+                type: PathPrefix
+                value: /
+  2: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      labels:
+        app.kubernetes.io/component: llm-proxy-data
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: llm-proxy-data
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: llm-proxy-http-redirect
+    spec:
+      hostnames:
+        - mlpa.example.com
+        - litellm.example.com
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: llm-proxy-redirect
+          sectionName: http
+      rules:
+        - filters:
+            - requestRedirect:
+                scheme: https
+                statusCode: 302
+              type: RequestRedirect
+          matches:
+            - path:
+                type: PathPrefix
+                value: /

--- a/mozcloud/application/tests/custom-routes-configuration_test.yaml
+++ b/mozcloud/application/tests/custom-routes-configuration_test.yaml
@@ -1,0 +1,95 @@
+---
+suite: "mozcloud: Custom routes configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/custom-routes.yaml
+templates:
+  - gateway/httproute.yaml
+  - gateway/customroutes.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: Combined HTTP-to-HTTPS redirect HTTPRoute covers both hostnames
+    template: gateway/customroutes.yaml
+    asserts:
+      - contains:
+          path: spec.parentRefs
+          count: 1
+          content:
+            group: gateway.networking.k8s.io
+            kind: Gateway
+            name: llm-proxy-redirect
+            sectionName: http
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: llm-proxy-http-redirect
+      - contains:
+          path: spec.hostnames
+          content: "mlpa.example.com"
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: llm-proxy-http-redirect
+      - contains:
+          path: spec.hostnames
+          content: "litellm.example.com"
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: llm-proxy-http-redirect
+      - contains:
+          path: spec.rules[0].filters
+          count: 1
+          content:
+            type: RequestRedirect
+            requestRedirect:
+              scheme: https
+              statusCode: 302
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: llm-proxy-http-redirect
+
+  - it: Custom backend HTTPRoute points at external service
+    template: gateway/customroutes.yaml
+    asserts:
+      - contains:
+          path: spec.parentRefs
+          count: 1
+          content:
+            group: gateway.networking.k8s.io
+            kind: Gateway
+            name: llm-proxy-redirect
+            sectionName: https
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: litellm-https
+      - contains:
+          path: spec.hostnames
+          content: "litellm.example.com"
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: litellm-https
+      - contains:
+          path: spec.rules[0].backendRefs
+          count: 1
+          content:
+            group: ""
+            kind: Service
+            name: litellm
+            port: 8000
+            weight: 1
+        documentSelector:
+          path: $[?(@.kind == "HTTPRoute")].metadata.name
+          value: litellm-https
+
+  - it: createHttpRoutes false suppresses all auto-generated routes for that host
+    template: gateway/httproute.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/mozcloud/application/tests/values/custom-routes.yaml
+++ b/mozcloud/application/tests/values/custom-routes.yaml
@@ -1,0 +1,45 @@
+---
+workloads:
+  mlpa:
+    component: llm-proxy-data
+    containers: {}
+    hosts:
+      default:
+        domains:
+          - mlpa.example.com
+        api: gateway
+        type: external
+        servicePort: 8000
+        tls:
+          type: certmap
+          certs:
+            - mlpa-nonprod-dev
+        gatewayName: llm-proxy-redirect
+        httpRoutes:
+          createHttpRoutes: false
+
+customRoutes:
+  llm-proxy-http-redirect:
+    component: llm-proxy-data
+    gatewayRefs:
+      - name: llm-proxy-redirect
+        section: http
+    hostnames:
+      - mlpa.example.com
+      - litellm.example.com
+    httpToHttpsRedirect: true
+  litellm-https:
+    component: llm-proxy-data
+    gatewayRefs:
+      - name: llm-proxy-redirect
+        section: https
+    hostnames:
+      - litellm.example.com
+    rules:
+      - backendRefs:
+          - name: litellm
+            port: 8000
+        matches:
+          - path:
+              type: PathPrefix
+              value: /

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -362,7 +362,9 @@
               {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["workload"],
+                "required": [
+                  "workload"
+                ],
                 "properties": {
                   "workload": {
                     "type": "string",
@@ -374,7 +376,9 @@
               {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["labels"],
+                "required": [
+                  "labels"
+                ],
                 "properties": {
                   "labels": {
                     "type": "object",
@@ -391,8 +395,12 @@
           "port": {
             "description": "Port name or number to scrape. Required when using match.labels; optional when using match.workload with a single-container workload.",
             "oneOf": [
-              {"type": "string"},
-              {"type": "integer"}
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
             ]
           },
           "path": {
@@ -406,19 +414,31 @@
             "default": "30s"
           }
         },
-        "required": ["match"],
+        "required": [
+          "match"
+        ],
         "oneOf": [
           {
-            "description": "Workload reference — port is optional for single-container workloads.",
+            "description": "Workload reference \u2014 port is optional for single-container workloads.",
             "properties": {
-              "match": {"required": ["workload"]}
+              "match": {
+                "required": [
+                  "workload"
+                ]
+              }
             }
           },
           {
-            "description": "Explicit selector — port is required.",
-            "required": ["port"],
+            "description": "Explicit selector \u2014 port is required.",
+            "required": [
+              "port"
+            ],
             "properties": {
-              "match": {"required": ["labels"]}
+              "match": {
+                "required": [
+                  "labels"
+                ]
+              }
             }
           }
         ]
@@ -1268,7 +1288,10 @@
               },
               "podManagementPolicy": {
                 "type": "string",
-                "enum": ["OrderedReady", "Parallel"],
+                "enum": [
+                  "OrderedReady",
+                  "Parallel"
+                ],
                 "default": "Parallel",
                 "description": "Pod management policy for StatefulSet workloads."
               },
@@ -1282,14 +1305,25 @@
                 "additionalProperties": {
                   "type": "object",
                   "additionalProperties": false,
-                  "required": ["storage"],
+                  "required": [
+                    "storage"
+                  ],
                   "properties": {
                     "accessMode": {
                       "type": "string",
-                      "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"]
+                      "enum": [
+                        "ReadWriteOnce",
+                        "ReadOnlyMany",
+                        "ReadWriteMany",
+                        "ReadWriteOncePod"
+                      ]
                     },
-                    "storageClassName": { "type": "string" },
-                    "storage": { "type": "string" }
+                    "storageClassName": {
+                      "type": "string"
+                    },
+                    "storage": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -1303,21 +1337,34 @@
         "allOf": [
           {
             "if": {
-              "properties": { "type": { "const": "statefulset" } },
-              "required": ["type"]
+              "properties": {
+                "type": {
+                  "const": "statefulset"
+                }
+              },
+              "required": [
+                "type"
+              ]
             },
             "then": {
               "properties": {
                 "strategy": {
                   "type": "string",
-                  "enum": ["RollingUpdate", "OnDelete"]
+                  "enum": [
+                    "RollingUpdate",
+                    "OnDelete"
+                  ]
                 }
               }
             }
           },
           {
             "if": {
-              "properties": { "type": { "const": "deployment" } }
+              "properties": {
+                "type": {
+                  "const": "deployment"
+                }
+              }
             },
             "then": {
               "properties": {
@@ -1325,21 +1372,30 @@
                   "oneOf": [
                     {
                       "type": "string",
-                      "enum": ["Recreate", "RollingUpdate"]
+                      "enum": [
+                        "Recreate",
+                        "RollingUpdate"
+                      ]
                     },
                     {
                       "type": "object",
-                      "required": ["canary"],
+                      "required": [
+                        "canary"
+                      ],
                       "additionalProperties": false,
                       "properties": {
                         "canary": {
                           "type": "object",
-                          "required": ["steps"],
+                          "required": [
+                            "steps"
+                          ],
                           "properties": {
                             "steps": {
                               "type": "array",
                               "minItems": 1,
-                              "items": { "type": "object" }
+                              "items": {
+                                "type": "object"
+                              }
                             }
                           }
                         }
@@ -1352,8 +1408,14 @@
           },
           {
             "if": {
-              "properties": { "type": { "const": "rollout" } },
-              "required": ["type"]
+              "properties": {
+                "type": {
+                  "const": "rollout"
+                }
+              },
+              "required": [
+                "type"
+              ]
             },
             "then": {
               "properties": {
@@ -1417,6 +1479,134 @@
                 "Issuer"
               ],
               "default": "ClusterIssuer"
+            }
+          }
+        }
+      }
+    },
+    "customRoutes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "component": {
+            "type": "string"
+          },
+          "gatewayRefs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "section"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "section": {
+                  "type": "string",
+                  "enum": [
+                    "http",
+                    "https"
+                  ]
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "hostnames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "httpToHttpsRedirect": {
+            "type": "boolean"
+          },
+          "rules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "backendRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "name",
+                      "port"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
+                      },
+                      "weight": {
+                        "type": "number"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "matches": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "path": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "value": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "default": "PathPrefix"
+                          }
+                        }
+                      },
+                      "headers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -1637,7 +1827,13 @@
               "loggingSeverity": {
                 "type": "string",
                 "description": "Severity for gcsfuse logs. Maps to volumeAttributes.gcsfuseLoggingSeverity.",
-                "enum": ["trace", "debug", "info", "warning", "error"]
+                "enum": [
+                  "trace",
+                  "debug",
+                  "info",
+                  "warning",
+                  "error"
+                ]
               }
             },
             "required": [
@@ -1682,10 +1878,26 @@
                 "else": {
                   "not": {
                     "anyOf": [
-                      {"required": ["bucketName"]},
-                      {"required": ["mountOptions"]},
-                      {"required": ["skipCSIBucketAccessCheck"]},
-                      {"required": ["loggingSeverity"]}
+                      {
+                        "required": [
+                          "bucketName"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "mountOptions"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "skipCSIBucketAccessCheck"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "loggingSeverity"
+                        ]
+                      }
                     ]
                   }
                 }

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1538,6 +1538,9 @@ workloads:
         # Options for HTTPRoutes.
         #
         # * createHttpRoutes: boolean, disable building HTTPRoutes completely.
+        #   Set to false when you want full control over routing via the
+        #   top-level customRoutes key instead (e.g. a single HTTP-to-HTTPS
+        #   redirect route spanning hostnames from multiple services).
         # * rules: add a custom rules array to your workload's HTTPRoute.
         #
         httpRoutes:
@@ -2324,6 +2327,74 @@ workloads:
     #
     # Default: 30, min: 1
     #terminationGracePeriodSeconds: 30
+
+# customRoutes — top-level custom HTTPRoute definitions
+#
+# Use this to define HTTPRoutes that are not tied to a specific mozcloud
+# workload. Common use cases:
+#
+# 1. A single HTTP-to-HTTPS redirect route spanning multiple domains from
+#    different services (e.g. one route covers both "mlpa.example.com" and
+#    "litellm.example.com" rather than generating separate per-host redirects
+#    via the workload httpRoutes mechanism).
+#
+# 2. An HTTPS route pointing at a Service not managed by mozcloud workloads,
+#    such as a service provided by a dependency/subchart (e.g. litellm).
+#
+# When using customRoutes for a combined redirect, suppress the per-host
+# auto-redirect on the affected workload host by setting:
+#   hosts.<host>.httpRoutes.httpToHttpsRedirect: false
+#
+# Schema for each entry:
+#   <route-name>:
+#     component: <string>      # optional; component code for labels (default: "gateway")
+#     gatewayRefs:             # required
+#       - name: <string>       # gateway name
+#         section: http|https  # gateway section
+#         namespace: <string>  # optional; cross-namespace gateway reference
+#     hostnames:               # optional list of hostnames this route serves
+#       - <string>
+#     httpToHttpsRedirect: <bool>  # true = scheme-redirect-only rule (no backendRefs needed)
+#     rules:                   # required when httpToHttpsRedirect is false/absent
+#       - backendRefs:
+#           - name: <string>
+#             port: <number>
+#             weight: <number> # optional
+#             kind: <string>   # optional (default: Service)
+#             group: <string>  # optional
+#         matches:             # optional; defaults to path: / PathPrefix
+#           - path:
+#               type: PathPrefix
+#               value: /foo
+#             headers:
+#               - name: X-My-Header
+#                 value: expected-value
+#
+# Example — one redirect + two HTTPS routes for an mlpa + litellm setup:
+#
+#customRoutes:
+#  llm-proxy-http-redirect:
+#    component: llm-proxy-data
+#    gatewayRefs:
+#      - name: llm-proxy-redirect
+#        section: http
+#    hostnames:
+#      - mlpa.example.com
+#      - litellm.example.com
+#    httpToHttpsRedirect: true
+#  litellm-https:
+#    component: llm-proxy-data
+#    gatewayRefs:
+#      - name: llm-proxy-redirect
+#        section: https
+#    hostnames:
+#      - litellm.example.com
+#    rules:
+#      - backendRefs:
+#          - name: litellm
+#            port: 8000
+
+customRoutes: {}
 
 # We have additional features we will want to add in the coming releases.
 #


### PR DESCRIPTION
mozcloud defaults to a single Gateway, a HTTP to HTTPS redirect HTTPRoute, and a HTTPRoute that points to workload service, some tenants require advanced Routes though, e.g. llm-proxy requires the redirect route to specify multiple domains, but configure 2 different routes for a workload based backend and an external backend from an extra chart, with both having a single domain only. This allows disabling default routes and adding custom routes. 