### PR TITLE
feat(mozcloud): allow explicit container resource limits

### DIFF
--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -99,7 +99,9 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | tasks.jobs.default.containers.default.image.tag | string | `""` |  |
 | tasks.jobs.default.containers.default.imagePullPolicy | string | `"Always"` |  |
 | tasks.jobs.default.containers.default.lifecycle | object | `{}` |  |
-| tasks.jobs.default.containers.default.resources | object | `{}` |  |
+| tasks.jobs.default.containers.default.resources.cpu | string | `"100m"` |  |
+| tasks.jobs.default.containers.default.resources.limits | object | `{}` |  |
+| tasks.jobs.default.containers.default.resources.memory | string | `"128Mi"` |  |
 | tasks.jobs.default.containers.default.secrets | list | `[]` |  |
 | tasks.jobs.default.containers.default.security | object | `{}` |  |
 | tasks.jobs.default.containers.default.volumes | list | `[]` |  |
@@ -149,6 +151,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.containers.default.port | int | `8000` |  |
 | workloads.default.containers.default.portName | string | `""` |  |
 | workloads.default.containers.default.resources.cpu | string | `"100m"` |  |
+| workloads.default.containers.default.resources.limits | object | `{}` |  |
 | workloads.default.containers.default.resources.memory | string | `"128Mi"` |  |
 | workloads.default.containers.default.secrets | list | `[]` |  |
 | workloads.default.containers.default.security | object | `{}` |  |
@@ -173,6 +176,7 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.initContainers.default.imagePullPolicy | string | `"Always"` |  |
 | workloads.default.initContainers.default.lifecycle | object | `{}` |  |
 | workloads.default.initContainers.default.resources.cpu | string | `"100m"` |  |
+| workloads.default.initContainers.default.resources.limits | object | `{}` |  |
 | workloads.default.initContainers.default.resources.memory | string | `"128Mi"` |  |
 | workloads.default.initContainers.default.secrets | list | `[]` |  |
 | workloads.default.initContainers.default.security | object | `{}` |  |

--- a/mozcloud/application/templates/task/_jobTemplate.yaml
+++ b/mozcloud/application/templates/task/_jobTemplate.yaml
@@ -144,11 +144,14 @@ template:
         This function can be found in templates/_pod.yaml
         */}}
         resources:
-          {{- $resourceParams := dict "requests" (dict 
+          {{- $resourceParams := dict "requests" (dict
            "cpu" $containerConfig.resources.cpu
-           "memory" $containerConfig.resources.memory 
+           "memory" $containerConfig.resources.memory
            "ephemeral-storage" (index $containerConfig.resources "ephemeral-storage"))
           -}}
+          {{- if $containerConfig.resources.limits -}}
+            {{- $_ := set $resourceParams "limits" $containerConfig.resources.limits -}}
+          {{- end -}}
           {{- include "pod.container.resources" $resourceParams | nindent 10 }}
 
         {{- /*

--- a/mozcloud/application/templates/workload/_helpers.tpl
+++ b/mozcloud/application/templates/workload/_helpers.tpl
@@ -235,11 +235,14 @@ Returns:
   {{- end }}
   {{- end }}
   resources:
-    {{- $resourceParams := dict "requests" (dict 
+    {{- $resourceParams := dict "requests" (dict
       "cpu" $containerConfig.resources.cpu
-      "memory" $containerConfig.resources.memory 
+      "memory" $containerConfig.resources.memory
       "ephemeral-storage" (index $containerConfig.resources "ephemeral-storage"))
     -}}
+    {{- if $containerConfig.resources.limits -}}
+      {{- $_ := set $resourceParams "limits" $containerConfig.resources.limits -}}
+    {{- end -}}
     {{- include "pod.container.resources" $resourceParams | nindent 4 }}
   {{- /* Sidecars run as init containers need restartPolicy: Always configured */ -}}
   {{- if and (eq $type "initContainer") (dig "sidecar" false $containerConfig) }}

--- a/mozcloud/application/templates/workload/_workloadTemplate.yaml
+++ b/mozcloud/application/templates/workload/_workloadTemplate.yaml
@@ -142,6 +142,9 @@ template:
           {{- $cpu := default "50m" ($config.nginx.resources).cpu }}
           {{- $memory := default "128Mi" ($config.nginx.resources).memory }}
           {{- $resources := dict "requests" (dict "cpu" $cpu "memory" $memory) }}
+          {{- if ($config.nginx.resources).limits }}
+            {{- $_ := set $resources "limits" $config.nginx.resources.limits }}
+          {{- end }}
           {{- include "pod.container.resources" $resources | nindent 10 }}
         readinessProbe:
           {{- /* Use first container in workload for NGINX readiness and liveness probe default values */}}

--- a/mozcloud/application/tests/__snapshot__/container-resources-limits_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/container-resources-limits_test.yaml.snap
@@ -1,0 +1,134 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: web
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: web
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: web
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: web
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-image:1.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: app
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 1000m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 150Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-sidecar:1.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: sidecar
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: sidecar
+              ports:
+                - containerPort: 8000
+                  name: sidecar
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: sidecar
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test

--- a/mozcloud/application/tests/container-resources-limits_test.yaml
+++ b/mozcloud/application/tests/container-resources-limits_test.yaml
@@ -1,0 +1,53 @@
+---
+suite: "mozcloud: Container resources explicit limits"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/container-resources-limits.yaml
+templates:
+  - workload/deployment.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: Container with explicit limits uses them verbatim
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="app")].resources.requests.cpu
+          value: "100m"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="app")].resources.requests.memory
+          value: "150Mi"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="app")].resources.limits.cpu
+          value: "1000m"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="app")].resources.limits.memory
+          value: "256Mi"
+
+  - it: Container without limits override falls back to auto-doubled limits
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="sidecar")].resources.requests.cpu
+          value: "50m"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="sidecar")].resources.requests.memory
+          value: "128Mi"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="sidecar")].resources.limits.cpu
+          value: "100m"
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="sidecar")].resources.limits.memory
+          value: "256Mi"

--- a/mozcloud/application/tests/values/container-resources-limits.yaml
+++ b/mozcloud/application/tests/values/container-resources-limits.yaml
@@ -1,0 +1,23 @@
+---
+workloads:
+  test-service:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: "1.0.0"
+        resources:
+          cpu: 100m
+          memory: 150Mi
+          limits:
+            cpu: 1000m
+            memory: 256Mi
+      sidecar:
+        image:
+          repository: test-repo/test-sidecar
+          tag: "1.0.0"
+        resources:
+          # No limits override: should auto-double to 100m/256Mi
+          cpu: 50m
+          memory: 128Mi

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1162,6 +1162,21 @@
                   "memory": {
                     "type": "string",
                     "pattern": "^\\d+(K|Ki|M|Mi|G|Gi)$"
+                  },
+                  "limits": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "description": "Optional explicit container resource limits. If unset, limits default to 2x requests for cpu and memory.",
+                    "properties": {
+                      "cpu": {
+                        "type": "string",
+                        "pattern": "^(\\d+|\\d+m)$"
+                      },
+                      "memory": {
+                        "type": "string",
+                        "pattern": "^\\d+(K|Ki|M|Mi|G|Gi)$"
+                      }
+                    }
                   }
                 }
               }
@@ -1524,6 +1539,23 @@
               "type": "string",
               "description": "Ephemeral storage request using K, Ki, M, Mi, G, or Gi units",
               "pattern": "^\\d+(K|Ki|M|Mi|G|Gi)$"
+            },
+            "limits": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Optional explicit container resource limits. If unset, limits default to 2x requests for cpu and memory.",
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "description": "Integer cores (e.g., 2) or millicores (e.g., 200m)",
+                  "pattern": "^(\\d+|\\d+m)$"
+                },
+                "memory": {
+                  "type": "string",
+                  "description": "K, Ki, M, Mi, G, or Gi (recommend binary units)",
+                  "pattern": "^\\d+(K|Ki|M|Mi|G|Gi)$"
+                }
+              }
             }
           }
         },

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -599,8 +599,8 @@ tasks:
           lifecycle: {}
 
           # The "resources" section allows you to specify the amount of CPU and
-          # memory that your container needs to run. These are equivalent to
-          # requests values.
+          # memory that your container needs to run. The top-level "cpu" and
+          # "memory" fields are equivalent to requests values.
           #
           # Format:
           #
@@ -627,6 +627,12 @@ tasks:
           #     #
           #     # The default value is 128Mi.
           #     memory: 128Mi
+          #
+          #     # Optional explicit container resource limits. If unset,
+          #     # limits default to 2x requests for cpu and memory.
+          #     limits:
+          #       cpu: 1000m
+          #       memory: 256Mi
           #
           # Defaults are set in .Values.tasks.common.container.resources
           resources: {}
@@ -1297,8 +1303,8 @@ workloads:
         portName: ''
 
         # The "resources" section allows you to specify the amount of CPU and
-        # memory that your container needs to run. These are equivalent to
-        # requests values.
+        # memory that your container needs to run. The top-level "cpu" and
+        # "memory" fields are equivalent to requests values.
         resources:
           # CPU can be specified in either of the following formats:
           #
@@ -1325,10 +1331,23 @@ workloads:
 
           # Ephemeral storage can optionally be specified using K, Ki, M, Mi,
           # G, or Gi suffixes. Unlike CPU and memory, limits are not
-          # auto-calculated — the limit is set equal to the request.
+          # auto-calculated, the limit is set equal to the request.
           #
           # Example:
           #   ephemeral-storage: 1Gi
+
+          # Optional explicit container resource limits. If unset, limits
+          # default to 2x requests for cpu and memory. Use this when the
+          # auto-doubled limit does not provide enough headroom (eg. a
+          # bursty HTTP front-end where the cold-start ramp peak is much
+          # higher than the HPA steady-state request) or when you need to
+          # tune the request:limit ratio away from 50% so node autoscaling
+          # sees node pressure at the same time the container does.
+          #
+          # Example:
+          #   limits:
+          #     cpu: 1000m
+          #     memory: 256Mi
 
         # Optionally override some securityContext settings for the container.
         # This section should not be configured unless the user knows what they
@@ -1883,8 +1902,8 @@ workloads:
         #port:
 
         # The "resources" section allows you to specify the amount of CPU and
-        # memory that your container needs to run. These are equivalent to
-        # requests values.
+        # memory that your container needs to run. The top-level "cpu" and
+        # "memory" fields are equivalent to requests values.
         resources:
           # CPU can be specified in either of the following formats:
           #
@@ -1911,10 +1930,23 @@ workloads:
 
           # Ephemeral storage can optionally be specified using K, Ki, M, Mi,
           # G, or Gi suffixes. Unlike CPU and memory, limits are not
-          # auto-calculated — the limit is set equal to the request.
+          # auto-calculated, the limit is set equal to the request.
           #
           # Example:
           #   ephemeral-storage: 1Gi
+
+          # Optional explicit container resource limits. If unset, limits
+          # default to 2x requests for cpu and memory. Use this when the
+          # auto-doubled limit does not provide enough headroom (eg. a
+          # bursty HTTP front-end where the cold-start ramp peak is much
+          # higher than the HPA steady-state request) or when you need to
+          # tune the request:limit ratio away from 50% so node autoscaling
+          # sees node pressure at the same time the container does.
+          #
+          # Example:
+          #   limits:
+          #     cpu: 1000m
+          #     memory: 256Mi
 
         # Optionally override some securityContext settings for the container.
         # This section should not be configured unless the user knows what they

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -635,7 +635,10 @@ tasks:
           #       memory: 256Mi
           #
           # Defaults are set in .Values.tasks.common.container.resources
-          resources: {}
+          resources:
+            cpu: 100m
+            memory: 128Mi
+            limits: {}
 
           # Optionally override some securityContext settings for the container.
           # This section should not be configured unless the user knows what they
@@ -1348,6 +1351,7 @@ workloads:
           #   limits:
           #     cpu: 1000m
           #     memory: 256Mi
+          limits: {}
 
         # Optionally override some securityContext settings for the container.
         # This section should not be configured unless the user knows what they
@@ -1947,6 +1951,7 @@ workloads:
           #   limits:
           #     cpu: 1000m
           #     memory: 256Mi
+          limits: {}
 
         # Optionally override some securityContext settings for the container.
         # This section should not be configured unless the user knows what they


### PR DESCRIPTION
## Description

The `pod.container.resources` helper already accepts an optional `.limits` key, but every workload and task caller built the helper input with `.requests` only, so users had no way to set explicit limits from values. The fallback in the helper auto-doubled the request to produce the limit.

This adds an optional `limits` sub-object under ` containers.*.resources` and forwards it through every caller. Backward compatible: existing values with only flat `cpu` / `memory` keys keep getting auto-doubled limits.

```yaml
workloads:
  myapp:
    containers:
      app:
        resources:
          cpu: 100m
          memory: 150Mi
          # New: optional explicit limits override the auto-doubled defaults.
          limits:
            cpu: 1000m
            memory: 256Mi
```

# Related Tickets
* [MZCLD-3014](https://mozilla-hub.atlassian.net/browse/MZCLD-3014)
* [SVCSE-4142](https://mozilla-hub.atlassian.net/browse/SVCSE-4142)