### PR TITLE
fix(mozcloud): aggregate TLS certs across all hosts sharing a Gateway

### DIFF
--- a/mozcloud/application/templates/gateway/gateway.yaml
+++ b/mozcloud/application/templates/gateway/gateway.yaml
@@ -115,7 +115,14 @@ Returns:
         {{- $_ = set $gatewayConfig "nameOverride" $nameOverride }}
         {{- $_ = set $gatewayConfigs $configKey $gatewayConfig }}
       {{- end }}
-      {{- /* Aggregate certs from every host sharing this gateway, deduped. */}}
+      {{- /*
+      Aggregate certs from every host sharing this gateway, deduped.
+      $existing is a reference (via `index`) to the gateway config stored
+      in $gatewayConfigs — dicts are reference types in Go templates, so
+      mutating $existing.certs mutates the stored entry. This runs for
+      every host (new key or not), letting later hosts contribute their
+      certs to a Gateway that an earlier host already created.
+      */}}
       {{- $existing := index $gatewayConfigs $configKey }}
       {{- range $cert := $certs }}
         {{- if not (has $cert $existing.certs) }}

--- a/mozcloud/application/templates/gateway/gateway.yaml
+++ b/mozcloud/application/templates/gateway/gateway.yaml
@@ -102,7 +102,7 @@ Returns:
         {{- $_ := set $gatewayConfig "type" $hostConfig.type }}
         {{- $_ = set $gatewayConfig "className" $className }}
         {{- $_ = set $gatewayConfig "addresses" $addresses }}
-        {{- $_ = set $gatewayConfig "certs" $certs }}
+        {{- $_ = set $gatewayConfig "certs" (list) }}
         {{- $tlsType := ($hostConfig.tls).type }}
         {{- if not $tlsType }}
           {{- if eq $provider "gke" }}
@@ -114,6 +114,13 @@ Returns:
         {{- $_ = set $gatewayConfig "tlsType" $tlsType }}
         {{- $_ = set $gatewayConfig "nameOverride" $nameOverride }}
         {{- $_ = set $gatewayConfigs $configKey $gatewayConfig }}
+      {{- end }}
+      {{- /* Aggregate certs from every host sharing this gateway, deduped. */}}
+      {{- $existing := index $gatewayConfigs $configKey }}
+      {{- range $cert := $certs }}
+        {{- if not (has $cert $existing.certs) }}
+          {{- $_ := set $existing "certs" (append $existing.certs $cert) }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/mozcloud/application/tests/__snapshot__/multi-host-gateway-cert-aggregation_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/multi-host-gateway-cert-aggregation_test.yaml.snap
@@ -1,0 +1,38 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      labels:
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: gateway
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: mozcloud-test
+    spec:
+      gatewayClassName: traefik
+      listeners:
+        - allowedRoutes:
+            namespaces:
+              from: Same
+          name: http
+          port: 80
+          protocol: HTTP
+        - allowedRoutes:
+            namespaces:
+              from: Same
+          name: https
+          port: 443
+          protocol: HTTPS
+          tls:
+            certificateRefs:
+              - name: service-a-tls
+              - name: service-b-tls
+              - name: service-c-tls
+            mode: Terminate

--- a/mozcloud/application/tests/multi-host-gateway-cert-aggregation_test.yaml
+++ b/mozcloud/application/tests/multi-host-gateway-cert-aggregation_test.yaml
@@ -1,0 +1,41 @@
+---
+suite: "mozcloud: Multi-host gateway cert aggregation"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/multi-host-gateway-cert-aggregation.yaml
+templates:
+  - gateway/gateway.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: Single Gateway is emitted and lists every host's certificate
+    template: gateway/gateway.yaml
+    documentSelector:
+      path: $[?(@.kind == "Gateway")].metadata.name
+      value: mozcloud-test
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.gatewayClassName
+          value: traefik
+      - contains:
+          path: spec.listeners[?(@.name == "https")].tls.certificateRefs
+          content:
+            name: service-a-tls
+      - contains:
+          path: spec.listeners[?(@.name == "https")].tls.certificateRefs
+          content:
+            name: service-b-tls
+      - contains:
+          path: spec.listeners[?(@.name == "https")].tls.certificateRefs
+          content:
+            name: service-c-tls

--- a/mozcloud/application/tests/values/multi-host-gateway-cert-aggregation.yaml
+++ b/mozcloud/application/tests/values/multi-host-gateway-cert-aggregation.yaml
@@ -1,0 +1,58 @@
+---
+cloud:
+  provider: on-prem
+  ingress:
+    default: traefik
+
+workloads:
+  service-a:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      service-a:
+        type: external
+        domains:
+          - service-a.dev.test-domain.com
+        api: gateway
+        tls:
+          type: secret
+          certs:
+            - service-a-tls
+  service-b:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      service-b:
+        type: external
+        domains:
+          - service-b.dev.test-domain.com
+        api: gateway
+        tls:
+          type: secret
+          certs:
+            - service-b-tls
+  service-c:
+    component: web
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      service-c:
+        type: external
+        domains:
+          - service-c.dev.test-domain.com
+        api: gateway
+        tls:
+          type: secret
+          certs:
+            - service-c-tls


### PR DESCRIPTION
## Description

The gateway config dedup logic only recorded the first host's tls.certs when a configKey was created. Subsequent hosts that resolved to the same Gateway (same type/className/addresses/nameOverride) hit the hasKey branch and were skipped entirely, so their certs were dropped.

When multiple workloads share a single external Gateway and each contributes its own TLS cert, only the alphabetically-first workload's cert ended up in the listener's certificateRefs. The other hosts' HTTPRoutes attached fine but the Gateway had no cert for their hostnames.

Move cert collection out of the "new configKey" branch so every host contributes its certs (deduped) into the existing gateway config's cert list.

Adds a test that wires three workloads to one external Gateway with distinct per-host certs and asserts the listener's certificateRefs contains all three.


## Related Tickets & Documents
* MZCLD-3016