### PR TITLE
fix(zizmor): Scope action permissions

### DIFF
--- a/.github/workflows/release-helm-chart-automatic.yaml
+++ b/.github/workflows/release-helm-chart-automatic.yaml
@@ -152,6 +152,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-pull-requests: write
 
       - name: Apply label
         env:
@@ -183,6 +184,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-pull-requests: write
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5
@@ -281,6 +283,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-pull-requests: write
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5 # zizmor: ignore[artipacked]

--- a/.github/workflows/release-helm-chart-automatic.yaml
+++ b/.github/workflows/release-helm-chart-automatic.yaml
@@ -283,7 +283,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-pull-requests: write
+          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5 # zizmor: ignore[artipacked]

--- a/.github/workflows/release-helm-chart-manual.yaml
+++ b/.github/workflows/release-helm-chart-manual.yaml
@@ -44,6 +44,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5 # zizmor: ignore[artipacked]


### PR DESCRIPTION
## Description

Fix failures with scoping of permissions, from https://github.com/mozilla/helm-charts/actions/runs/25885099209/job/76074566670?pr=278

```
[3](https://github.com/mozilla/helm-charts/actions/runs/25885099209/job/76074566670?pr=278#step:4:14)
error[github-app]: dangerous use of GitHub App tokens
   --> ./.github/workflows/release-helm-chart-automatic.yaml:151:15
    |
151 |         uses: actions/create-github-app-token@v2 # zizmor: ignore[unpinned-uses]
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ app token inherits blanket installation permissions
    |
    = note: audit confidence → High
    = tip: specify at least one `permission-<name>` input to limit the token's permissions
    = help: audit documentation → https://docs.zizmor.sh/audits/#github-app

error[github-app]: dangerous use of GitHub App tokens
   --> ./.github/workflows/release-helm-chart-automatic.yaml:182:15
    |
182 |         uses: actions/create-github-app-token@v2 # zizmor: ignore[unpinned-uses]
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ app token inherits blanket installation permissions
    |
    = note: audit confidence → High
    = tip: specify at least one `permission-<name>` input to limit the token's permissions
    = help: audit documentation → https://docs.zizmor.sh/audits/#github-app

error[github-app]: dangerous use of GitHub App tokens
   --> ./.github/workflows/release-helm-chart-automatic.yaml:280:15
    |
280 |         uses: actions/create-github-app-token@v2 # zizmor: ignore[unpinned-uses]
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ app token inherits blanket installation permissions
    |
    = note: audit confidence → High
    = tip: specify at least one `permission-<name>` input to limit the token's permissions
    = help: audit documentation → https://docs.zizmor.sh/audits/#github-app

error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/release-helm-chart-manual.yaml:43:15
   |
43 |         uses: actions/create-github-app-token@v2 # zizmor: ignore[unpinned-uses]
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ app token inherits blanket installation permissions
   |
   = note: audit confidence → High
   = tip: specify at least one `permission-<name>` input to limit the token's permissions
   = help: audit documentation → https://docs.zizmor.sh/audits/#github-app

44 findings (7 ignored, 33 suppressed): 0 informational, 0 low, 0 medium, 4 high
```