### PR TITLE
fix(mozcloud-gateway): align IAP fields with GKE Gateway API spec

### DIFF
--- a/mozcloud-gateway/library/templates/_backendpolicy.yaml
+++ b/mozcloud-gateway/library/templates/_backendpolicy.yaml
@@ -18,8 +18,9 @@ spec:
     {{- if $config.iap }}
     iap:
       enabled: {{ $config.iap.enabled }}
-      oauth2ClientId: {{ $config.iap.oauth2ClientId }}
-      oauth2ClientSecret: {{ $config.iap.oauth2ClientSecret }}
+      clientID: {{ $config.iap.oauth2ClientId }}
+      oauth2ClientSecret: 
+        name: {{ $config.iap.oauth2ClientSecret }}
     {{- end }}
     logging:
       enabled: {{ $config.logging.enabled }}

--- a/mozcloud-gateway/library/templates/_backendpolicy.yaml
+++ b/mozcloud-gateway/library/templates/_backendpolicy.yaml
@@ -19,7 +19,7 @@ spec:
     iap:
       enabled: {{ $config.iap.enabled }}
       clientID: {{ $config.iap.oauth2ClientId }}
-      oauth2ClientSecret: 
+      oauth2ClientSecret:
         name: {{ $config.iap.oauth2ClientSecret }}
     {{- end }}
     logging:


### PR DESCRIPTION
## Summary

Corrects the GCPBackendPolicy IAP rendering in `mozcloud-gateway-lib` to match the GKE Gateway API spec:

- `oauth2ClientId` → `clientID` (per [`IdentityAwareProxyConfig`](https://googlecloudplatform.github.io/gke-gateway-api/#identityawareproxyconfig))
- `oauth2ClientSecret` was rendered as a scalar string; the spec requires a [`SecretObjectReference`](https://googlecloudplatform.github.io/gke-gateway-api/#oauth2clientsecret) (`{ name: <secret> }`)

Input contract (`$config.iap.oauth2ClientId`, `$config.iap.oauth2ClientSecret`) is preserved — no values-file changes are required for consumers of the `mozcloud` chart. Schemas and `values.yaml` examples in `mozcloud-gateway` and `mozcloud` continue to use the existing input field names.

Jira: [MZCLD-3062](https://mozilla-hub.atlassian.net/browse/MZCLD-3062)

## Test plan

- [x] `make unit-tests` passes (79/79 suites, no IAP-specific snapshots exist so no snapshot churn)
- [ ] Reviewer: confirm rendered output of any service that uses `iap.oauth2ClientId` / `iap.oauth2ClientSecret` matches the GKE Gateway API CRD spec