### PR TITLE
feat(mozcloud): support exec readiness / liveness commands

### DIFF
--- a/mozcloud/application/templates/workload/_helpers.tpl
+++ b/mozcloud/application/templates/workload/_helpers.tpl
@@ -189,6 +189,11 @@ Returns:
   {{- if eq $type "container" }}
   {{- if (dig "healthCheck" "liveness" "enabled" true $containerConfig) }}
   livenessProbe:
+    {{- if (($containerConfig.healthCheck).liveness).exec }}
+    exec:
+      command:
+        {{- toYaml $containerConfig.healthCheck.liveness.exec.command | nindent 8 }}
+    {{- else }}
     httpGet:
       {{- if (($containerConfig.healthCheck).liveness).httpHeaders }}
       httpHeaders:
@@ -205,6 +210,7 @@ Returns:
       {{- end }}
       path: {{ default "/__lbheartbeat__" $containerConfig.healthCheck.liveness.path }}
       port: {{ $portName }}
+    {{- end }}
     {{- if (($containerConfig.healthCheck).liveness).probes }}
     {{- range $k, $v := $containerConfig.healthCheck.liveness.probes }}
     {{ $k }}: {{ $v }}
@@ -217,6 +223,11 @@ Returns:
   {{- end }}
   {{- if (dig "healthCheck" "readiness" "enabled" true $containerConfig) }}
   readinessProbe:
+    {{- if (($containerConfig.healthCheck).readiness).exec }}
+    exec:
+      command:
+        {{- toYaml $containerConfig.healthCheck.readiness.exec.command | nindent 8 }}
+    {{- else }}
     httpGet:
       {{- if (($containerConfig.healthCheck).readiness).httpHeaders }}
       httpHeaders:
@@ -227,6 +238,7 @@ Returns:
       {{- end }}
       path: {{ default "/__lbheartbeat__" $containerConfig.healthCheck.readiness.path }}
       port: {{ $portName }}
+    {{- end }}
     {{- if (($containerConfig.healthCheck).readiness).probes }}
     {{- range $k, $v := $containerConfig.healthCheck.readiness.probes }}
     {{ $k }}: {{ $v }}

--- a/mozcloud/application/tests/__snapshot__/basic-workload-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/basic-workload-configuration_test.yaml.snap
@@ -344,6 +344,102 @@ Configuration matches entire snapshot:
         realm: nonprod
       name: test-service-nginx
   6: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: worker
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: worker
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-worker-exec
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: worker
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: worker
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: worker
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: worker
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/test-image:1.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                exec:
+                  command:
+                    - /bin/sh
+                    - -c
+                    - /usr/local/bin/healthcheck
+                failureThreshold: 5
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: app
+              readinessProbe:
+                exec:
+                  command:
+                    - /bin/sh
+                    - -c
+                    - /usr/local/bin/healthcheck
+                failureThreshold: 3
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test
+  7: |
     apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     metadata:
@@ -375,3 +471,35 @@ Configuration matches entire snapshot:
         apiVersion: apps/v1
         kind: Deployment
         name: test-service
+  8: |
+    apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+      labels:
+        app.kubernetes.io/component: worker
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: worker
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-worker-exec
+    spec:
+      maxReplicas: 30
+      metrics:
+        - resource:
+            name: cpu
+            target:
+              averageUtilization: 60
+              type: Utilization
+          type: Resource
+      minReplicas: 1
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: test-worker-exec

--- a/mozcloud/application/tests/basic-workload-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-workload-configuration_test.yaml
@@ -276,6 +276,29 @@ tests:
             name: nginx-conf
             readOnly: true
             subPath: nginx.conf
+      # Exec probes render correctly and suppress httpGet
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          value: ["/bin/sh", "-c", "/usr/local/bin/healthcheck"]
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-worker-exec
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-worker-exec
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value: ["/bin/sh", "-c", "/usr/local/bin/healthcheck"]
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-worker-exec
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-worker-exec
 
   - it: NGINX sidecar ConfigMap is rendered with nginx.conf data
     template: workload/deployment.yaml

--- a/mozcloud/application/tests/values/basic-configuration.yaml
+++ b/mozcloud/application/tests/values/basic-configuration.yaml
@@ -56,3 +56,19 @@ workloads:
         options:
           logSampleRate: 50
 
+  # Worker workload with exec-based liveness and readiness probes.
+  test-worker-exec:
+    component: worker
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+        healthCheck:
+          liveness:
+            exec:
+              command: ["/bin/sh", "-c", "/usr/local/bin/healthcheck"]
+          readiness:
+            exec:
+              command: ["/bin/sh", "-c", "/usr/local/bin/healthcheck"]
+

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -589,17 +589,7 @@
                           "default": true
                         },
                         "exec": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "required": ["command"],
-                          "properties": {
-                            "command": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
+                          "$ref": "#/$defs/execProbe"
                         },
                         "path": {
                           "type": "string",
@@ -662,17 +652,7 @@
                           "default": true
                         },
                         "exec": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "required": ["command"],
-                          "properties": {
-                            "command": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
+                          "$ref": "#/$defs/execProbe"
                         },
                         "path": {
                           "type": "string",
@@ -1530,6 +1510,19 @@
     }
   },
   "$defs": {
+    "execProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "gcsFuseSidecar": {
       "type": "object",
       "additionalProperties": false,

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -588,6 +588,19 @@
                           "type": "boolean",
                           "default": true
                         },
+                        "exec": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": ["command"],
+                          "properties": {
+                            "command": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
                         "path": {
                           "type": "string",
                           "default": "/__lbheartbeat__"
@@ -647,6 +660,19 @@
                         "enabled": {
                           "type": "boolean",
                           "default": true
+                        },
+                        "exec": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": ["command"],
+                          "properties": {
+                            "command": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
                         },
                         "path": {
                           "type": "string",

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1137,6 +1137,14 @@ workloads:
             # (eg. celery).
             enabled: true
 
+            # Configure an exec-based probe instead of the default httpGet.
+            # When set, path and httpHeaders are ignored for this probe.
+            #
+            # Example:
+            #
+            #   exec:
+            #     command: ["/bin/sh", "-c", "/usr/local/bin/healthcheck"]
+
             # This is typically configured to match the application container's
             # load balancer heartbeat health check endpoint.
             #
@@ -1192,6 +1200,15 @@ workloads:
             # Disable for worker workloads that do not require health checks
             # (eg. celery).
             enabled: true
+
+            # Configure an exec-based probe instead of the default httpGet.
+            # When set, path and httpHeaders are ignored for this probe.
+            # If not set, falls back to the readiness httpHeaders if defined.
+            #
+            # Example:
+            #
+            #   exec:
+            #     command: ["/bin/sh", "-c", "/usr/local/bin/healthcheck"]
 
             # This is typically configured to match the application container's
             # load balancer heartbeat health check endpoint.


### PR DESCRIPTION
## Description
Adds support for exec based readiness / liveness commands to support [lando](https://github.com/mozilla/webservices-infra/blob/222269617f69c48e0474446d3f9f3cfa4f335645/lando/k8s/lando/templates/deployment.yaml#L99-L106)

## Related Tickets & Documents
* MZCLD-3094

