### PR TITLE
feat(mozcloud): expose customRequestHeaders, customResponseHeaders, and healthCheck.requestPath in hosts.X.options

### DIFF
--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -95,6 +95,27 @@ ingresses:
                 {{- if ($hostConfig.options).securityPolicy }}
                 securityPolicy: {{ $hostConfig.options.securityPolicy }}
                 {{- end }}
+                {{- if ($hostConfig.options).customRequestHeaders }}
+                customRequestHeaders:
+                  headers:
+                    {{- range $hostConfig.options.customRequestHeaders.headers }}
+                    - {{ . | quote }}
+                    {{- end }}
+                {{- end }}
+                {{- if ($hostConfig.options).customResponseHeaders }}
+                customResponseHeaders:
+                  headers:
+                    {{- range $hostConfig.options.customResponseHeaders.headers }}
+                    - {{ . | quote }}
+                    {{- end }}
+                {{- end }}
+                {{- if (($hostConfig.options).healthCheck).requestPath }}
+                healthCheck:
+                  requestPath: {{ $hostConfig.options.healthCheck.requestPath | quote }}
+                  {{- if $hostConfig.options.healthCheck.port }}
+                  port: {{ $hostConfig.options.healthCheck.port }}
+                  {{- end }}
+                {{- end }}
               service:
                 name: {{ $serviceName }}
                 port: {{ $port }}

--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -98,14 +98,14 @@ ingresses:
                 {{- if ($hostConfig.options).customRequestHeaders }}
                 customRequestHeaders:
                   headers:
-                    {{- range $hostConfig.options.customRequestHeaders.headers }}
+                    {{- range $hostConfig.options.customRequestHeaders }}
                     - {{ . | quote }}
                     {{- end }}
                 {{- end }}
                 {{- if ($hostConfig.options).customResponseHeaders }}
                 customResponseHeaders:
                   headers:
-                    {{- range $hostConfig.options.customResponseHeaders.headers }}
+                    {{- range $hostConfig.options.customResponseHeaders }}
                     - {{ . | quote }}
                     {{- end }}
                 {{- end }}

--- a/mozcloud/application/tests/__snapshot__/ingress-backend-custom-headers-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/ingress-backend-custom-headers-configuration_test.yaml.snap
@@ -1,0 +1,107 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      customRequestHeaders:
+        headers:
+          - X-Client-TLS:{tls_version} {tls_cipher_suite}
+          - X-LB-Backend:default
+      customResponseHeaders:
+        headers:
+          - Strict-Transport-Security:max-age=31536000
+      healthCheck:
+        port: 8000
+        requestPath: /__lbheartbeat__
+      logging:
+        enable: true
+        sampleRate: 0.1
+  2: |
+    apiVersion: networking.gke.io/v1
+    kind: ManagedCertificate
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service-dev-test-domain-com
+    spec:
+      domains:
+        - test-service.dev.test-domain.com
+  3: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: gce
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
+        networking.gke.io/managed-certificates: test-service-dev-test-domain-com
+        networking.gke.io/v1beta1.FrontendConfig: test-service
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      defaultBackend:
+        service:
+          name: test-service
+          port:
+            number: 8080
+  4: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/backend-config: '{"default": "test-service"}'
+        cloud.google.com/neg: '{"ingress": true}'
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP

--- a/mozcloud/application/tests/ingress-backend-custom-headers-configuration_test.yaml
+++ b/mozcloud/application/tests/ingress-backend-custom-headers-configuration_test.yaml
@@ -1,0 +1,54 @@
+---
+suite: "mozcloud: Ingress backend custom headers configuration"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/ingress-backend-custom-headers-configuration.yaml
+templates:
+  - gke/ingress.yaml
+  - ingress/ingress.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: BackendConfig spec renders customRequestHeaders verbatim
+    template: gke/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "BackendConfig")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.customRequestHeaders.headers
+          value:
+            - "X-Client-TLS:{tls_version} {tls_cipher_suite}"
+            - "X-LB-Backend:default"
+
+  - it: BackendConfig spec renders customResponseHeaders verbatim
+    template: gke/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "BackendConfig")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.customResponseHeaders.headers
+          value:
+            - "Strict-Transport-Security:max-age=31536000"
+
+  - it: BackendConfig spec renders healthCheck.requestPath and port
+    template: gke/ingress.yaml
+    documentSelector:
+      path: $[?(@.kind == "BackendConfig")].metadata.name
+      value: test-service
+    asserts:
+      - equal:
+          path: spec.healthCheck.requestPath
+          value: /__lbheartbeat__
+      - equal:
+          path: spec.healthCheck.port
+          value: 8000

--- a/mozcloud/application/tests/values/ingress-backend-custom-headers-configuration.yaml
+++ b/mozcloud/application/tests/values/ingress-backend-custom-headers-configuration.yaml
@@ -1,0 +1,30 @@
+---
+workloads:
+  test-service:
+    component: app
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      test-service:
+        domains:
+          - test-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        tls:
+          type: ManagedCertificate
+          create: true
+        options:
+          customRequestHeaders:
+            headers:
+              - "X-Client-TLS:{tls_version} {tls_cipher_suite}"
+              - "X-LB-Backend:default"
+          customResponseHeaders:
+            headers:
+              - "Strict-Transport-Security:max-age=31536000"
+          healthCheck:
+            requestPath: /__lbheartbeat__
+            port: 8000

--- a/mozcloud/application/tests/values/ingress-backend-custom-headers-configuration.yaml
+++ b/mozcloud/application/tests/values/ingress-backend-custom-headers-configuration.yaml
@@ -19,12 +19,10 @@ workloads:
           create: true
         options:
           customRequestHeaders:
-            headers:
-              - "X-Client-TLS:{tls_version} {tls_cipher_suite}"
-              - "X-LB-Backend:default"
+            - "X-Client-TLS:{tls_version} {tls_cipher_suite}"
+            - "X-LB-Backend:default"
           customResponseHeaders:
-            headers:
-              - "Strict-Transport-Security:max-age=31536000"
+            - "Strict-Transport-Security:max-age=31536000"
           healthCheck:
             requestPath: /__lbheartbeat__
             port: 8000

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1108,29 +1108,17 @@
                       }
                     },
                     "customRequestHeaders": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "description": "Custom headers added by the GCLB to requests before forwarding to backends (Ingress API only). Values may use GCLB variable substitution like {tls_version} and {tls_cipher_suite}; see https://cloud.google.com/load-balancing/docs/https/custom-headers.",
-                      "properties": {
-                        "headers": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
+                      "type": "array",
+                      "description": "Custom headers the GCLB adds to requests before forwarding to backends (Ingress API only). Each entry is a 'Name:Value' string. Values may use GCLB variable substitution like {tls_version} and {tls_cipher_suite}; see https://cloud.google.com/load-balancing/docs/https/custom-headers.",
+                      "items": {
+                        "type": "string"
                       }
                     },
                     "customResponseHeaders": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "description": "Custom headers added by the GCLB to responses before returning to clients (Ingress API only). See https://cloud.google.com/load-balancing/docs/https/custom-headers.",
-                      "properties": {
-                        "headers": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
+                      "type": "array",
+                      "description": "Custom headers the GCLB adds to responses before returning to clients (Ingress API only). Each entry is a 'Name:Value' string. See https://cloud.google.com/load-balancing/docs/https/custom-headers.",
+                      "items": {
+                        "type": "string"
                       }
                     }
                   }

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1100,6 +1100,36 @@
                         },
                         "host": {
                           "type": "string"
+                        },
+                        "requestPath": {
+                          "type": "string",
+                          "description": "Path the GCLB health check should send GET requests to (Ingress API only). Required for multi-container backends per GKE docs (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#direct_hc_instead). If unset, GKE picks a container readiness probe path arbitrarily."
+                        }
+                      }
+                    },
+                    "customRequestHeaders": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Custom headers added by the GCLB to requests before forwarding to backends (Ingress API only). Values may use GCLB variable substitution like {tls_version} and {tls_cipher_suite}; see https://cloud.google.com/load-balancing/docs/https/custom-headers.",
+                      "properties": {
+                        "headers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "customResponseHeaders": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Custom headers added by the GCLB to responses before returning to clients (Ingress API only). See https://cloud.google.com/load-balancing/docs/https/custom-headers.",
+                      "properties": {
+                        "headers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
                         }
                       }
                     }

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1850,19 +1850,18 @@ workloads:
         #  #  #host: my-custom-backend-host
         #  #  #requestPath: /__lbheartbeat__
         #
-        #  # Custom headers added by the GCLB to requests before forwarding to
-        #  # backends (Ingress API only). Values may use GCLB variable
-        #  # substitution like {tls_version} and {tls_cipher_suite}; see
+        #  # Custom headers the GCLB adds to requests before forwarding to
+        #  # backends (Ingress API only). Each entry is a "Name:Value" string.
+        #  # Values may use GCLB variable substitution like {tls_version} and
+        #  # {tls_cipher_suite}; see
         #  # https://cloud.google.com/load-balancing/docs/https/custom-headers.
         #  #customRequestHeaders:
-        #  #  headers:
-        #  #    - "X-Client-TLS:{tls_version} {tls_cipher_suite}"
+        #  #  - "X-Client-TLS:{tls_version} {tls_cipher_suite}"
         #
-        #  # Custom headers added by the GCLB to responses before returning to
+        #  # Custom headers the GCLB adds to responses before returning to
         #  # clients (Ingress API only).
         #  #customResponseHeaders:
-        #  #  headers:
-        #  #    - "Strict-Transport-Security:max-age=31536000"
+        #  #  - "Strict-Transport-Security:max-age=31536000"
 
     # All of the init containers you need to deploy for your workload.
     #

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1839,11 +1839,30 @@ workloads:
         #  # Backend service timeout period in seconds.
         #  #timeoutSec: 30
         #
-        #  # Custom config for backend health check
+        #  # Custom config for backend health check. For Gateway API, only
+        #  # path/host/port apply. For Ingress API, requestPath sets the GCLB
+        #  # health-check path on the emitted BackendConfig (required for
+        #  # multi-container backends; see
+        #  # https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#direct_hc_instead).
         #  #healthCheck:
         #  #  #path: /readiness/
         #  #  #port: 8000
         #  #  #host: my-custom-backend-host
+        #  #  #requestPath: /__lbheartbeat__
+        #
+        #  # Custom headers added by the GCLB to requests before forwarding to
+        #  # backends (Ingress API only). Values may use GCLB variable
+        #  # substitution like {tls_version} and {tls_cipher_suite}; see
+        #  # https://cloud.google.com/load-balancing/docs/https/custom-headers.
+        #  #customRequestHeaders:
+        #  #  headers:
+        #  #    - "X-Client-TLS:{tls_version} {tls_cipher_suite}"
+        #
+        #  # Custom headers added by the GCLB to responses before returning to
+        #  # clients (Ingress API only).
+        #  #customResponseHeaders:
+        #  #  headers:
+        #  #    - "Strict-Transport-Security:max-age=31536000"
 
     # All of the init containers you need to deploy for your workload.
     #


### PR DESCRIPTION
## Summary

The Ingress API BackendConfig CRD supports `customRequestHeaders`, `customResponseHeaders`, and `healthCheck.requestPath`. The underlying `mozcloud-ingress-lib` BackendConfig template already passes any field placed in `path.backend.config` through to the rendered spec via `omit ... | toYaml`. The application chart's `mozcloud.config.ingresses` helper, however, hand-rolls the backend.config dict and only forwards `iap`, `logging`, `timeoutSec`, and `securityPolicy` from `hosts.X.options`.

This PR wires three missing fields through (additive, backward-compatible). The tenant-facing shape is flat lists for the header blocks; the helper expands them back into the CRD's `{headers: [...]}` structure at render time, following the same pattern as `logSampleRate` → `logging.sampleRate` and `securityPolicy: "name"` → `{name: "name"}`:

```yaml
workloads:
  myapp:
    hosts:
      default:
        domains:
          - app.example.com
        api: ingress
        options:
          customRequestHeaders:
            - "X-Client-TLS:{tls_version} {tls_cipher_suite}"
          customResponseHeaders:
            - "Strict-Transport-Security:max-age=31536000"
          healthCheck:
            requestPath: /__lbheartbeat__
```

Renders into the auto-emitted BackendConfig:

```yaml
spec:
  customRequestHeaders:
    headers:
      - "X-Client-TLS:{tls_version} {tls_cipher_suite}"
  customResponseHeaders:
    headers:
      - "Strict-Transport-Security:max-age=31536000"
  healthCheck:
    requestPath: /__lbheartbeat__
```

## Motivation

Motivating use case: the ingestion-edge GCPv2 chart in [mozilla/dataservices-infra (SVCSE-4428)](https://mozilla-hub.atlassian.net/browse/SVCSE-4428).

- **`customRequestHeaders`**: ingestion-edge uses `X-LB-Tags:{tls_version}, {tls_cipher_suite}` to feed per-request TLS metadata into BigQuery. The data team queries this for TLS deprecation planning and security audits. Without exposing this in mozcloud's host schema, every tenant needing custom headers has to maintain a raw Service+Ingress+BackendConfig stack outside mozcloud's emission.
- **`customResponseHeaders`**: included for symmetry. HSTS, custom CSP, etc. are common cases.
- **`healthCheck.requestPath`**: required for multi-container backends per [GKE docs](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#direct_hc_instead). Without it, GKE picks one of the container readiness probe paths arbitrarily.

After this lands, ingestion-edge can drop its five raw networking templates (`service.yaml`, `ingress.yaml`, `backendconfig.yaml`, `frontendconfig.yaml`, `managedcert.yaml`) entirely.

## Changes

- `templates/ingress/ingress.yaml`: extend the backend.config block emitted by `mozcloud.config.ingresses` to forward the three new fields when set on `hosts.X.options`. The list-shaped header values are wrapped into the `{headers: [...]}` shape the BackendConfig CRD expects.
- `values.schema.json`: add `customRequestHeaders` and `customResponseHeaders` as arrays of strings, and `requestPath` (under existing `healthCheck`) to `hosts.X.options`.
- `values.yaml`: document the new fields with examples.
- `tests/ingress-backend-custom-headers-configuration_test.yaml` + values fixture + snapshot: explicit asserts on rendered BackendConfig spec.

## Related

- [SVCSE-4428](https://mozilla-hub.atlassian.net/browse/SVCSE-4428) (ingestion-edge GCPv2 migration, the chart this unblocks).
- Similar shape to the prior MZCLD-3014 PR (#277), which exposed container resource limits.

## Test plan

- [x] New test suite passes (`helm unittest -f 'tests/ingress-backend-custom-headers-configuration_test.yaml' mozcloud/application/`).
- [x] Existing ingress-related test suites still pass (basic-ingress, multi-domain, multi-backend, named-backend, secret, cert-manager, onprem, custom-service-port, multi-cert-names, backend-options): 23 tests, 51 snapshots, all green.
- [x] Defaults unchanged: configurations without the new fields render identically.