### PR TITLE
feat(mozcloud): bump nginx version to 1.31 for CVE-2026-42945

### DIFF
--- a/mozcloud/application/README.md
+++ b/mozcloud/application/README.md
@@ -185,8 +185,8 @@ Next, update your tenant's values. Shared charts are meant to be self-documented
 | workloads.default.initContainers.default.volumes | list | `[]` |  |
 | workloads.default.labels | object | `{}` |  |
 | workloads.default.nginx.enabled | bool | `true` |  |
-| workloads.default.nginx.image.repository | string | `"us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged"` |  |
-| workloads.default.nginx.image.tag | string | `"1.29"` |  |
+| workloads.default.nginx.image.repository | string | `"us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged"` |  |
+| workloads.default.nginx.image.tag | string | `"1.31"` |  |
 | workloads.default.nginx.lifecycle | object | `{}` |  |
 | workloads.default.nodeSelector | object | `{}` |  |
 | workloads.default.otel.autoInstrumentation.enabled | bool | `false` |  |

--- a/mozcloud/application/tests/__snapshot__/basic-workload-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/basic-workload-configuration_test.yaml.snap
@@ -116,7 +116,7 @@ Configuration matches entire snapshot:
             realm: nonprod
         spec:
           containers:
-            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 5

--- a/mozcloud/application/tests/__snapshot__/container-port-name_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/container-port-name_test.yaml.snap
@@ -488,7 +488,7 @@ Configuration matches entire snapshot:
             realm: nonprod
         spec:
           containers:
-            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 5

--- a/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/image-registry_test.yaml.snap
@@ -269,7 +269,7 @@ Configuration matches entire snapshot:
             realm: nonprod
         spec:
           containers:
-            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 5

--- a/mozcloud/application/tests/__snapshot__/lifecycle-configuration_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/lifecycle-configuration_test.yaml.snap
@@ -388,7 +388,7 @@ Configuration matches entire snapshot:
             realm: nonprod
         spec:
           containers:
-            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
               imagePullPolicy: Always
               lifecycle:
                 preStop:

--- a/mozcloud/application/tests/__snapshot__/preview-all-resources_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/preview-all-resources_test.yaml.snap
@@ -497,7 +497,7 @@ Configuration matches entire snapshot:
             realm: nonprod
         spec:
           containers:
-            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 5

--- a/mozcloud/application/tests/__snapshot__/preview-multiple-workloads_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/preview-multiple-workloads_test.yaml.snap
@@ -386,7 +386,7 @@ Configuration matches entire snapshot:
             realm: nonprod
         spec:
           containers:
-            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 5
@@ -636,7 +636,7 @@ Configuration matches entire snapshot:
             realm: nonprod
         spec:
           containers:
-            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 5
@@ -886,7 +886,7 @@ Configuration matches entire snapshot:
             realm: nonprod
         spec:
           containers:
-            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 5

--- a/mozcloud/application/tests/basic-workload-configuration_test.yaml
+++ b/mozcloud/application/tests/basic-workload-configuration_test.yaml
@@ -208,7 +208,7 @@ tests:
       # Deployment (nginx container) is configured correctly
       - equal:
           path: spec.template.spec.containers[0].image
-          value: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+          value: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always

--- a/mozcloud/application/tests/image-registry_test.yaml
+++ b/mozcloud/application/tests/image-registry_test.yaml
@@ -42,7 +42,7 @@ tests:
       # Does not prepend registry to nginx when its repository already contains a domain
       - equal:
           path: spec.template.spec.containers[?(@.name == "nginx")].image
-          value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29"
+          value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31"
         documentSelector:
           path: $[?(@.kind == "Deployment")].metadata.name
           value: test-service-nginx
@@ -53,15 +53,15 @@ tests:
         test-service-nginx:
           nginx:
             image:
-              repository: nginxinc/nginx-unprivileged
-              tag: "1.29"
+              repository: platform-shared-images/nginx-unprivileged
+              tag: "1.31"
     documentSelector:
       path: $[?(@.kind == "Deployment")].metadata.name
       value: test-service-nginx
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "nginx")].image
-          value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/nginxinc/nginx-unprivileged:1.29"
+          value: "us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31"
   - it: Works without registry set (backwards compatible)
     set:
       global:

--- a/mozcloud/application/tests/values/image-registry.yaml
+++ b/mozcloud/application/tests/values/image-registry.yaml
@@ -28,8 +28,8 @@ workloads:
     nginx:
       enabled: true
       image:
-        repository: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged
-        tag: "1.29"
+        repository: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged
+        tag: "1.31"
       configMap: nginx-config
     containers:
       app:

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -2228,7 +2228,7 @@ workloads:
     #     #
     #     # Default:
     #     #
-    #     #   us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged:1.29
+    #     #   us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
     #     image: ''
     #
     #     # Optionally define an NGINX configuration to use for nginx.conf. This
@@ -2252,8 +2252,8 @@ workloads:
     nginx:
       enabled: true
       image:
-        repository: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-dockerhub-cache/nginxinc/nginx-unprivileged
-        tag: "1.29"
+        repository: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged
+        tag: "1.31"
 
       # Optionally configure a lifecycle hook for the nginx sidecar container.
       #


### PR DESCRIPTION
## Description
This bumps nginx to version 1.31 to address [CVE-2026-42945](https://nvd.nist.gov/vuln/detail/CVE-2026-42945), aka "NGINX Rift".

## Related Tickets & Documents
* [CVE-2026-42945](https://nvd.nist.gov/vuln/detail/CVE-2026-42945)
