### PR TITLE
fix(mozcloud): don't render ports on init containers

### DIFF
--- a/mozcloud/application/templates/workload/_helpers.tpl
+++ b/mozcloud/application/templates/workload/_helpers.tpl
@@ -177,11 +177,11 @@ Returns:
     {{- end }}
     {{- end }}
   {{- end }}
-  {{- if or
+  {{- if and (eq $type "container") (or
       $config.hosts
       (($containerConfig.healthCheck).readiness).enabled
       (($containerConfig.healthCheck).liveness).enabled
-  }}
+  ) }}
   ports:
     - name: {{ $portName }}
       containerPort: {{ $containerConfig.port }}

--- a/mozcloud/application/tests/__snapshot__/init-container-ports_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/init-container-ports_test.yaml.snap
@@ -1,0 +1,268 @@
+Configuration matches entire snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: web
+          app.kubernetes.io/name: mozcloud-test
+          env_code: dev
+      strategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            resource.opentelemetry.io/app_code: mozcloud-test
+            resource.opentelemetry.io/component_code: web
+            resource.opentelemetry.io/env_code: dev
+            resource.opentelemetry.io/realm: nonprod
+          labels:
+            app.kubernetes.io/component: web
+            app.kubernetes.io/managed-by: argocd
+            app.kubernetes.io/name: mozcloud-test
+            app_code: mozcloud-test
+            component_code: web
+            env_code: dev
+            helm.sh/chart: test-chart
+            mozcloud_chart: mozcloud
+            mozcloud_chart_version: 1.0.0
+            realm: nonprod
+        spec:
+          containers:
+            - image: us-west1-docker.pkg.dev/moz-fx-platform-artifacts/platform-shared-images/nginx-unprivileged:1.31
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__nginxheartbeat__
+                  port: http
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: nginx
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: http
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsGroup: 101
+                runAsUser: 101
+              volumeMounts:
+                - mountPath: /etc/nginx/nginx.conf
+                  name: nginx-conf
+                  readOnly: true
+                  subPath: nginx.conf
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/app:1.0.0
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: app
+              ports:
+                - containerPort: 8000
+                  name: app
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /__lbheartbeat__
+                  port: app
+                initialDelaySeconds: 10
+                periodSeconds: 6
+                successThreshold: 1
+                timeoutSeconds: 5
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          initContainers:
+            - envFrom:
+                - secretRef:
+                    name: test-chart-secrets
+              image: test-repo/migrate:1.0.0
+              imagePullPolicy: Always
+              name: migrate
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          securityContext:
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: mozcloud-test
+          volumes:
+            - configMap:
+                name: test-service-nginx
+              name: nginx-conf
+  2: |
+    apiVersion: v1
+    data:
+      nginx.conf: |
+        # The nginx docker container has ln -sf /dev/stderr /var/log/nginx/error.log
+        error_log  /var/log/nginx/error.log warn;
+        pid        /tmp/nginx.pid;
+
+        events {
+            worker_connections  2048;
+        }
+
+        http {
+            include       /etc/nginx/mime.types;
+
+            default_type  application/octet-stream;
+
+            log_format main escape=json
+            '{'
+              '"time":"$time_local",'
+              '"remote_addr":"$remote_addr",'
+              '"remote_user":"$remote_user",'
+              '"request":"$request",'
+              '"status": "$status",'
+              '"log_type": "access",'
+              '"bytes_sent": $body_bytes_sent,'
+              '"request_time": $request_time,'
+              '"referrer":"$http_referer",'
+              '"user_agent":"$http_user_agent",'
+              '"x_forwarded_for":"$http_x_forwarded_for",'
+              '"x_forwarded_proto":"$http_x_forwarded_proto",'
+              '"trace":"$http_x_cloud_trace_context"'
+            '}';
+
+            # The nginx docker container has ln -sf /dev/stdout /var/log/nginx/access.log
+            access_log  /var/log/nginx/access.log  main;
+
+            sendfile        on;
+
+            keepalive_timeout  620;
+
+            server_tokens off;
+
+            gzip on;
+            gzip_http_version 1.1;
+            gzip_comp_level 1;
+            gzip_vary on;
+            gzip_proxied any;
+            gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+            gzip_min_length 1100;
+            gzip_types
+                text/plain
+                text/css
+                application/json
+                application/x-javascript
+                text/xml
+                application/xml
+                application/xml+rss
+                text/javascript
+                application/javascript;
+
+            upstream upstream_docker {
+                server 127.0.0.1:8000;
+            }
+
+            server {
+                listen 8080;
+
+                client_max_body_size 2g;
+
+                add_header Strict-Transport-Security "max-age=31536000" always;
+
+                location / {
+                    proxy_set_header x-forwarded-proto $http_x_forwarded_proto;
+                    proxy_set_header x-forwarded-for $proxy_add_x_forwarded_for;
+                    proxy_set_header Host $http_host;
+                    proxy_redirect off;
+                    proxy_pass http://upstream_docker;
+                }
+
+                location = /nginx_status {
+                  stub_status on;
+                  access_log off;
+                  allow 127.0.0.1;
+                  deny all;
+                }
+
+                location = /__nginxheartbeat__ {
+                  return 200;
+                }
+            }
+        }
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: web
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service-nginx

--- a/mozcloud/application/tests/init-container-ports_test.yaml
+++ b/mozcloud/application/tests/init-container-ports_test.yaml
@@ -1,0 +1,33 @@
+---
+suite: "mozcloud: Init container ports"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+# By overriding the chart version, we are preventing the labels chart from
+# updating the mozcloud_chart_version label for every snapshot every time we
+# bump chart versions.
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/init-container-ports.yaml
+templates:
+  - workload/deployment.yaml
+tests:
+  - it: Configuration matches entire snapshot
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+
+  - it: Init containers omit ports even when the workload defines hosts, while app containers keep them
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: test-service
+    asserts:
+      # The app container gets a ports block because the workload defines hosts.
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="app")].ports[0].containerPort
+          value: 8000
+      # The init container must NOT get a ports block; it does not serve traffic.
+      - notExists:
+          path: spec.template.spec.initContainers[?(@.name=="migrate")].ports

--- a/mozcloud/application/tests/values/init-container-ports.yaml
+++ b/mozcloud/application/tests/values/init-container-ports.yaml
@@ -1,0 +1,21 @@
+---
+workloads:
+  # A workload that defines hosts. The presence of hosts is what triggers a
+  # ports block on app containers; it must NOT trigger one on init containers,
+  # which do not serve traffic.
+  test-service:
+    component: web
+    hosts:
+      default:
+        api: ingress
+        domains: ["test.example.com"]
+    containers:
+      app:
+        image:
+          repository: test-repo/app
+          tag: 1.0.0
+    initContainers:
+      migrate:
+        image:
+          repository: test-repo/migrate
+          tag: 1.0.0


### PR DESCRIPTION
The `mozcloud.workload.containers` helper renders both app containers and init containers from the same template. The `livenessProbe`/`readinessProbe` blocks were correctly gated to app containers, but the `ports` block was not, so any workload that defined `hosts` (a workload-level field) forced a `ports` block onto **every** init container. Init containers don't serve traffic, and when one had no `port` set the chart rendered an invalid, empty `containerPort:`. This change gates the `ports` block to app containers only.

Changes:
- Gate the container `ports` block to app containers only
  - In `templates/workload/_helpers.tpl`, wrapped the `ports` condition with `eq $type "container"` so it matches the existing `livenessProbe`/`readinessProbe` gating directly below it
- Add regression test coverage for init container port rendering
  - New suite `tests/init-container-ports_test.yaml` with fixture `tests/values/init-container-ports.yaml`: for a workload defining `hosts`, asserts the `app` container keeps `containerPort: 8000` while the `migrate` init container has no `ports`
  - Includes the standard whole-render snapshot baseline (`tests/__snapshot__/init-container-ports_test.yaml.snap`)
