### PR TITLE
feat(mozcloud): support generic ephemeral volumes

### DIFF
--- a/mozcloud/application/templates/workload/_helpers.tpl
+++ b/mozcloud/application/templates/workload/_helpers.tpl
@@ -75,7 +75,7 @@ Returns:
         resources:
           requests:
             storage: {{ $volumeConfig.size }}
-        storageClassName: {{ $volumeConfig.storageClassName }}
+        storageClassName: {{ $volumeConfig.storageClassName | default "standard-rwo" }}
   {{- else if eq $volumeConfig.type "gcsFuseCsi" }}
   {{- include "mozcloud.volumes.gcsFuseCsi" (dict "config" $volumeConfig) | nindent 2 }}
   {{- else }}

--- a/mozcloud/application/templates/workload/_helpers.tpl
+++ b/mozcloud/application/templates/workload/_helpers.tpl
@@ -64,6 +64,18 @@ Returns:
   {{- else }}
   emptyDir: {}
   {{- end }}
+  {{- else if eq $volumeConfig.type "ephemeral" }}
+  ephemeral:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          {{- range $accessMode := $volumeConfig.accessModes }}
+          - {{ $accessMode }}
+          {{- end }}
+        resources:
+          requests:
+            storage: {{ $volumeConfig.size }}
+        storageClassName: {{ $volumeConfig.storageClassName }}
   {{- else if eq $volumeConfig.type "gcsFuseCsi" }}
   {{- include "mozcloud.volumes.gcsFuseCsi" (dict "config" $volumeConfig) | nindent 2 }}
   {{- else }}

--- a/mozcloud/application/tests/__snapshot__/workload-volumes_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/workload-volumes_test.yaml.snap
@@ -345,7 +345,7 @@ Configuration matches entire snapshot:
                     resources:
                       requests:
                         storage: 20Gi
-                    storageClassName: premium-rwo
+                    storageClassName: standard-rwo
               name: ephemeral-scratch
             - csi:
                 driver: gcsfuse.csi.storage.gke.io

--- a/mozcloud/application/tests/__snapshot__/workload-volumes_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/workload-volumes_test.yaml.snap
@@ -327,6 +327,8 @@ Configuration matches entire snapshot:
                 - mountPath: /data/bucket
                   name: gcs-bucket
                   readOnly: true
+                - mountPath: /data/ephemeral-scratch
+                  name: ephemeral-scratch
           securityContext:
             runAsGroup: 10001
             runAsNonRoot: true
@@ -335,6 +337,16 @@ Configuration matches entire snapshot:
               type: RuntimeDefault
           serviceAccountName: mozcloud-test
           volumes:
+            - ephemeral:
+                volumeClaimTemplate:
+                  spec:
+                    accessModes:
+                      - ReadWriteOnce
+                    resources:
+                      requests:
+                        storage: 20Gi
+                    storageClassName: premium-rwo
+              name: ephemeral-scratch
             - csi:
                 driver: gcsfuse.csi.storage.gke.io
                 readOnly: true

--- a/mozcloud/application/tests/values/workload-volumes.yaml
+++ b/mozcloud/application/tests/values/workload-volumes.yaml
@@ -75,6 +75,13 @@ workloads:
             readOnly: true
             skipCSIBucketAccessCheck: true
             loggingSeverity: warning
+          - name: ephemeral-scratch
+            type: ephemeral
+            path: /data/ephemeral-scratch
+            accessModes:
+              - ReadWriteOnce
+            size: 20Gi
+            storageClassName: premium-rwo
   test-service-no-gcs:
     component: web
     containers:

--- a/mozcloud/application/tests/values/workload-volumes.yaml
+++ b/mozcloud/application/tests/values/workload-volumes.yaml
@@ -81,7 +81,6 @@ workloads:
             accessModes:
               - ReadWriteOnce
             size: 20Gi
-            storageClassName: premium-rwo
   test-service-no-gcs:
     component: web
     containers:

--- a/mozcloud/application/tests/workload-volumes_test.yaml
+++ b/mozcloud/application/tests/workload-volumes_test.yaml
@@ -128,6 +128,34 @@ tests:
         documentSelector:
           path: $[?(@.kind == "Deployment")].metadata.name
           value: test-service
+      # Ephemeral volume renders as inline volumeClaimTemplate
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ephemeral-scratch
+            ephemeral:
+              volumeClaimTemplate:
+                spec:
+                  accessModes:
+                    - ReadWriteOnce
+                  resources:
+                    requests:
+                      storage: 20Gi
+                  storageClassName: premium-rwo
+        template: workload/deployment.yaml
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
+      # Ephemeral volume container volumeMount is wired up
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="app")].volumeMounts
+          content:
+            name: ephemeral-scratch
+            mountPath: /data/ephemeral-scratch
+        template: workload/deployment.yaml
+        documentSelector:
+          path: $[?(@.kind == "Deployment")].metadata.name
+          value: test-service
       # gcsFuseCsi volume renders as inline CSI volume with full options
       - contains:
           path: spec.template.spec.volumes

--- a/mozcloud/application/tests/workload-volumes_test.yaml
+++ b/mozcloud/application/tests/workload-volumes_test.yaml
@@ -128,7 +128,8 @@ tests:
         documentSelector:
           path: $[?(@.kind == "Deployment")].metadata.name
           value: test-service
-      # Ephemeral volume renders as inline volumeClaimTemplate
+      # Ephemeral volume renders as inline volumeClaimTemplate; storageClassName
+      # defaults to standard-rwo when not specified in values.
       - contains:
           path: spec.template.spec.volumes
           content:
@@ -141,7 +142,7 @@ tests:
                   resources:
                     requests:
                       storage: 20Gi
-                  storageClassName: premium-rwo
+                  storageClassName: standard-rwo
         template: workload/deployment.yaml
         documentSelector:
           path: $[?(@.kind == "Deployment")].metadata.name

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1844,8 +1844,7 @@
                 "then": {
                   "required": [
                     "accessModes",
-                    "size",
-                    "storageClassName"
+                    "size"
                   ]
                 },
                 "else": {

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1717,6 +1717,7 @@
                   "secret",
                   "persistentVolume",
                   "emptyDir",
+                  "ephemeral",
                   "gcsFuseCsi"
                 ]
               },
@@ -1755,6 +1756,28 @@
                 "type": "string",
                 "description": "Severity for gcsfuse logs. Maps to volumeAttributes.gcsfuseLoggingSeverity.",
                 "enum": ["trace", "debug", "info", "warning", "error"]
+              },
+              "accessModes": {
+                "type": "array",
+                "description": "Access modes for ephemeral volumes.",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "ReadWriteOnce",
+                    "ReadOnlyMany",
+                    "ReadWriteMany",
+                    "ReadWriteOncePod"
+                  ]
+                }
+              },
+              "size": {
+                "type": "string",
+                "description": "Storage request size for ephemeral volumes (e.g. 10Gi).",
+                "pattern": "^\\d+(K|Ki|M|Mi|G|Gi)$"
+              },
+              "storageClassName": {
+                "type": "string",
+                "description": "StorageClass for ephemeral volumes."
               }
             },
             "required": [
@@ -1803,6 +1826,34 @@
                       {"required": ["mountOptions"]},
                       {"required": ["skipCSIBucketAccessCheck"]},
                       {"required": ["loggingSeverity"]}
+                    ]
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "ephemeral"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "accessModes",
+                    "size",
+                    "storageClassName"
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "anyOf": [
+                      {"required": ["accessModes"]},
+                      {"required": ["size"]},
+                      {"required": ["storageClassName"]}
                     ]
                   }
                 }

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1429,7 +1429,10 @@ workloads:
         # "emptyDir" volumes, as the name suggests, create an empty volume
         # that's created when the Pod is assigned to a node. When a Pod is
         # removed from a node for any reason, the data in the emptyDir is
-        # deleted permanently. Config options include:
+        # deleted permanently. Prefer "ephemeral" (below) for non-trivial
+        # scratch storage: emptyDir borrows the node's local disk without
+        # capacity accounting, so a noisy pod can exhaust host storage
+        # shared with other workloads. Config options include:
         #
         #   "medium": By default, emptyDir volumes use the node's backing
         #             storage (disk, SSD, or network). Setting emptyDir.medium
@@ -1440,15 +1443,16 @@ workloads:
         #
         # "ephemeral" volumes create a per-pod PersistentVolumeClaim via an
         # inline volumeClaimTemplate. The PVC is bound to the pod's lifetime
-        # and deleted when the pod is removed. Useful for per-pod scratch
-        # storage on a real StorageClass (e.g. premium-rwo). All options
-        # below are required:
+        # and deleted when the pod is removed. Prefer this over "emptyDir"
+        # for non-trivial scratch storage: emptyDir borrows the node's local
+        # disk without capacity accounting, so a noisy pod can exhaust host
+        # storage shared with other workloads. Options:
         #
-        #   "accessModes": List of access modes (e.g. [ReadWriteOnce]).
+        #   "accessModes": (required) List of access modes (e.g. [ReadWriteOnce]).
         #
-        #   "size": Storage request (e.g. 10Gi).
+        #   "size": (required) Storage request (e.g. 10Gi).
         #
-        #   "storageClassName": StorageClass to use (e.g. premium-rwo).
+        #   "storageClassName": StorageClass to use. Defaults to "standard-rwo".
         #
         # "gcsFuseCsi" volumes mount a Google Cloud Storage bucket as an
         # ephemeral inline CSI volume using the GKE GCS FUSE CSI driver.
@@ -1501,7 +1505,6 @@ workloads:
         #       path: /scratch
         #       accessModes: [ReadWriteOnce]
         #       size: 10Gi
-        #       storageClassName: premium-rwo
         #     - name: my-gcs-bucket
         #       type: gcsFuseCsi
         #       path: /path/to/mount
@@ -2155,7 +2158,10 @@ workloads:
         # "emptyDir" volumes, as the name suggests, create an empty volume
         # that's created when the Pod is assigned to a node. When a Pod is
         # removed from a node for any reason, the data in the emptyDir is
-        # deleted permanently. Config options include:
+        # deleted permanently. Prefer "ephemeral" (below) for non-trivial
+        # scratch storage: emptyDir borrows the node's local disk without
+        # capacity accounting, so a noisy pod can exhaust host storage
+        # shared with other workloads. Config options include:
         #
         #   "medium": By default, emptyDir volumes use the node's backing
         #             storage (disk, SSD, or network). Setting emptyDir.medium
@@ -2166,15 +2172,16 @@ workloads:
         #
         # "ephemeral" volumes create a per-pod PersistentVolumeClaim via an
         # inline volumeClaimTemplate. The PVC is bound to the pod's lifetime
-        # and deleted when the pod is removed. Useful for per-pod scratch
-        # storage on a real StorageClass (e.g. premium-rwo). All options
-        # below are required:
+        # and deleted when the pod is removed. Prefer this over "emptyDir"
+        # for non-trivial scratch storage: emptyDir borrows the node's local
+        # disk without capacity accounting, so a noisy pod can exhaust host
+        # storage shared with other workloads. Options:
         #
-        #   "accessModes": List of access modes (e.g. [ReadWriteOnce]).
+        #   "accessModes": (required) List of access modes (e.g. [ReadWriteOnce]).
         #
-        #   "size": Storage request (e.g. 10Gi).
+        #   "size": (required) Storage request (e.g. 10Gi).
         #
-        #   "storageClassName": StorageClass to use (e.g. premium-rwo).
+        #   "storageClassName": StorageClass to use. Defaults to "standard-rwo".
         #
         # "gcsFuseCsi" volumes mount a Google Cloud Storage bucket as an
         # ephemeral inline CSI volume using the GKE GCS FUSE CSI driver.
@@ -2227,7 +2234,6 @@ workloads:
         #       path: /scratch
         #       accessModes: [ReadWriteOnce]
         #       size: 10Gi
-        #       storageClassName: premium-rwo
         #     - name: my-gcs-bucket
         #       type: gcsFuseCsi
         #       path: /path/to/mount

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1399,7 +1399,7 @@ workloads:
 
         # Optionally mount volumes to the container. The supported volume types
         # are "configMap" (default), "secret", "persistentVolume", "emptyDir",
-        # and "gcsFuseCsi".
+        # "ephemeral", and "gcsFuseCsi".
         #
         # Volumes should use names that match either config map, external
         # secret, or persistent volume claim names created as part of and
@@ -1437,6 +1437,18 @@ workloads:
         #
         #   "sizeLimit": the maximum amount of storage that an emptyDir volume
         #                can consume (e.g. 500Mi)
+        #
+        # "ephemeral" volumes create a per-pod PersistentVolumeClaim via an
+        # inline volumeClaimTemplate. The PVC is bound to the pod's lifetime
+        # and deleted when the pod is removed. Useful for per-pod scratch
+        # storage on a real StorageClass (e.g. premium-rwo). All options
+        # below are required:
+        #
+        #   "accessModes": List of access modes (e.g. [ReadWriteOnce]).
+        #
+        #   "size": Storage request (e.g. 10Gi).
+        #
+        #   "storageClassName": StorageClass to use (e.g. premium-rwo).
         #
         # "gcsFuseCsi" volumes mount a Google Cloud Storage bucket as an
         # ephemeral inline CSI volume using the GKE GCS FUSE CSI driver.
@@ -1484,6 +1496,12 @@ workloads:
         #       path: /path/to/another/dir
         #       sizeLimit: 500Mi
         #       medium: Memory
+        #     - name: scratch
+        #       type: ephemeral
+        #       path: /scratch
+        #       accessModes: [ReadWriteOnce]
+        #       size: 10Gi
+        #       storageClassName: premium-rwo
         #     - name: my-gcs-bucket
         #       type: gcsFuseCsi
         #       path: /path/to/mount
@@ -2107,7 +2125,7 @@ workloads:
 
         # Optionally mount volumes to the container. The supported volume types
         # are "configMap" (default), "secret", "persistentVolume", "emptyDir",
-        # and "gcsFuseCsi".
+        # "ephemeral", and "gcsFuseCsi".
         #
         # Volumes should use names that match either config map, external
         # secret, or persistent volume claim names created as part of and
@@ -2145,6 +2163,18 @@ workloads:
         #
         #   "sizeLimit": the maximum amount of storage that an emptyDir volume
         #                can consume (e.g. 500Mi)
+        #
+        # "ephemeral" volumes create a per-pod PersistentVolumeClaim via an
+        # inline volumeClaimTemplate. The PVC is bound to the pod's lifetime
+        # and deleted when the pod is removed. Useful for per-pod scratch
+        # storage on a real StorageClass (e.g. premium-rwo). All options
+        # below are required:
+        #
+        #   "accessModes": List of access modes (e.g. [ReadWriteOnce]).
+        #
+        #   "size": Storage request (e.g. 10Gi).
+        #
+        #   "storageClassName": StorageClass to use (e.g. premium-rwo).
         #
         # "gcsFuseCsi" volumes mount a Google Cloud Storage bucket as an
         # ephemeral inline CSI volume using the GKE GCS FUSE CSI driver.
@@ -2192,6 +2222,12 @@ workloads:
         #       path: /path/to/another/dir
         #       sizeLimit: 500Mi
         #       medium: Memory
+        #     - name: scratch
+        #       type: ephemeral
+        #       path: /scratch
+        #       accessModes: [ReadWriteOnce]
+        #       size: 10Gi
+        #       storageClassName: premium-rwo
         #     - name: my-gcs-bucket
         #       type: gcsFuseCsi
         #       path: /path/to/mount


### PR DESCRIPTION
## Description
Adds [generic ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes) support to enable bugbug and commonvoice migrations.

## Related Tickets & Documents
* MZCLD-3304
