### PR TITLE
fix(mozcloud): reject and forward options.healthCheck fields per host api

### DIFF
--- a/mozcloud/application/templates/ingress/ingress.yaml
+++ b/mozcloud/application/templates/ingress/ingress.yaml
@@ -109,11 +109,32 @@ ingresses:
                     - {{ . | quote }}
                     {{- end }}
                 {{- end }}
-                {{- if (($hostConfig.options).healthCheck).requestPath }}
+                {{- $healthCheck := default dict ($hostConfig.options).healthCheck }}
+                {{- /* Gate on the BackendConfig-supported fields only so a values
+                   override that sets only gateway-only keys (host/path) does
+                   not emit an empty healthCheck block on the ingress path. */}}
+                {{- if or $healthCheck.requestPath $healthCheck.port $healthCheck.type $healthCheck.checkIntervalSec $healthCheck.timeoutSec $healthCheck.healthyThreshold $healthCheck.unhealthyThreshold }}
                 healthCheck:
-                  requestPath: {{ $hostConfig.options.healthCheck.requestPath | quote }}
-                  {{- if $hostConfig.options.healthCheck.port }}
-                  port: {{ $hostConfig.options.healthCheck.port }}
+                  {{- if $healthCheck.requestPath }}
+                  requestPath: {{ $healthCheck.requestPath | quote }}
+                  {{- end }}
+                  {{- if $healthCheck.port }}
+                  port: {{ $healthCheck.port }}
+                  {{- end }}
+                  {{- if $healthCheck.type }}
+                  type: {{ $healthCheck.type }}
+                  {{- end }}
+                  {{- if $healthCheck.checkIntervalSec }}
+                  checkIntervalSec: {{ $healthCheck.checkIntervalSec }}
+                  {{- end }}
+                  {{- if $healthCheck.timeoutSec }}
+                  timeoutSec: {{ $healthCheck.timeoutSec }}
+                  {{- end }}
+                  {{- if $healthCheck.healthyThreshold }}
+                  healthyThreshold: {{ $healthCheck.healthyThreshold }}
+                  {{- end }}
+                  {{- if $healthCheck.unhealthyThreshold }}
+                  unhealthyThreshold: {{ $healthCheck.unhealthyThreshold }}
                   {{- end }}
                 {{- end }}
               service:

--- a/mozcloud/application/tests/__snapshot__/ingress-backend-healthcheck-options-forwarded_test.yaml.snap
+++ b/mozcloud/application/tests/__snapshot__/ingress-backend-healthcheck-options-forwarded_test.yaml.snap
@@ -1,0 +1,105 @@
+Configuration matches snapshot and forwards every supported options.healthCheck field:
+  1: |
+    apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      healthCheck:
+        checkIntervalSec: 10
+        healthyThreshold: 1
+        port: 8000
+        requestPath: /__lbheartbeat__
+        timeoutSec: 5
+        type: HTTP
+        unhealthyThreshold: 3
+      logging:
+        enable: true
+        sampleRate: 0.1
+  2: |
+    apiVersion: networking.gke.io/v1
+    kind: ManagedCertificate
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service-dev-test-domain-com
+    spec:
+      domains:
+        - test-service.dev.test-domain.com
+  3: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: gce
+        kubernetes.io/ingress.global-static-ip-name: mozcloud-dev-ip-v4
+        networking.gke.io/managed-certificates: test-service-dev-test-domain-com
+        networking.gke.io/v1beta1.FrontendConfig: test-service
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      defaultBackend:
+        service:
+          name: test-service
+          port:
+            number: 8080
+  4: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/backend-config: '{"default": "test-service"}'
+        cloud.google.com/neg: '{"ingress": true}'
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: argocd
+        app.kubernetes.io/name: mozcloud-test
+        app_code: mozcloud-test
+        component_code: app
+        env_code: dev
+        helm.sh/chart: test-chart
+        mozcloud_chart: mozcloud
+        mozcloud_chart_version: 1.0.0
+        realm: nonprod
+      name: test-service
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: mozcloud-test
+        env_code: dev
+      type: ClusterIP

--- a/mozcloud/application/tests/gateway-host-options-healthcheck-rejects-ingress-only-fields_test.yaml
+++ b/mozcloud/application/tests/gateway-host-options-healthcheck-rejects-ingress-only-fields_test.yaml
@@ -1,0 +1,17 @@
+---
+suite: "mozcloud: Gateway host rejects ingress-only options.healthCheck fields"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/gateway-host-options-healthcheck-rejects-ingress-only-fields.yaml
+templates:
+  - gateway/backend.yaml
+tests:
+  - it: Fails when any ingress-only options.healthCheck field is set on an api gateway host
+    asserts:
+      - failedTemplate:
+          errorPattern: "healthCheck"

--- a/mozcloud/application/tests/ingress-backend-healthcheck-options-forwarded_test.yaml
+++ b/mozcloud/application/tests/ingress-backend-healthcheck-options-forwarded_test.yaml
@@ -1,0 +1,67 @@
+---
+suite: "mozcloud: Ingress BackendConfig forwards full options.healthCheck"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/ingress-backend-healthcheck-options-forwarded.yaml
+templates:
+  - gke/ingress.yaml
+  - ingress/ingress.yaml
+tests:
+  - it: Configuration matches snapshot and forwards every supported options.healthCheck field
+    asserts:
+      - notFailedTemplate: {}
+      - matchSnapshot: {}
+      - equal:
+          path: spec.healthCheck.requestPath
+          value: /__lbheartbeat__
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-service
+      - equal:
+          path: spec.healthCheck.port
+          value: 8000
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-service
+      - equal:
+          path: spec.healthCheck.type
+          value: HTTP
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-service
+      - equal:
+          path: spec.healthCheck.checkIntervalSec
+          value: 10
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-service
+      - equal:
+          path: spec.healthCheck.timeoutSec
+          value: 5
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-service
+      - equal:
+          path: spec.healthCheck.healthyThreshold
+          value: 1
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-service
+      - equal:
+          path: spec.healthCheck.unhealthyThreshold
+          value: 3
+        template: gke/ingress.yaml
+        documentSelector:
+          path: $[?(@.kind == "BackendConfig")].metadata.name
+          value: test-service

--- a/mozcloud/application/tests/ingress-host-options-healthcheck-rejects-gateway-only-fields_test.yaml
+++ b/mozcloud/application/tests/ingress-host-options-healthcheck-rejects-gateway-only-fields_test.yaml
@@ -1,0 +1,17 @@
+---
+suite: "mozcloud: Ingress host rejects gateway-only options.healthCheck fields"
+release:
+  name: mozcloud-test
+  namespace: mozcloud-test-dev
+chart:
+  version: 1.0.0
+values:
+  - values/globals.yaml
+  - values/ingress-host-options-healthcheck-rejects-gateway-only-fields.yaml
+templates:
+  - ingress/ingress.yaml
+tests:
+  - it: Fails when options.healthCheck.host or path is set on an api ingress host
+    asserts:
+      - failedTemplate:
+          errorPattern: "healthCheck"

--- a/mozcloud/application/tests/values/gateway-host-options-healthcheck-rejects-ingress-only-fields.yaml
+++ b/mozcloud/application/tests/values/gateway-host-options-healthcheck-rejects-ingress-only-fields.yaml
@@ -1,0 +1,26 @@
+---
+workloads:
+  test-service:
+    component: app
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      test-service:
+        domains:
+          - test-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        tls:
+          certs:
+            - test-service-nonprod-dev
+        options:
+          healthCheck:
+            requestPath: /__lbheartbeat__
+            type: HTTP
+            checkIntervalSec: 10
+            timeoutSec: 5
+            healthyThreshold: 1
+            unhealthyThreshold: 3

--- a/mozcloud/application/tests/values/ingress-backend-healthcheck-options-forwarded.yaml
+++ b/mozcloud/application/tests/values/ingress-backend-healthcheck-options-forwarded.yaml
@@ -1,0 +1,28 @@
+---
+workloads:
+  test-service:
+    component: app
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      test-service:
+        domains:
+          - test-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        tls:
+          type: ManagedCertificate
+          create: true
+        options:
+          healthCheck:
+            requestPath: /__lbheartbeat__
+            port: 8000
+            type: HTTP
+            checkIntervalSec: 10
+            timeoutSec: 5
+            healthyThreshold: 1
+            unhealthyThreshold: 3

--- a/mozcloud/application/tests/values/ingress-host-options-healthcheck-rejects-gateway-only-fields.yaml
+++ b/mozcloud/application/tests/values/ingress-host-options-healthcheck-rejects-gateway-only-fields.yaml
@@ -1,0 +1,23 @@
+---
+workloads:
+  test-service:
+    component: app
+    containers:
+      app:
+        image:
+          repository: test-repo/test-image
+          tag: 1.0.0
+    hosts:
+      test-service:
+        domains:
+          - test-service.dev.test-domain.com
+        addresses:
+          - mozcloud-dev-ip-v4
+        api: ingress
+        tls:
+          type: ManagedCertificate
+          create: true
+        options:
+          healthCheck:
+            host: dev.example.com
+            path: /__lbheartbeat__

--- a/mozcloud/application/values.schema.json
+++ b/mozcloud/application/values.schema.json
@@ -1092,7 +1092,8 @@
                       "additionalProperties": false,
                       "properties": {
                         "path": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Health check request path on the HealthCheckPolicy (Gateway API only). For the Ingress API, use requestPath instead."
                         },
                         "port": {
                           "anyOf": [
@@ -1105,11 +1106,41 @@
                           ]
                         },
                         "host": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Host header sent by the GCLB health check (Gateway API only). The Ingress API's BackendConfig health check does not accept a Host header; set the Host header via container-level healthCheck.readiness.httpHeaders instead."
                         },
                         "requestPath": {
                           "type": "string",
                           "description": "Path the GCLB health check should send GET requests to (Ingress API only). Required for multi-container backends per GKE docs (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#direct_hc_instead). If unset, GKE picks a container readiness probe path arbitrarily."
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "HTTP",
+                            "HTTPS",
+                            "HTTP2"
+                          ],
+                          "description": "Protocol used by the GCLB health check (Ingress API only). See https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#direct_health."
+                        },
+                        "checkIntervalSec": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Interval in seconds between health check probes (Ingress API only)."
+                        },
+                        "timeoutSec": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Timeout in seconds for an individual health check probe (Ingress API only). Must be less than or equal to checkIntervalSec."
+                        },
+                        "healthyThreshold": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Consecutive successful probes required to mark a backend healthy (Ingress API only)."
+                        },
+                        "unhealthyThreshold": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Consecutive failed probes required to mark a backend unhealthy (Ingress API only)."
                         }
                       }
                     },
@@ -1168,6 +1199,26 @@
                             ]
                           }
                         }
+                      },
+                      "options": {
+                        "properties": {
+                          "healthCheck": {
+                            "not": {
+                              "anyOf": [
+                                {
+                                  "required": [
+                                    "host"
+                                  ]
+                                },
+                                {
+                                  "required": [
+                                    "path"
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
                       }
                     }
                   },
@@ -1188,6 +1239,46 @@
                                 ]
                               }
                             ]
+                          }
+                        }
+                      },
+                      "options": {
+                        "properties": {
+                          "healthCheck": {
+                            "not": {
+                              "anyOf": [
+                                {
+                                  "required": [
+                                    "requestPath"
+                                  ]
+                                },
+                                {
+                                  "required": [
+                                    "type"
+                                  ]
+                                },
+                                {
+                                  "required": [
+                                    "checkIntervalSec"
+                                  ]
+                                },
+                                {
+                                  "required": [
+                                    "timeoutSec"
+                                  ]
+                                },
+                                {
+                                  "required": [
+                                    "healthyThreshold"
+                                  ]
+                                },
+                                {
+                                  "required": [
+                                    "unhealthyThreshold"
+                                  ]
+                                }
+                              ]
+                            }
                           }
                         }
                       }

--- a/mozcloud/application/values.yaml
+++ b/mozcloud/application/values.yaml
@@ -1877,16 +1877,50 @@ workloads:
         #  # Backend service timeout period in seconds.
         #  #timeoutSec: 30
         #
-        #  # Custom config for backend health check. For Gateway API, only
-        #  # path/host/port apply. For Ingress API, requestPath sets the GCLB
-        #  # health-check path on the emitted BackendConfig (required for
-        #  # multi-container backends; see
-        #  # https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#direct_hc_instead).
+        #  # Custom config for the backend health check. The supported fields
+        #  # depend on which API the host uses — each subkey is labeled with
+        #  # the API it applies to. Fields scoped to the other API are
+        #  # rejected by schema validation.
+        #  #
+        #  # See:
+        #  #   * Gateway API HealthCheckPolicy:
+        #  #     https://cloud.google.com/kubernetes-engine/docs/how-to/gateway-health-checks
+        #  #   * Ingress API BackendConfig health check:
+        #  #     https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#direct_health
         #  #healthCheck:
-        #  #  #path: /readiness/
-        #  #  #port: 8000
+        #  #  # Gateway API only. The Ingress API has no Host-header equivalent
+        #  #  # on the BackendConfig; set the Host header via container-level
+        #  #  # healthCheck.readiness.httpHeaders instead.
         #  #  #host: my-custom-backend-host
+        #  #
+        #  #  # Gateway API only. Path the HealthCheckPolicy probes.
+        #  #  #path: /readiness/
+        #  #
+        #  #  # Both APIs. Port the GCLB health check targets.
+        #  #  #port: 8000
+        #  #
+        #  #  # Ingress API only. Path the GCLB sends GET requests to on the
+        #  #  # emitted BackendConfig (required for multi-container backends).
         #  #  #requestPath: /__lbheartbeat__
+        #  #
+        #  #  # Ingress API only. Protocol used by the GCLB health check.
+        #  #  # One of HTTP, HTTPS, HTTP2.
+        #  #  #type: HTTP
+        #  #
+        #  #  # Ingress API only. Interval in seconds between probes.
+        #  #  #checkIntervalSec: 10
+        #  #
+        #  #  # Ingress API only. Per-probe timeout in seconds. Must be <=
+        #  #  # checkIntervalSec.
+        #  #  #timeoutSec: 5
+        #  #
+        #  #  # Ingress API only. Consecutive successful probes required to
+        #  #  # mark a backend healthy.
+        #  #  #healthyThreshold: 1
+        #  #
+        #  #  # Ingress API only. Consecutive failed probes required to mark
+        #  #  # a backend unhealthy.
+        #  #  #unhealthyThreshold: 2
         #
         #  # Custom headers the GCLB adds to requests before forwarding to
         #  # backends (Ingress API only). Each entry is a "Name:Value" string.


### PR DESCRIPTION
## Description

The ingress code path silently dropped any options.healthCheck field not named requestPath or port — so host, path, and the rest of the BackendConfig surface (type, checkIntervalSec, timeoutSec, healthyThreshold, unhealthyThreshold) had no effect on the rendered BackendConfig. Schema validation now rejects gateway-only fields (host/path) on api: ingress hosts and rejects ingress-only fields on api: gateway hosts, replacing the silent drop with a clear error. The ingress template now forwards every BackendConfig-supported field.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* MZCLD-3322

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
